### PR TITLE
[feat] Add propose skill, proposal and PR-body templates

### DIFF
--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -486,7 +486,10 @@ git -C C:/Users/brown/Git/engineering-journal push
 
 ## Step 11 — Open PR
 
-Open the PR immediately using `gh`:
+Open the PR immediately using `gh`.
+
+Before composing the PR body, read `~/.claude/templates/pr-body.md` and use it as the
+structural guide. This is a journal PR — use the "Journal PR" pattern from that file.
 
 ```bash
 gh pr create \

--- a/claude/skills/propose/SKILL.md
+++ b/claude/skills/propose/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: propose
+description: One-sentence idea → PRD in docs/proposals/ → linked GitHub issue → ROADMAP.md update. Run from the lifting-logbook repo root on a clean working tree.
+argument-hint: "<one-line idea>"
+disable-model-invocation: true
+allowed-tools: Read Edit Write Bash Glob Grep
+---
+
+You are implementing the `/propose` workflow: expand a one-line idea into a proposal document,
+create the linked GitHub issue, and update the roadmap. Follow every step in order.
+
+---
+
+## Step 1 — Capture the idea
+
+If `$ARGUMENTS` is provided, use it as the idea.
+If not, ask: "What's the idea? (one sentence is enough)"
+
+---
+
+## Step 2 — Ask clarifying questions
+
+Ask at most three targeted questions to fill in the PRD sections that cannot be inferred
+from the one-liner. Typical questions:
+
+- What problem does this solve, and for which user? (if not clear from the idea)
+- What would "done" look like? (anchor for acceptance criteria)
+- Is anything explicitly out of scope?
+
+Skip any question whose answer is already obvious from the idea or from `docs/PRD.md`.
+Skip questions the user has already answered in their opening message.
+
+---
+
+## Step 3 — Read supporting files
+
+Read these two files before drafting:
+
+1. The master proposal template:
+   ```bash
+   cat ~/.claude/templates/proposal.md
+   ```
+
+2. The project PRD (for persona and milestone context):
+   ```bash
+   cat docs/PRD.md
+   ```
+
+---
+
+## Step 4 — Collect metadata
+
+Ask the user to choose:
+
+**Milestone** (pick one):
+- `v0.1 — Foundation`
+- `v0.2 — Core API`
+- `v0.3 — Client Applications`
+
+**Epic** (pick one):
+- Monorepo Scaffolding
+- Package & App Scaffolding
+- Port Interfaces
+- Shared Types
+- CI/CD Foundation
+- Architecture & Documentation
+
+The epic option IDs (needed later for GitHub project assignment) are in `CLAUDE.md`.
+
+---
+
+## Step 5 — Draft the proposal
+
+Using the template from Step 3 and the answers from Steps 1–4, compose the full proposal.
+
+Produce:
+- A **slug**: lowercase, hyphens, 3–5 words (e.g., `bodyweight-exercise-tracking`)
+- A **filename**: `docs/proposals/YYYY-MM-DD-<slug>.md` (use today's date)
+- The **full proposal document**, filled in from the template
+
+Show the draft to the user. Ask: "Does this look right? Any edits before I write the file?"
+
+Wait for confirmation. Apply any requested edits, then confirm once more before proceeding.
+
+---
+
+## Step 6 — Check the working tree
+
+```bash
+git status --porcelain
+```
+
+If the output is non-empty, stop and tell the user:
+"Working tree is not clean. Please commit or stash your changes before running /propose."
+
+If clean, create a branch:
+```bash
+git checkout main
+git pull
+git checkout -b docs/propose-<slug>
+```
+
+---
+
+## Step 7 — Write the proposal file
+
+```bash
+mkdir -p docs/proposals
+```
+
+Write the confirmed proposal to `docs/proposals/YYYY-MM-DD-<slug>.md`.
+
+---
+
+## Step 8 — Create the GitHub issue
+
+Issue title format: `[feat] <proposal title>` (use `[docs]` or `[chore]` if more appropriate).
+
+Issue body: paste the **Problem**, **Proposed Solution**, and **Acceptance Criteria** sections
+from the proposal, then append:
+
+```
+---
+Proposal: [docs/proposals/YYYY-MM-DD-<slug>.md](docs/proposals/YYYY-MM-DD-<slug>.md)
+```
+
+Create the issue:
+```bash
+gh issue create \
+  -R brownm09/lifting-logbook \
+  --title "[feat] <title>" \
+  --body "..."
+```
+
+Then run the full project/milestone/epic assignment workflow from `CLAUDE.md`:
+1. Set milestone: `gh issue edit <N> --milestone "<milestone-title>"`
+2. Add to project and capture item ID
+3. Set Epic field with the option ID for the chosen epic
+
+After the issue is created and assigned, update the `**Issue:**` line in the proposal file
+with the issue number and URL.
+
+---
+
+## Step 9 — Update ROADMAP.md
+
+Read `ROADMAP.md`. Find the section for the milestone chosen in Step 4.
+
+Add a new row to that milestone's proposal table:
+
+```
+| [<Title>](docs/proposals/YYYY-MM-DD-<slug>.md) | <one-line description> | [#N](<issue-url>) |
+```
+
+If the milestone section has no proposal table yet, add one before adding the row:
+
+```markdown
+| Proposal | Description | Issue |
+|---|---|---|
+```
+
+---
+
+## Step 10 — Commit and push
+
+```bash
+git add docs/proposals/YYYY-MM-DD-<slug>.md ROADMAP.md
+git commit -m "$(cat <<'EOF'
+[docs] Propose: <title>
+
+Adds proposal doc and links GitHub issue #N.
+
+EOF
+)"
+git push -u origin docs/propose-<slug>
+```
+
+Do not use `Closes #N` — the linked issue tracks the feature work, not this proposal PR.
+
+---
+
+## Step 11 — Open the PR
+
+Read `~/.claude/templates/pr-body.md` and use it as the structural guide for the PR body.
+This is a docs PR — use the "Docs / proposal PR" pattern.
+
+```bash
+gh pr create \
+  -R brownm09/lifting-logbook \
+  --title "[docs] Propose: <title>" \
+  --body "..."
+```
+
+Return the PR URL to the user.

