### PR TITLE
[fix] Remove disable-model-invocation from propose skill

### DIFF
--- a/claude/skills/propose/SKILL.md
+++ b/claude/skills/propose/SKILL.md
@@ -2,7 +2,6 @@
 name: propose
 description: One-sentence idea → PRD in docs/proposals/ → linked GitHub issue → ROADMAP.md update. Run from the lifting-logbook repo root on a clean working tree.
 argument-hint: "<one-line idea>"
-disable-model-invocation: true
 allowed-tools: Read Edit Write Bash Glob Grep
 ---
 


### PR DESCRIPTION
## Summary

- Removes the `disable-model-invocation: true` frontmatter flag from `claude/skills/propose/SKILL.md`
- The flag was blocking the skill from being invoked via the `Skill` tool in Claude Code

## Test plan

- [ ] Run `/propose <idea>` from the lifting-logbook repo — skill should load and execute without error