### PR TITLE
[docs] Update README and add CONTRIBUTING.md template

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Development environment configuration for cross-device use.
 | Path | Linked to | Purpose |
 |---|---|---|
 | `claude/CLAUDE.md` | `~/.claude/CLAUDE.md` | Claude Code global configuration |
+| `claude/settings.json` | `~/.claude/settings.json` | Claude Code hooks and permissions |
+| `claude/scripts/` | `~/.claude/scripts/` (junction) | Hook scripts and utilities |
+| `claude/skills/` | `~/.claude/skills/` (junction) | Custom slash command skills |
+| `claude/templates/` | read at runtime by skills | Document templates |
 
 ## Setup
 
@@ -18,11 +22,46 @@ cd ~/Git/dev-env
 bash setup.sh
 ```
 
-The script creates symlinks from the expected config locations into this repo.
+The script creates symlinks/junctions from the expected config locations into this repo.
 Any edits made through those symlinks update the repo file directly.
+
+## Skills
+
+Custom skills extend Claude Code with project-aware slash commands. Invoke with `/skill-name`.
+
+| Skill | Command | Description |
+|---|---|---|
+| [`propose`](claude/skills/propose/SKILL.md) | `/propose <idea>` | Expands a one-line idea into a proposal doc, creates a GitHub issue, and updates ROADMAP.md. Targets `lifting-logbook`. |
+| [`journal-compose`](claude/skills/journal-compose/SKILL.md) | `/journal-compose [draft-path]` | Composes the end-of-day engineering journal from the day's draft file. Produces the canonical 11-section document, updates READMEs, commits, and opens a PR. |
+| [`research`](claude/skills/research/SKILL.md) | `/research [tag:] <decision> [--compare <alt>]` | Finds 1–3 primary sources for an engineering decision. Greps the shared source library first; spawns a subagent only on a cache miss. |
+
+The source library for `/research` and `/journal-compose` lives at [`claude/skills/sources.md`](claude/skills/sources.md).
+
+## Scripts
+
+Hook scripts run automatically via Claude Code's `hooks` configuration in `settings.json`.
+
+| Script | Trigger | Purpose |
+|---|---|---|
+| `post-tool-use.py` | After every tool call | Tracks token usage to the session JSONL log |
+| `token-tracker.py` | Session start/stop | Writes and closes session records |
+| `token-report.py` | On demand | Generates markdown and JSON token usage reports by date |
+| `backfill-tokens.py` | On demand | Backfills token data for sessions predating the tracker |
+| `pr-merge-reminder.py` | After tool calls | Reminds to open a PR when changes are pushed without one |
+
+## Templates
+
+Document templates consumed by skills at runtime.
+
+| Template | Used by | Purpose |
+|---|---|---|
+| [`proposal.md`](claude/templates/proposal.md) | `/propose` | PRD template for feature proposals |
+| [`pr-body.md`](claude/templates/pr-body.md) | `/propose`, `/journal-compose` | PR body structure guide |
+| [`contributing.md`](claude/templates/contributing.md) | Manual / `/propose` | CONTRIBUTING.md template for project repos |
 
 ## Adding new configs
 
-1. Add the file under a descriptive directory (e.g., `git/`, `vscode/`)
-2. Add a `ln -sf` line for it in `setup.sh`
-3. Add a row to the table above
+1. Add the file under a descriptive directory (e.g., `claude/scripts/`, `claude/skills/`)
+2. Add a `ln -sf` or `mklink` line for it in `setup.sh` (if it needs symlinking)
+3. Add a row to the relevant table above
+4. Update `claude/CLAUDE.md` if the artifact changes session behavior

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -486,7 +486,10 @@ git -C C:/Users/brown/Git/engineering-journal push
 
 ## Step 11 — Open PR
 
-Open the PR immediately using `gh`:
+Open the PR immediately using `gh`.
+
+Before composing the PR body, read `~/.claude/templates/pr-body.md` and use it as the
+structural guide. This is a journal PR — use the "Journal PR" pattern from that file.
 
 ```bash
 gh pr create \