--- a/claude/templates/pr-body.md
+++ b/claude/templates/pr-body.md
@@ -1,0 +1,76 @@
+# PR Body Template
+
+This file defines the structure skills must follow when composing pull request bodies.
+Read it before drafting any PR body. Adapt — do not copy verbatim.
+
+---
+
+## Required sections (every PR)
+
+### Summary
+
+1–3 bullet points. Lead with *what* changed, follow with *why*.
+Use imperative mood: "Add X", "Remove Y", "Fix Z".
+Do not restate the PR title.
+
+---
+
+## Conditional sections
+
+### Changes
+Include when 3+ files are changed or the file structure is non-obvious.
+Brief list: what was added, modified, or deleted and where.
+Omit for small, self-explanatory PRs.
+
+### Test plan
+Include for all code PRs. Omit for docs-only and journal PRs.
+Use `- [ ]` checkboxes so reviewers can check off steps as they verify.
+
+---
+
+## Footer (every PR)
+
+End every PR body with exactly:
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## Patterns by PR type
+
+### Code PR
+
+```
+## Summary
+
+- <what changed and why — bullet 1>
+- <what changed and why — bullet 2>
+
+## Test plan
+
+- [ ] <step a reviewer can follow to verify the change>
+- [ ] <step>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### Docs / proposal PR
+
+```
+## Summary
+
+- <what was written or updated>
+- <why — which decision, feature, or gap it addresses>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### Journal PR
+
+```
+End-of-day journal: <one-line topic summary>.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/claude/templates/proposal.md
+++ b/claude/templates/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: <Title>
+
+**Status:** `draft` | `accepted` | `shipped` | `declined`
+**Date:** YYYY-MM-DD
+**Issue:** [#N](<url>)
+
+---
+
+## Problem
+
+<2–3 sentences. What situation or gap does this address, and why does it matter now?
+Anchor to a specific job-to-be-done or architectural need — not a general observation.>
+
+## Proposed Solution
+
+<What are we building? Focus on the outcome, not the implementation. Keep it to a paragraph.
+Avoid enumerating implementation steps here — those belong in the issue or ADR.>
+
+## Acceptance Criteria
+
+- [ ] <criterion — testable and unambiguous>
+- [ ] <criterion>
+
+## Out of Scope
+
+- <item — explicitly excluded to prevent scope creep>
+
+## Open Questions
+
+<Optional. Unresolved decisions that need an answer before or during implementation.
+Remove this section if empty.>
+
+## References
+
+<Primary sources only: official documentation, ADRs, RFCs, foundational writings.
+No blog summaries. Remove this section if genuinely empty.>


### PR DESCRIPTION
## Summary

- Add `/propose` skill: one-sentence idea → PRD in `docs/proposals/` → GitHub issue → `ROADMAP.md` update → PR
- Add `claude/templates/proposal.md`: master PRD template used by `/propose`
- Add `claude/templates/pr-body.md`: master PR body template; three patterns (code, docs, journal)
- Update `journal-compose`: reference `pr-body.md` instead of inline PR body logic

## Changes

- `claude/skills/propose/SKILL.md` — 11-step skill; reads proposal template; handles branch, issue creation with project/epic/milestone assignment, ROADMAP update, and PR
- `claude/templates/proposal.md` — fields: Status, Date, Issue, Problem, Solution, AC, Out of Scope, Open Questions, References
- `claude/templates/pr-body.md` — required sections, conditional sections, footer rule, patterns by PR type
- `claude/skills/journal-compose/SKILL.md` — Step 11 now reads `pr-body.md` before composing the journal PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)