### PR TITLE
feat: new-day journal hook (UserPromptSubmit)

### DIFF
--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -11,12 +11,12 @@ Stdout is injected as context Claude sees before processing the user's message.
 """
 
 import glob
-import json
 import os
 import sys
 from datetime import date
+from pathlib import Path
 
-JOURNAL_REPO = "C:/Users/brown/Git/engineering-journal"
+JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
 TODAY = date.today().strftime("%Y-%m-%d")
 
 
@@ -27,7 +27,7 @@ def main() -> None:
     except Exception:
         pass
 
-    pattern = os.path.join(JOURNAL_REPO, "sessions", "**", "*_draft.md")
+    pattern = str(JOURNAL_REPO / "sessions" / "**" / "*_draft.md")
     drafts = glob.glob(pattern, recursive=True)
     stale = [
         f for f in drafts
@@ -39,7 +39,7 @@ def main() -> None:
 
     # Most recent stale draft first (basename sort is date-based).
     stale.sort(key=lambda f: os.path.basename(f), reverse=True)
-    draft_path = stale[0].replace("\\", "/")
+    draft_path = Path(stale[0]).as_posix()
     draft_date = os.path.basename(stale[0]).replace("_draft.md", "")
 
     print(

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: detect stale draft files in engineering-journal.
+
+If a *_draft.md file from a previous calendar day exists in the journal's
+sessions/ tree, inject a reminder so Claude runs /journal-compose before
+handling the user's request.
+
+Exit 0 always — never block the user's prompt.
+Stdout is injected as context Claude sees before processing the user's message.
+"""
+
+import glob
+import json
+import os
+import sys
+from datetime import date
+
+JOURNAL_REPO = "C:/Users/brown/Git/engineering-journal"
+TODAY = date.today().strftime("%Y-%m-%d")
+
+
+def main() -> None:
+    # Consume stdin (UserPromptSubmit sends JSON; we don't need the contents).
+    try:
+        sys.stdin.read()
+    except Exception:
+        pass
+
+    pattern = os.path.join(JOURNAL_REPO, "sessions", "**", "*_draft.md")
+    drafts = glob.glob(pattern, recursive=True)
+    stale = [
+        f for f in drafts
+        if not os.path.basename(f).startswith(TODAY)
+    ]
+
+    if not stale:
+        sys.exit(0)
+
+    # Most recent stale draft first (basename sort is date-based).
+    stale.sort(key=lambda f: os.path.basename(f), reverse=True)
+    draft_path = stale[0].replace("\\", "/")
+    draft_date = os.path.basename(stale[0]).replace("_draft.md", "")
+
+    print(
+        f"[journal-hook] Stale draft detected: {draft_path}\n"
+        f"The engineering journal draft from {draft_date} was never composed.\n"
+        f"Before responding to the user's message, invoke the journal-compose skill "
+        f"to close out the {draft_date} session. Then proceed with the user's request."
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/new-day-journal-check.py"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

- Adds `claude/scripts/new-day-journal-check.py` — scans `engineering-journal/sessions/**/` for `*_draft.md` files from prior calendar days
- Wires it as a `UserPromptSubmit` hook in `settings.json` so it runs on every session start
- When a stale draft is detected, outputs a reminder to stdout (injected as context) instructing Claude to run `/journal-compose` before handling the user's request; exits 0 so the prompt is never blocked

## Test plan

- [ ] Start a session with no stale drafts → hook is silent
- [ ] Manually create a `sessions/test/2026-01-01_draft.md`, start a session → hook injects reminder
- [ ] After `/journal-compose` deletes the draft file → hook is silent again on subsequent prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)