--- a/claude/skills/propose/SKILL.md
+++ b/claude/skills/propose/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: propose
+description: One-sentence idea → PRD in docs/proposals/ → linked GitHub issue → ROADMAP.md update. Run from the lifting-logbook repo root on a clean working tree.
+argument-hint: "<one-line idea>"
+disable-model-invocation: true
+allowed-tools: Read Edit Write Bash Glob Grep
+---
+
+You are implementing the `/propose` workflow: expand a one-line idea into a proposal document,
+create the linked GitHub issue, and update the roadmap. Follow every step in order.
+
+---
+
+## Step 1 — Capture the idea
+
+If `$ARGUMENTS` is provided, use it as the idea.
+If not, ask: "What's the idea? (one sentence is enough)"
+
+---
+
+## Step 2 — Ask clarifying questions
+
+Ask at most three targeted questions to fill in the PRD sections that cannot be inferred
+from the one-liner. Typical questions:
+
+- What problem does this solve, and for which user? (if not clear from the idea)
+- What would "done" look like? (anchor for acceptance criteria)
+- Is anything explicitly out of scope?
+
+Skip any question whose answer is already obvious from the idea or from `docs/PRD.md`.
+Skip questions the user has already answered in their opening message.
+
+---
+
+## Step 3 — Read supporting files
+
+Read these two files before drafting:
+
+1. The master proposal template:
+   ```bash
+   cat ~/.claude/templates/proposal.md
+   ```
+
+2. The project PRD (for persona and milestone context):
+   ```bash
+   cat docs/PRD.md
+   ```
+
+---
+
+## Step 4 — Collect metadata
+
+Ask the user to choose:
+
+**Milestone** (pick one):
+- `v0.1 — Foundation`
+- `v0.2 — Core API`
+- `v0.3 — Client Applications`
+
+**Epic** (pick one):
+- Monorepo Scaffolding
+- Package & App Scaffolding
+- Port Interfaces
+- Shared Types
+- CI/CD Foundation
+- Architecture & Documentation
+
+The epic option IDs (needed later for GitHub project assignment) are in `CLAUDE.md`.
+
+---
+
+## Step 5 — Draft the proposal
+
+Using the template from Step 3 and the answers from Steps 1–4, compose the full proposal.
+
+Produce:
+- A **slug**: lowercase, hyphens, 3–5 words (e.g., `bodyweight-exercise-tracking`)
+- A **filename**: `docs/proposals/YYYY-MM-DD-<slug>.md` (use today's date)
+- The **full proposal document**, filled in from the template
+
+Show the draft to the user. Ask: "Does this look right? Any edits before I write the file?"
+
+Wait for confirmation. Apply any requested edits, then confirm once more before proceeding.
+
+---
+
+## Step 6 — Check the working tree
+
+```bash
+git status --porcelain
+```
+
+If the output is non-empty, stop and tell the user:
+"Working tree is not clean. Please commit or stash your changes before running /propose."
+
+If clean, create a branch:
+```bash
+git checkout main
+git pull
+git checkout -b docs/propose-<slug>
+```
+
+---
+
+## Step 7 — Write the proposal file
+
+```bash
+mkdir -p docs/proposals
+```
+
+Write the confirmed proposal to `docs/proposals/YYYY-MM-DD-<slug>.md`.
+
+---
+
+## Step 8 — Create the GitHub issue
+
+Issue title format: `[feat] <proposal title>` (use `[docs]` or `[chore]` if more appropriate).
+
+Issue body: paste the **Problem**, **Proposed Solution**, and **Acceptance Criteria** sections
+from the proposal, then append:
+
+```
+---
+Proposal: [docs/proposals/YYYY-MM-DD-<slug>.md](docs/proposals/YYYY-MM-DD-<slug>.md)
+```
+
+Create the issue:
+```bash
+gh issue create \
+  -R brownm09/lifting-logbook \
+  --title "[feat] <title>" \
+  --body "..."
+```
+
+Then run the full project/milestone/epic assignment workflow from `CLAUDE.md`:
+1. Set milestone: `gh issue edit <N> --milestone "<milestone-title>"`
+2. Add to project and capture item ID
+3. Set Epic field with the option ID for the chosen epic
+
+After the issue is created and assigned, update the `**Issue:**` line in the proposal file
+with the issue number and URL.
+
+---
+
+## Step 9 — Update ROADMAP.md
+
+Read `ROADMAP.md`. Find the section for the milestone chosen in Step 4.
+
+Add a new row to that milestone's proposal table:
+
+```
+| [<Title>](docs/proposals/YYYY-MM-DD-<slug>.md) | <one-line description> | [#N](<issue-url>) |
+```
+
+If the milestone section has no proposal table yet, add one before adding the row:
+
+```markdown
+| Proposal | Description | Issue |
+|---|---|---|
+```
+
+---
+
+## Step 10 — Commit and push
+
+```bash
+git add docs/proposals/YYYY-MM-DD-<slug>.md ROADMAP.md
+git commit -m "$(cat <<'EOF'
+[docs] Propose: <title>
+
+Adds proposal doc and links GitHub issue #N.
+
+EOF
+)"
+git push -u origin docs/propose-<slug>
+```
+
+Do not use `Closes #N` — the linked issue tracks the feature work, not this proposal PR.
+
+---
+
+## Step 11 — Open the PR
+
+Read `~/.claude/templates/pr-body.md` and use it as the structural guide for the PR body.
+This is a docs PR — use the "Docs / proposal PR" pattern.
+
+```bash
+gh pr create \
+  -R brownm09/lifting-logbook \
+  --title "[docs] Propose: <title>" \
+  --body "..."
+```
+
+Return the PR URL to the user.

--- a/claude/templates/contributing.md
+++ b/claude/templates/contributing.md
@@ -1,0 +1,71 @@
+# Contributing to `<repo-name>`
+
+> **Template usage:** Copy this file to `CONTRIBUTING.md` in the target repo. Replace
+> bracketed placeholders and remove this notice block.
+
+---
+
+## Workflow
+
+All changes go through a branch and PR — never commit directly to `main`.
+
+**Branch naming:**
+
+| Prefix | Use for |
+|---|---|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation only |
+| `config/` | Configuration, tooling, CI |
+| `chore/` | Housekeeping, dependency bumps |
+| `draft/` | Work-in-progress not ready for review |
+
+**Pull requests:**
+- Open the PR as soon as you push the branch — draft PRs are fine for early feedback
+- PR titles follow the same prefix convention: `[feat]`, `[fix]`, `[docs]`, `[config]`, `[chore]`
+- Squash merge into `main`; delete the branch after merge
+
+## Adding a feature
+
+1. Open or find the relevant GitHub issue first
+2. Create a branch: `git checkout -b feat/<short-description>`
+3. For non-trivial changes, add a proposal under `docs/proposals/` using `/propose`
+4. Implement, test, and commit
+5. Open the PR and link the issue (`Closes #N` in the PR body)
+
+## README and documentation hygiene
+
+When your PR introduces or changes a named artifact — a skill, script, config file, template,
+or API endpoint — update the relevant README table in the same PR. Do not leave READMEs
+trailing by a commit.
+
+**Specifically:**
+- New skills → `README.md` Skills table
+- New scripts → `README.md` Scripts table
+- New templates → `README.md` Templates table
+- New CLI flags or API endpoints → the section that documents them
+- Changes to setup or onboarding → `README.md` Setup section
+
+## Commit messages
+
+```
+[prefix] Short imperative summary (≤72 chars)
+
+Optional longer explanation — why, not what.
+```
+
+Examples:
+- `[feat] Add bodyweight exercise tracking`
+- `[fix] Correct calorie calculation for AMRAP sets`
+- `[docs] Propose: sleep-aware recommendation weighting`
+- `[config] Add post-tool-use hook for token tracking`
+
+## Claude Code sessions
+
+This repo uses Claude Code for assisted development. Session conventions:
+
+- All Claude-assisted changes still go through the normal branch/PR workflow
+- Engineering journal entries for this project live in
+  `brownm09/engineering-journal` → `sessions/<project>/`
+- Use `/propose` to capture significant feature ideas before implementation
+- Use `/journal-compose` at end of day to publish the session transcript

--- a/claude/templates/pr-body.md
+++ b/claude/templates/pr-body.md
@@ -1,0 +1,76 @@
+# PR Body Template
+
+This file defines the structure skills must follow when composing pull request bodies.
+Read it before drafting any PR body. Adapt — do not copy verbatim.
+
+---
+
+## Required sections (every PR)
+
+### Summary
+
+1–3 bullet points. Lead with *what* changed, follow with *why*.
+Use imperative mood: "Add X", "Remove Y", "Fix Z".
+Do not restate the PR title.
+
+---
+
+## Conditional sections
+
+### Changes
+Include when 3+ files are changed or the file structure is non-obvious.
+Brief list: what was added, modified, or deleted and where.
+Omit for small, self-explanatory PRs.
+
+### Test plan
+Include for all code PRs. Omit for docs-only and journal PRs.
+Use `- [ ]` checkboxes so reviewers can check off steps as they verify.
+
+---
+
+## Footer (every PR)
+
+End every PR body with exactly:
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## Patterns by PR type
+
+### Code PR
+
+```
+## Summary
+
+- <what changed and why — bullet 1>
+- <what changed and why — bullet 2>
+
+## Test plan
+
+- [ ] <step a reviewer can follow to verify the change>
+- [ ] <step>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### Docs / proposal PR
+
+```
+## Summary
+
+- <what was written or updated>
+- <why — which decision, feature, or gap it addresses>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### Journal PR
+
+```
+End-of-day journal: <one-line topic summary>.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/claude/templates/proposal.md
+++ b/claude/templates/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: <Title>
+
+**Status:** `draft` | `accepted` | `shipped` | `declined`
+**Date:** YYYY-MM-DD
+**Issue:** [#N](<url>)
+
+---
+
+## Problem
+
+<2–3 sentences. What situation or gap does this address, and why does it matter now?
+Anchor to a specific job-to-be-done or architectural need — not a general observation.>
+
+## Proposed Solution
+
+<What are we building? Focus on the outcome, not the implementation. Keep it to a paragraph.
+Avoid enumerating implementation steps here — those belong in the issue or ADR.>
+
+## Acceptance Criteria
+
+- [ ] <criterion — testable and unambiguous>
+- [ ] <criterion>
+
+## Out of Scope
+
+- <item — explicitly excluded to prevent scope creep>
+
+## Open Questions
+
+<Optional. Unresolved decisions that need an answer before or during implementation.
+Remove this section if empty.>
+
+## References
+
+<Primary sources only: official documentation, ADRs, RFCs, foundational writings.
+No blog summaries. Remove this section if genuinely empty.>


### PR DESCRIPTION
## Summary

- Brings `README.md` fully up to date: adds `settings.json`, `scripts/`, `skills/`, and `templates/` to the Contents table
- Adds Skills catalog (3 skills with commands and descriptions), Scripts table, and Templates table
- Adds `claude/templates/contributing.md` — a generic CONTRIBUTING.md template covering branch/PR workflow, README hygiene rules, commit conventions, and Claude Code session conventions

## Why

The README was only tracking `CLAUDE.md` while 4 additional artifacts had been added across multiple PRs. A contributor reading the README would have no idea skills, scripts, or templates existed.

The CONTRIBUTING.md template establishes the README hygiene rule ("update the table in the same PR that adds the artifact") to prevent future drift.

## Test plan

- [ ] README Contents, Skills, Scripts, and Templates tables render correctly on GitHub
- [ ] `contributing.md` template placeholders are clearly marked for substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)