### PR TITLE
[chore] Add .gitignore to exclude .claude/ project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Claude Code project-level directory (machine-local, not version-controlled)
+.claude/


### PR DESCRIPTION
Claude Code creates a machine-local `.claude/` directory in each project root (for project-level memory, settings, etc.). It was showing up as an untracked file. This excludes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)