### PR TITLE
fix: remove disable-model-invocation from journal-compose skill

### DIFF
--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -2,7 +2,6 @@
 name: journal-compose
 description: Compose the end-of-day engineering journal from today's draft file. Produces the canonical 11-section document, updates READMEs, commits, and prompts for a PR. Invoke as /journal-compose [draft-file-path].
 argument-hint: "[sessions/<project>/YYYY-MM-DD_draft.md]"
-disable-model-invocation: true
 allowed-tools: Read Edit Write Bash Glob Grep Agent
 ---
 


### PR DESCRIPTION
## Summary

- Removes `disable-model-invocation: true` from `claude/skills/journal-compose/SKILL.md`
- Mirrors the fix applied in #13 for the `/propose` skill
- The flag was preventing the Skill tool from invoking `/journal-compose` in agentic sessions

## Test plan

- [ ] Invoke `/journal-compose` via the Skill tool in a session with a draft file present — should execute without `disable-model-invocation` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)