### PR TITLE
feat: add /research skill and track skills/ in dev-env

### DIFF
--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -1,0 +1,505 @@
+---
+name: journal-compose
+description: Compose the end-of-day engineering journal from today's draft file. Produces the canonical 11-section document, updates READMEs, commits, and prompts for a PR. Invoke as /journal-compose [draft-file-path].
+argument-hint: "[sessions/<project>/YYYY-MM-DD_draft.md]"
+disable-model-invocation: true
+allowed-tools: Read Edit Write Bash Glob Grep Agent
+---
+
+You are composing the end-of-day engineering journal from the day's draft file.
+Follow every step in order. Do not skip steps.
+
+Supporting files:
+- `~/.claude/skills/sources.md` — shared primary source library, organized by topic tag;
+  use Grep on this file before spawning any research subagent (see Section 11)
+
+## Step 1 — Locate the draft file
+
+If `$ARGUMENTS` is provided, use it as the draft file path (relative to the repo root
+`C:/Users/brown/Git/engineering-journal`).
+
+If no argument is given, detect from the current branch:
+```bash
+git -C C:/Users/brown/Git/engineering-journal branch --show-current
+```
+The branch name is `draft/YYYY-MM-DD`. List draft files on that branch:
+```bash
+find C:/Users/brown/Git/engineering-journal/sessions -name "*_draft.md"
+```
+If multiple draft files exist (multiple projects active today), ask the user which one to
+compose. If exactly one draft file is found, proceed with it.
+
+Confirm the path and tell the user: "Composing journal from: `<path>`"
+
+## Step 2 — Read the draft file once
+
+Read the entire draft file in a single `Read` call. Do not read it again during composition.
+Capture all content in memory for use in all subsequent steps.
+
+From the draft file, extract:
+- **Date** — from the `<!-- draft: YYYY-MM-DD -->` comment
+- **Project path** — the `sessions/<project>/` directory component of the draft file path
+- **Opening brief** — the text after `Opening brief:` at the top, before the first `<!-- session: ... -->`
+- **Session blocks** — each `<!-- session: <slug> -->` … `<!-- tokens: ... -->` … `<!-- next-session-context -->` unit
+  - Session slug, H2 heading, body content
+  - Token comment (may be absent — note if missing)
+  - Next-session-context paragraph
+- **Last next-session-context** — the final one in the file (used in Section 9)
+
+## Step 3 — Determine the slug
+
+The slug for the final filename comes from the overall day's theme.
+
+Check the draft for a clear unifying theme across session blocks:
+- If one session dominated the day, use its slug
+- If multiple sessions share a theme, synthesize a slug (e.g., `token-tracker-and-dev-env`)
+- If the theme is unclear, ask the user: "What slug should I use for the final filename?
+  (e.g., `v02-core-api-sprint`)"
+
+The output filename will be: `sessions/<project>/YYYY-MM-DD-<slug>.md`
+
+Tell the user the proposed filename and confirm before writing.
+
+## Step 4 — Fetch real token data
+
+Token data comes from two sources. Collect both; the JSONL log is authoritative.
+
+**Source A — Real JSONL data (authoritative):**
+
+```bash
+TMPFILE="C:/Users/brown/.claude/scratch/tmp_tokens_$$.json"
+python3 ~/.claude/scripts/token-report.py --date YYYY-MM-DD --format json > "$TMPFILE"
+node -e "
+  const d = JSON.parse(require('fs').readFileSync('$TMPFILE','utf8'));
+  console.log('SESSION_COUNT=' + d.length);
+  d.forEach((s, i) => {
+    const t = s.tokens || {};
+    console.log('S' + i + '_ID=' + (s.session_id||'').slice(0,8));
+    console.log('S' + i + '_BRANCH=' + (s.git_branch||''));
+    console.log('S' + i + '_TURNS=' + (s.turn_count||0));
+    console.log('S' + i + '_INP=' + (t.input_tokens||0));
+    console.log('S' + i + '_OUT=' + (t.output_tokens||0));
+    console.log('S' + i + '_CR=' + (t.cache_read_input_tokens||0));
+    console.log('S' + i + '_CW=' + (t.cache_creation_input_tokens||0));
+    console.log('S' + i + '_COST=' + (s.estimated_cost_usd||0).toFixed(4));
+    console.log('S' + i + '_SUB=' + (s.subagent_count||0));
+  });
+"
+rm -f "$TMPFILE"
+```
+
+Also run the markdown report for use in the Token Usage section:
+```bash
+python3 ~/.claude/scripts/token-report.py --date YYYY-MM-DD
+```
+
+Note the session count from the JSONL log. **Important:** the current journal-compose
+session will not appear in the log yet — the Stop hook fires after this conversation ends.
+That session's data will need to be added retroactively if it matters.
+
+**Source B — Draft token comments (supplemental):**
+
+For each `<!-- session: <slug> -->` block in the draft, extract the
+`<!-- tokens: ... -->` comment if present. Format variants:
+- `<!-- tokens: input=N output=N cost≈$N -->`
+- `<!-- tokens: input=N output=N cache_r=N cache_w=N cost≈$N -->`
+
+These values were pulled from the CLI session summary at the time of writing and
+should roughly match the JSONL data. Use them to correlate slugs to JSONL session rows.
+
+**Matching JSONL rows to draft slugs:**
+
+Sort JSONL sessions by `first_turn_ts` ascending. Match to draft session blocks in order
+(first JSONL session → Session 1 slug, second → Session 2 slug, etc.).
+
+If the JSONL count ≠ draft session block count, note the discrepancy. Possible causes:
+- A scratch/exploratory Claude Code session ran that day with no corresponding draft block
+- The journal-compose session itself (current) is absent from the log (expected)
+- Multiple draft slugs correspond to one CLI session (unlikely but possible)
+
+When counts don't match, use real JSONL data for Combined Totals and note which sessions
+couldn't be matched by slug.
+
+## Step 5 — Compose the 11-section document
+
+Compose the complete document in order. Every section is required.
+
+---
+
+### Section 1 — Header block
+
+```
+# Session Transcript — YYYY-MM-DD
+
+**Topic:** <one-line summary of the day's work — synthesize from all session H2s>
+**Repo / Branch:** <repo and branches worked on, drawn from draft content>
+**Issues closed:** <comma-separated linked issues, or "None">
+**PRs merged:** <comma-separated linked PRs, or "None">
+```
+
+---
+
+### Section 2 — Table of Contents
+
+Generate anchor links for all H2 and H3 sections that follow.
+Format: `- [Section Name](#anchor)` where anchor is lowercase, spaces → hyphens, special chars dropped.
+Nest H3 entries under their parent H2 with two-space indent.
+
+Always include these entries (in this order):
+- Opening Brief
+- Key Decisions
+- (one entry per session dialogue section, with sub-entries for H3s)
+- Open Items / Next Steps
+- Token Usage
+- Token Optimization Suggestions
+- Next Session Context
+- Reflection
+- Further Reading
+
+---
+
+### Section 3 — Opening Brief
+
+```
+## Opening Brief
+
+> *[paste the opening brief from the draft verbatim, or "First session for this project — no prior Next Session Context." if applicable]*
+```
+
+---
+
+### Section 4 — Key Decisions
+
+```
+## Key Decisions
+
+### Session N
+
+- **<decision title>** — <rationale, one sentence>. ([§N.M](#anchor-to-dialogue-subsection)[, Issue #N](url)])
+```
+
+One `### Session N` heading per session block.
+Pull decisions from the draft body — look for choices made, tradeoffs resolved, patterns adopted.
+Link each decision to its dialogue subsection using the anchor format `#nN--slug`.
+Link to issues/PRs where referenced in the draft.
+
+---
+
+### Section 5 — Dialogue sections
+
+One `## Session N — <Title>` per session block, drawn from the draft's H2s.
+Use H3s for sub-topics within a session.
+Reproduce the draft content faithfully — do not summarize or omit technical detail.
+Reformat for readability (code fences, bullets) but preserve meaning.
+
+Label sessions: `## Session 1 — <slug title>`, `## Session 2 — <slug title>`, etc.
+
+---
+
+### Section 6 — Open Items / Next Steps
+
+```
+## Open Items / Next Steps
+
+- [ ] <item>
+- [ ] <item>
+```
+
+Extract from:
+1. Any explicit "next steps" listed in draft session blocks
+2. The last `<!-- next-session-context -->` block (convert implied next work to checkbox items)
+3. Any items flagged as deferred or TODO in the draft
+
+---
+
+### Section 7 — Token Usage
+
+```
+## Token Usage
+```
+
+**Primary source is the JSONL log fetched in Step 4.** Draft `<!-- tokens: ... -->` comments
+are supplemental and used only for slug labeling or when no JSONL data exists.
+
+**7a — Per-session breakdown**
+
+For each JSONL session row (matched to a draft slug where possible):
+
+```
+### Session N — <slug> (or <session-id[:8]> if unmatched)
+
+| | Value |
+|---|---|
+| Model | claude-sonnet-4-6 |
+| Input tokens | N |
+| Output tokens | N |
+| Cache read tokens | N |
+| Cache write tokens | N |
+| Turns | N (+N subagent turns if applicable) |
+| Estimated cost | $N |
+```
+
+If a JSONL row cannot be matched to a draft slug, label it with the short session ID
+and note: *"No corresponding draft session block — may be a scratch session or the
+journal-compose session itself."*
+
+If the current journal-compose session is absent from the log (expected, since Stop hook
+hasn't fired yet), add a placeholder:
+
+```
+### Session N — journal-compose (current session, pending)
+
+*Token data not yet available — Stop hook fires after this conversation ends.*
+*Run `python3 ~/.claude/scripts/token-report.py --date YYYY-MM-DD` after session close*
+*to get the actual figures and update this section if needed.*
+```
+
+If **no JSONL data exists at all** for this date (e.g., token tracking was not yet active
+for this project's sessions), fall back to draft comments and label each table:
+*"Source: draft token comment — retroactive estimate, not from JSONL log."*
+If a draft comment is also absent, use a retroactive estimate based on session scope:
+short session (< 30 min) ≈ 15k input / 3k output; medium (1–2 hours) ≈ 50k / 8k;
+long (> 2 hours) ≈ 100k+ / 15k+. Label: *"Retroactive estimate — no JSONL data or draft comment."*
+
+**7b — Raw session table from token-report.py**
+
+Insert the markdown output of `token-report.py --date YYYY-MM-DD` verbatim under a
+`#### All sessions (from token-report.py)` sub-heading. This is the authoritative
+unmodified record.
+
+**7c — Combined Totals**
+
+Sum across all JSONL rows for the date (excluding the current compose session if absent):
+
+```
+### Combined Totals
+
+| Session | Input | Output | Cache R | Cache W | Turns | Cost |
+|---|---|---|---|---|---|---|
+| 1 — <slug> | N | N | N | N | N | $N |
+| 2 — <slug> | N | N | N | N | N | $N |
+| *(compose — pending)* | — | — | — | — | — | — |
+| **Total** | **N** | **N** | **N** | **N** | **N** | **$N** |
+```
+
+Total row excludes any pending/unresolved rows.
+
+---
+
+### Section 8 — Token Optimization Suggestions
+
+```
+## Token Optimization Suggestions
+
+### Session N
+
+- <observation about context efficiency, prompt length, or tool call patterns>
+- <2–4 observations per session>
+
+### Cross-Session Patterns
+
+- <generalizable findings that apply across sessions>
+```
+
+Observations should be specific and actionable. Examples:
+- "Draft opened with full file read; a targeted grep would have reduced input by ~20k tokens"
+- "Three agent spawns in one turn — could have been batched with one multi-task prompt"
+- "Session ran long without a context-reset; splitting at the halfway point would have saved cache misses"
+
+---
+
+### Section 9 — Next Session Context
+
+```
+## Next Session Context
+
+<paste the final <!-- next-session-context --> paragraph from the draft verbatim>
+```
+
+This section is required in all published journals — project journals and meta entries alike.
+
+---
+
+### Section 10 — Reflection
+
+```
+## Reflection
+
+<2–5 bullet points covering: gaps in the work, risks introduced, strategic questions
+raised but not resolved, anything surprising or worth revisiting>
+```
+
+Write this section last (logically). Pull from the full day's content.
+
+---
+
+### Section 11 — Further Reading
+
+```
+## Further Reading
+```
+
+1–3 primary sources per session. The goal is sources that explain the *reasoning* behind
+key decisions made in that session — not tutorials or summaries. Prefer:
+- Named practitioners writing from real enterprise experience
+- Official documentation for technology choices
+- Peer-reviewed papers or specifications
+- Books with free canonical URLs (SRE book, SE@Google, etc.)
+
+**Do this in two passes:**
+
+**Pass 1 — Grep the source library (zero token cost):**
+
+For each session, extract the 2–4 most significant decision keywords from the Key Decisions
+section (e.g., "hexagonal architecture", "testcontainers", "monorepo", "ADR", "REST").
+
+Grep `~/.claude/skills/sources.md` for each keyword:
+```bash
+grep -i "<keyword>" "~/.claude/skills/sources.md" -A 2
+```
+
+A match in the tags line of a section means that section contains relevant sources.
+Read the matched entries. Select the 1–3 most directly applicable to the decisions made.
+Do not cite a source just because the keyword matched — read the one-sentence relevance
+note and confirm it fits.
+
+**Pass 2 — Spawn a research subagent only if Pass 1 yields fewer than 1 source for a session:**
+
+Use the Agent tool to spawn a general-purpose subagent with this task:
+
+> Find 1–2 primary sources (no summaries, no blog posts without named authors) that a
+> senior engineer at a company like Stripe, Netflix, Google, or Uber would cite when
+> making this decision: "<decision description from Key Decisions>".
+> Prefer: named-practitioner engineering blog posts, peer-reviewed papers, official specs,
+> or free book chapters. Return title, author/org, URL, and one sentence on relevance.
+> Do not fabricate URLs — only return sources you can verify exist.
+
+The subagent runs in isolation so its research does not expand this session's context.
+Use its output to supplement the source library entry if the source is high-quality;
+add it as a new entry to `~/.claude/skills/sources.md` under the appropriate tag
+section for future use (this grows the library over time without extra effort).
+
+**Output format per session:**
+
+```
+### Session N — <slug>
+
+- [<Title>](<URL>) — <one sentence: what this source explains and why it matters for the
+  specific decision made in this session>. *(<Author/Org>, <year if known>)*
+```
+
+If a session had no externally-referenceable decisions (pure implementation/tooling work
+with no architectural choices), write:
+```
+### Session N — <slug>
+
+*No primary sources — session was implementation work with no architectural decisions.*
+```
+
+Do not pad with tangentially related sources to hit a count. One precise citation
+is better than three loose ones.
+
+---
+
+## Step 6 — Write the output file
+
+Write the composed document to:
+```
+C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD-<slug>.md
+```
+
+## Step 7 — Update the folder README
+
+Check whether `sessions/<project>/README.md` exists.
+
+**If it does not exist**, create it with this structure:
+```markdown
+# <Project Name> — Journal
+
+Session transcripts for the `<project>` project.
+
+## Progress Summary
+
+<2–3 sentence narrative: what the project is, what phase it is currently in,
+and what the most recent session accomplished or decided. Write from the perspective
+of someone opening this folder for the first time.>
+
+**Where to start next session:** <paste the Next Session Context from the journal
+you just wrote, so the folder README always points to the current thread.>
+
+## Entries
+
+| Date | Session | Topics |
+|---|---|---|
+| YYYY-MM-DD | [<slug title>](<filename>.md) | <comma-separated topic keywords> |
+```
+
+**If it already exists**, read it and append a new row to the Entries table and
+update the Progress Summary and "Where to start next session" sections to reflect
+today's journal.
+
+## Step 8 — Update the top-level README
+
+Read `C:/Users/brown/Git/engineering-journal/README.md`.
+
+The top-level README uses a hub-and-spoke layout: **no inline entry tables**. Each project
+section has a 2–3 sentence description, current state, and a link to its folder README.
+Entry tables live only in the folder READMEs (already updated in Step 7).
+
+For the project you just composed:
+- Find its `### <Project Name>` section in the top-level README
+- Update the description to reflect the current milestone, next step, and any open blockers
+  that changed today (draw from the journal's Open Items and Next Session Context sections)
+- Do not add entry rows — the folder README owns the table
+
+Top-level entry format (description + link only, no table):
+```markdown
+### <Project Name>
+
+<2–3 sentences: what the project is, current milestone, next step, open blockers if any.>
+
+**Repository:** [brownm09/<repo>](https://github.com/brownm09/<repo>)
+**Journal:** [sessions/<project>/](sessions/<project>/README.md)
+```
+
+If the project does not yet appear in the README, add a new `### <Project>` section
+under `## Projects` using this format.
+
+## Step 9 — Delete the draft file
+
+Delete the draft file:
+```bash
+rm C:/Users/brown/Git/engineering-journal/<draft-file-path>
+```
+
+Tell the user: "Draft file deleted."
+
+## Step 10 — Commit
+
+```bash
+git -C C:/Users/brown/Git/engineering-journal add sessions/<project>/YYYY-MM-DD-<slug>.md
+git -C C:/Users/brown/Git/engineering-journal add sessions/<project>/README.md
+git -C C:/Users/brown/Git/engineering-journal add README.md
+git -C C:/Users/brown/Git/engineering-journal commit -m "[docs] Add YYYY-MM-DD journal: <slug>"
+git -C C:/Users/brown/Git/engineering-journal push
+```
+
+## Step 11 — Open PR
+
+Open the PR immediately using `gh`:
+
+```bash
+gh pr create \
+  --repo brownm09/engineering-journal \
+  --base main \
+  --title "YYYY-MM-DD: <slug>" \
+  --body "$(cat <<'EOF'
+End-of-day journal: <one-line topic summary>.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL to the user. After the PR is merged (squash merge), delete the
+`draft/YYYY-MM-DD` branch.

--- a/claude/skills/research/SKILL.md
+++ b/claude/skills/research/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: research
+description: Find 1–3 primary sources for a decision or topic. Greps the shared source library first (zero cost), spawns a subagent only on a cache miss. Emits footnote-ready markdown. Invoke as /research [tag:] <decision description>.
+argument-hint: "[<tag>:] <decision description>"
+allowed-tools: Grep Read Agent Write Edit
+---
+
+You are finding primary sources for an engineering decision or topic.
+Produce footnote-ready markdown that can be pasted directly into any document.
+
+## Step 1 — Parse $ARGUMENTS
+
+`$ARGUMENTS` may take one of two forms:
+
+- **With tag prefix:** `architecture: chose hexagonal over layered for service boundary`
+- **Without tag prefix:** `chose hexagonal over layered for service boundary`
+
+Parse rule: if `$ARGUMENTS` matches the pattern `<word>: <rest>` where the prefix is a
+single word or hyphenated word, treat the prefix as a **topic tag** and the rest as the
+**decision description**. Otherwise treat the entire string as the decision description.
+
+Extract:
+- `TAG` — the topic prefix if present, otherwise empty
+- `DECISION` — the decision description
+
+Tell the user: "Researching: `<DECISION>`" (include tag if present: "Topic: `<TAG>`").
+
+## Step 2 — Pass 1: Grep the source library
+
+The shared source library is at `~/.claude/skills/sources.md`.
+
+**If TAG is set:** use Grep to search only within the section whose `**tags:**` line
+contains the tag value. Read that section of the file.
+
+**If TAG is not set:** extract 2–4 significant keywords from DECISION (e.g., for
+"chose hexagonal over layered for the service boundary" → "hexagonal", "layered",
+"ports-adapters"). Grep for each keyword:
+
+```bash
+grep -i "<keyword>" ~/.claude/skills/sources.md -A 2
+```
+
+After grepping, read the matched entries in full. Do not cite a source just because the
+keyword matched — read the one-sentence relevance note and confirm it fits the decision.
+
+**Candidate selection:** Select up to 3 sources from the library that most directly
+explain the reasoning behind DECISION. If 1 or more strong matches exist, skip Pass 2.
+If fewer than 1 strong match exists, proceed to Pass 2.
+
+## Step 3 — Pass 2: Research subagent (cache miss only)
+
+Spawn a general-purpose subagent (via the Agent tool) with the following task:
+
+> Find 1–2 primary sources (no summaries, no blog posts without a named author) that a
+> senior engineer at a company like Stripe, Netflix, Google, or Uber would cite when
+> making this decision: "<DECISION>".
+> Prefer: named-practitioner engineering blog posts, peer-reviewed papers, official
+> specifications, or free book chapters (SRE book, SE@Google, etc.).
+> Return for each source: title, author or org, URL, and one sentence on why it is
+> relevant to the specific decision.
+> Do not fabricate URLs — only return sources you can verify exist.
+
+The subagent runs in isolation; its output does not expand this conversation's context.
+
+**Library feedback loop:** If the subagent returns a high-quality source not already in
+`~/.claude/skills/sources.md`, append it under the appropriate `##` section. If no
+section fits, add a new one. Format:
+
+```
+- **<Title>** | <Author/Org> | <URL> |
+  <One-sentence relevance note.>
+```
+
+Tell the user: "Added `<Title>` to source library under `<Section>`."
+
+## Step 4 — Emit footnote-ready output
+
+Combine sources from Pass 1 and Pass 2 (up to 3 total). Assign sequential footnote
+numbers starting at `[^1]`.
+
+Output format:
+
+```
+**Decision:** <DECISION>
+
+<!-- paste [^N] markers inline wherever this citation supports a claim in your document -->
+
+[^1]: [<Title>](<URL>) — <Author/Org>, <year if known>. <One sentence: what this source explains and why it matters for this specific decision.>
+[^2]: ...
+```
+
+If only one source was found, emit one footnote. If no sources were found after both
+passes, say so explicitly and suggest rephrasing the decision description or broadening
+the topic tag.
+
+## Notes
+
+- Inline placement of `[^N]` markers is the caller's responsibility — this skill emits
+  the footnote definitions and a reminder to place the markers.
+- GitHub has rendered `[^N]` footnotes in Markdown files since September 2022.
+- For ADR alternatives coverage, invoke the skill once per decision branch (chosen
+  approach + each rejected alternative). A `--compare` flag for single-invocation
+  ADR coverage is tracked in brownm09/dev-env#2.

--- a/claude/skills/sources.md
+++ b/claude/skills/sources.md
@@ -1,0 +1,185 @@
+# Source Library
+
+Curated primary sources for Further Reading sections.
+Organized by topic tag. Each entry: Title | Author/Org | URL | one-sentence relevance.
+
+Do NOT use secondary summaries, blog posts interpreting these works, or articles without
+a named author. Prefer: official documentation, peer-reviewed papers, practitioner-authored
+posts on company engineering blogs, and books with canonical URLs.
+
+---
+
+## Architecture Patterns
+
+**tags: hexagonal, ports-adapters, clean-architecture, domain, dependency-inversion**
+
+- **Hexagonal Architecture** | Alistair Cockburn | https://alistair.cockburn.us/hexagonal-architecture/ |
+  The original 2005 paper by the pattern's author; defines ports, adapters, and the application boundary — cite when any adapter, port interface, or dependency-inversion decision is made.
+
+- **The Clean Architecture** | Robert C. Martin | https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html |
+  Martin's canonical synthesis of hexagonal, onion, and screaming architectures; the concentric-rings diagram; cite when discussing layer boundaries or use-case isolation.
+
+- **Domain-Driven Design reference** | Eric Evans | https://www.domainlanguage.com/ddd/reference/ |
+  Evans's free DDD reference card (condensed from the blue book); cite when aggregate, bounded context, or ubiquitous language decisions come up.
+
+- **Strangler Fig Application** | Martin Fowler | https://martinfowler.com/bliki/StranglerFigApplication.html |
+  Fowler's pattern for incrementally replacing a legacy system by routing traffic to new implementation; cite for any GAS→cloud-native migration decision.
+
+- **Domain-Oriented Microservice Architecture (DOMA)** | Uber Engineering | https://www.uber.com/blog/microservice-architecture/ |
+  Uber's 2020 post describing how they restructured 2,200 microservices into domains, layers, and gateways to reduce coupling at scale; cite for service decomposition or inter-service boundary decisions.
+
+- **Production Readiness Standards** | Stripe Engineering | https://stripe.com/blog/engineering-principles |
+  Stripe's public engineering principles, including the "operational excellence" and "design for failure" tenets; cite for reliability or production-hardening decisions.
+
+---
+
+## Testing
+
+**tags: testing, test-pyramid, integration-test, unit-test, contract-test, testcontainers, e2e**
+
+- **The Practical Test Pyramid** | Ham Vocke / Martin Fowler | https://martinfowler.com/articles/practical-test-pyramid.html |
+  Fowler's site hosts Vocke's definitive practitioner guide to the test pyramid — unit, integration, and UI layers with cost/speed tradeoffs; cite for any testing strategy or pyramid shape decision.
+
+- **Just Say No to More End-to-End Tests** | Mike Wacker (Google Testing Blog) | https://testing.googleblog.com/2015/04/just-say-no-to-more-end-to-end-tests.html |
+  Google's case for why the test pyramid inverts in practice and how to fix it; real data from Google projects; cite for E2E scope-limiting decisions.
+
+- **Test Doubles (Mocks, Fakes, Stubs, Spies)** | Martin Fowler | https://martinfowler.com/bliki/TestDouble.html |
+  Fowler's taxonomy of test doubles; the authoritative source for distinguishing mock vs. stub vs. fake vs. spy; cite when choosing between in-memory adapters and real infrastructure in tests.
+
+- **Testcontainers guides** | Testcontainers | https://testcontainers.com/guides/ |
+  Official guides for using real infrastructure (Postgres, Redis, etc.) in integration tests via Docker containers; cite when choosing Testcontainers for adapter tests over mocks.
+
+- **How Google Tests Software** | James Whittaker, Jason Arbon, Jeff Carollo | https://books.google.com/books/about/How_Google_Tests_Software.html |
+  Google's internal testing culture and SWE-in-Test role; context for large-scale test infrastructure decisions.
+
+- **Software Engineering at Google: Testing** | Titus Winters et al. | https://abseil.io/resources/swe-book/html/ch11.html |
+  Chapter 11 of the free SE@Google book; covers Google's unit testing philosophy, test size classification (small/medium/large), and test maintainability at scale.
+
+---
+
+## API Design
+
+**tags: api, rest, graphql, grpc, versioning, api-design**
+
+- **Architectural Styles and the Design of Network-based Software Architectures** | Roy Fielding | https://ics.uci.edu/~fielding/pubs/dissertation/top.htm |
+  Fielding's 2000 dissertation that defined REST; cite for REST constraint decisions (statelessness, uniform interface, HATEOAS), not just "we chose REST."
+
+- **GraphQL Specification** | GraphQL Foundation | https://spec.graphql.org/October2021/ |
+  The October 2021 release of the GraphQL specification; cite for schema design, execution behavior, or introspection decisions.
+
+- **Designing APIs for Humans** | Paul Assman (Stripe Developer Experience) | https://dev.to/stripe/designing-apis-for-humans-object-ids-3o5a |
+  Stripe's engineering blog series on API ergonomics from practitioners who run one of the most-cited developer APIs in the industry; cite for API naming, error format, or ID design decisions.
+
+- **API Versioning** | Phil Sturgeon | https://apisyouwonthate.com/blog/api-versioning-has-no-right-way/ |
+  Practitioner analysis of versioning strategies (URL path, header, query param) with tradeoffs; not a primary spec but a well-regarded practitioner reference.
+
+---
+
+## Monorepo & Build Systems
+
+**tags: monorepo, turborepo, nx, build, workspace, ci-speed**
+
+- **Why Google Stores Billions of Lines of Code in a Single Repository** | Rachel Potvin, Josh Levenberg | https://dl.acm.org/doi/10.1145/2854146 |
+  The 2016 CACM paper by two Google engineers on Piper, Google's internal monorepo — covers scale (1 billion files, 35,000 commits/day), tooling (Bazel), and the cultural tradeoffs; cite for monorepo structure and dependency management decisions.
+
+- **Monorepos in Git** | Atlassian Engineering | https://www.atlassian.com/git/tutorials/monorepos |
+  Atlassian's practitioner guide covering sparse checkout, shallow clones, and CI strategies for large monorepos; cite for git performance or workspace configuration decisions.
+
+- **Turborepo documentation: Caching** | Vercel | https://turbo.build/repo/docs/crafting-your-repository/caching |
+  Authoritative reference for Turborepo's task caching model (inputs, outputs, remote cache); cite for Turborepo pipeline or cache configuration decisions.
+
+---
+
+## Database & Persistence
+
+**tags: database, orm, prisma, migrations, repository-pattern, cqrs, event-sourcing**
+
+- **Patterns of Enterprise Application Architecture — Repository** | Martin Fowler | https://www.martinfowler.com/eaaCatalog/repository.html |
+  Fowler's catalog entry for the Repository pattern; the canonical reference distinguishing Repository from Data Mapper and Active Record; cite when designing repository interfaces or adapter boundaries.
+
+- **Prisma documentation: Data modeling** | Prisma | https://www.prisma.io/docs/orm/prisma-schema/data-model/models |
+  Official Prisma schema documentation; cite for Prisma model, relation, or migration decisions.
+
+- **Online migrations at scale** | Jacqueline Xu (Stripe Engineering) | https://stripe.com/blog/online-migrations |
+  Stripe's 4-step approach to zero-downtime database migrations (dual writing, backfill, switch reads, clean up) used at production scale; cite for any migration safety or backfill strategy decision.
+
+---
+
+## Engineering Process & Documentation
+
+**tags: adr, rfc, prd, documentation, decision-records, issue-workflow**
+
+- **Documenting Architecture Decisions** | Michael Nygard | https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions |
+  The original 2011 post that introduced ADRs — the source of the format and the "why" behind keeping decisions close to code; cite for any ADR process or format decision.
+
+- **RFC process at Rust** | Rust Lang | https://github.com/rust-lang/rfcs |
+  The Rust community's RFC (Request for Comments) process; widely cited model for structured pre-implementation design review in open and enterprise settings; cite for RFC or design review process decisions.
+
+- **A Software Development Life Cycle for ML Systems** | Google (PAIR Guidebook) | https://pair.withgoogle.com/guidebook/ |
+  Google's People + AI Research guidebook for structured product development involving ML; broader reference for PRD and spec practices at Google scale.
+
+---
+
+## CI/CD & DevOps
+
+**tags: ci, cd, devops, deployment, dora, accelerate, feature-flags, rollback**
+
+- **DORA Research: 2023 State of DevOps Report** | Google Cloud / DORA | https://dora.dev/research/2023/dora-report/ |
+  Annual research report measuring the four key DevOps metrics (deployment frequency, lead time, change failure rate, recovery time) across 36,000 professionals; the authoritative benchmark for CI/CD maturity; cite for any deployment pipeline or release strategy decision.
+
+- **Accelerate: The Science of DevOps** | Nicole Forsgren, Jez Humble, Gene Kim | https://itrevolution.com/product/accelerate/ |
+  The book behind DORA's research; connects software delivery practices to organizational outcomes with statistical rigor; cite for any "move fast vs. stability" tradeoff or branching strategy decision.
+
+- **Continuous Delivery** | Jez Humble, David Farley | https://continuousdelivery.com/ |
+  The canonical book on CD pipelines, deployment patterns, and feature toggles; the authors' site has free chapters; cite for trunk-based development, blue/green, or canary deployment decisions.
+
+- **Ship / Show / Ask** | Rouan Wilsenach (ThoughtWorks) | https://martinfowler.com/articles/ship-show-ask.html |
+  ThoughtWorks practitioner's three-tier PR strategy (merge directly, raise for visibility, request review); hosted on Fowler's site; cite for PR workflow or branch strategy decisions.
+
+---
+
+## Observability & Production Engineering
+
+**tags: observability, logging, tracing, metrics, sre, reliability, incident**
+
+- **Google Site Reliability Engineering** | Betsy Beyer et al. | https://sre.google/sre-book/table-of-contents/ |
+  Free online book from Google's SRE team; covers error budgets, SLOs, toil, postmortems, and on-call practices from practitioners running Google-scale systems; cite for reliability, on-call, or SLO decisions.
+
+- **Observability Engineering** | Charity Majors, Liz Fong-Jones, George Miranda | https://www.oreilly.com/library/view/observability-engineering/9781492076438/ |
+  The definitive practitioner book on structured events, distributed tracing, and high-cardinality observability; Majors co-founded Honeycomb; cite for logging schema, tracing, or debugging strategy decisions.
+
+- **Logging vs. Instrumentation** | Peter Bourgon | https://peter.bourgon.org/blog/2016/02/07/logging-v-instrumentation.html |
+  Concise practitioner post distinguishing logs (discrete events) from metrics (aggregated measurements) and when to use each; cite for any logging/metrics architecture decision.
+
+---
+
+## Engineering Management & Team Process
+
+**tags: management, team, productivity, technical-leadership, planning, estimation**
+
+- **An Elegant Puzzle: Systems of Engineering Management** | Will Larson | https://lethain.com/elegant-puzzle/ |
+  Larson's book (author was VP Eng at Stripe, then Calm, then Carta); covers team sizing, succession planning, technical debt, and reorgs — practitioner-authored from named enterprise contexts; cite for team process or engineering organization decisions.
+
+- **The Manager's Path** | Camille Fournier | https://www.oreilly.com/library/view/the-managers-path/9781491973882/ |
+  Fournier (former CTO of Rent the Runway) maps the engineering career ladder from IC to CTO; cite for career development, mentoring, or role definition decisions.
+
+- **StaffEng: Stories of Reaching Staff Engineer** | Will Larson | https://staffeng.com/stories/ |
+  Named practitioner stories from staff+ engineers at companies including Stripe, Dropbox, Fastly, Squarespace; cite for technical leadership or staff-level scope decisions.
+
+---
+
+## Claude Code & AI-Assisted Development
+
+**tags: claude-code, llm, ai-dev, token, hooks, skills, mcp**
+
+- **Claude Code hooks documentation** | Anthropic | https://docs.anthropic.com/en/docs/claude-code/hooks |
+  Primary reference for Stop, PreToolUse, PostToolUse, and SubagentStop hook events, stdin payload format, and exit code semantics; cite for any hook implementation decision.
+
+- **Claude Code skills documentation** | Anthropic | https://docs.anthropic.com/en/docs/claude-code/skills |
+  Authoritative reference for skill file format, frontmatter schema, `$ARGUMENTS` substitution, `context: fork`, and `allowed-tools`; cite for skill design decisions.
+
+- **Anthropic API pricing** | Anthropic | https://www.anthropic.com/pricing |
+  Per-token rates for all Claude models including cache read/write pricing; cite whenever token cost estimates or cache economics decisions are discussed.
+
+- **Prompt caching (beta)** | Anthropic | https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching |
+  Official documentation on how prompt caching works, what qualifies as a cache hit, and the 5-minute TTL; cite for any token optimization or cache strategy decision.

--- a/setup.sh
+++ b/setup.sh
@@ -33,4 +33,14 @@ fi
 cmd.exe /c "mklink /D \"$WIN_SCRIPTS_LINK\" \"$WIN_SCRIPTS_TARGET\""
 echo "  Linked claude/scripts/ -> ~/.claude/scripts/"
 
+# Claude Code skills — symlink the whole directory
+WIN_SKILLS_TARGET="$(cygpath -w "$REPO_DIR/claude/skills")"
+WIN_SKILLS_LINK="$(cygpath -w "$HOME/.claude/skills")"
+
+if [ -L "$HOME/.claude/skills" ] || [ -d "$HOME/.claude/skills" ]; then
+  cmd.exe /c "rmdir \"$WIN_SKILLS_LINK\"" 2>/dev/null || rm -rf "$HOME/.claude/skills"
+fi
+cmd.exe /c "mklink /D \"$WIN_SKILLS_LINK\" \"$WIN_SKILLS_TARGET\""
+echo "  Linked claude/skills/ -> ~/.claude/skills/"
+
 echo "Done."


### PR DESCRIPTION
## Summary

- Adds `claude/skills/` to dev-env with symlink wired in `setup.sh`, so skills are versioned alongside scripts and CLAUDE.md
- Hoists `sources.md` from `journal-compose/` to a shared `claude/skills/sources.md`; both skills now reference `~/.claude/skills/sources.md`
- Migrates `journal-compose/SKILL.md` into the repo (path references updated)
- Adds `research/SKILL.md`: two-pass grep→subagent pattern, `[^N]` footnote output, optional `[tag:]` prefix for targeted grep, library feedback loop when subagent finds a new high-quality source

## Design decisions resolved

| Decision | Resolution |
|---|---|
| inline vs. context:fork | Inline — output must be conversationally referenceable |
| Footnote format | `[^N]` markers + footnote block; paste-ready for any GFM doc |
| sources.md location | Shared at `claude/skills/sources.md`; research is canonical writer |
| `$ARGUMENTS` scope | `[<tag>:] <decision>` — tag is optional grep shortcut |

## Out of scope

`--compare` flag for ADR alternative coverage tracked in #2.

## Test plan

- [ ] Run `/research architecture: hexagonal ports-adapters` — confirm Pass 1 grep hits the Architecture Patterns section and returns Cockburn or Martin
- [ ] Run `/research` with a topic not in sources.md — confirm Pass 2 subagent fires and appends to `~/.claude/skills/sources.md`
- [ ] Run `/journal-compose` on a draft — confirm Section 11 grep resolves correctly against the new shared path
- [ ] On a fresh machine, run `setup.sh` and confirm `~/.claude/skills/` symlink is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)