### PR TITLE
feat: add cover-letter and fit-screen skills

### DIFF
--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -1,37 +1,50 @@
 ---
 name: cover-letter
-description: Draft a cover letter for a job application following the full 10-step job-search workflow. Invokes Haiku subagents for fit screening and style self-check. Invoke as /cover-letter [job-description-text or file path].
-argument-hint: "[JD text or path to JD file]"
-allowed-tools: Read Edit Write Bash Glob Grep Agent
+description: Draft a cover letter for a job application following the full cover letter workflow. Invokes Haiku subagents for fit screening and style self-check. Invoke as /cover-letter [JD text, file path, PDF path, or URL].
+argument-hint: "[JD text, file path, PDF path, or URL to job posting]"
+allowed-tools: Read Edit Write Bash Glob Grep Agent WebFetch
 ---
 
 You are drafting a cover letter for Mike Brown's job search, following the canonical workflow defined in `CLAUDE.md`.
 
 Follow every step in order. Do not skip steps.
 
-The job description is provided in `$ARGUMENTS`. If it is a file path, read it. If it is inline text, use it directly. If neither is provided, ask the user for the JD before proceeding.
+## Step 0 — Load the job description
 
-## Step 1 — Fit Screening (Haiku subagent)
+The job description is provided in `$ARGUMENTS`. Determine input type and load accordingly:
+
+- **No argument / pasted text:** If `$ARGUMENTS` is empty or looks like inline prose (not a path or URL), use it directly as the JD text. If empty, ask the user to paste the JD.
+- **File path (`.md`, `.txt`, `.docx`):** Read the file.
+- **PDF path (`.pdf`):** Read the file using the Read tool — it handles PDF extraction.
+- **URL:** Fetch the page using WebFetch. Extract the job description text from the page body; discard navigation, footers, and cookie banners.
+
+Store the extracted JD text. If the JD text is under 50 words after extraction, tell the user the source may not have loaded correctly and ask them to paste the JD directly.
+
+## Step 1 — Company log check
+
+Read `C:/Users/brown/Git/job-search/context/company_log.md`.
+Check the "Roles Completed" and "Roles Skipped" tables for this company and role.
+If already present, stop and tell the user: "This role is already logged as [completed/skipped]."
+
+## Step 2 — Fit Screening (Haiku subagent)
 
 Spawn a **Haiku** subagent with this task:
 
-> You are performing a fit screen for a job application. Read `C:/Users/brown/Git/job-search/context/session_instructions.md` — specifically the "Fit Screening Protocol", "Technical Stack Reference", and "Notable Gaps" sections. Then evaluate this job description against those rules and report:
-> 1. Any auto-skip triggers (list the rule and the JD text that triggered it)
-> 2. Any soft flags (compensation, seniority, stack mismatches)
+> You are performing a fit screen for a job application for Mike Brown, targeting Director and Senior Manager of Engineering roles.
+>
+> Read `C:/Users/brown/Git/job-search/context/session_instructions.md` — specifically the sections: "Fit Screening Protocol", "Technical Stack Reference", "Notable Gaps", "Compensation Floor", and "Auto-Skip Triggers".
+>
+> Evaluate the following job description against those rules and report:
+> 1. Any auto-skip triggers (list the rule and the JD text that triggered it). If none, write "None."
+> 2. Any soft flags (compensation uncertainty, seniority mismatch, stack gaps, industry fit). For each, quote the relevant JD text.
 > 3. Overall recommendation: PROCEED, FLAG, or SKIP
 >
 > Job description:
-> <paste JD here>
+> <JD text>
 
 If the subagent returns SKIP, stop and report the result to the user. Do not proceed.
 If the subagent returns FLAG, surface the flags and ask the user whether to proceed.
 If PROCEED, continue.
-
-## Step 2 — Company log check
-
-Read `C:/Users/brown/Git/job-search/context/company_log.md`.
-Check the "Roles Completed" and "Roles Skipped" tables for the company and role.
-If already present, stop and tell the user: "This role is already logged as [completed/skipped]."
 
 ## Step 3 — Read style rules
 
@@ -77,11 +90,17 @@ Apply every violation the self-check subagent flagged. Re-read each fixed passag
 
 ## Step 9 — Word count
 
-Run:
+Write the letter body to a temp file and count words:
 ```bash
-echo "<letter body>" | wc -w
+TMPFILE="C:/Users/brown/.claude/scratch/wc_$$.txt"
+cat > "$TMPFILE" << 'LETTER'
+<letter body here>
+LETTER
+wc -w < "$TMPFILE"
+rm -f "$TMPFILE"
 ```
-Or count manually. The body must be under 470 words (subtract approximately 30–35 words for header, salutation, and sign-off). If over, trim.
+
+The body must be under 470 words (subtract approximately 30–35 words for header, salutation, and sign-off from the total). If over, trim.
 
 Report the final word count to the user.
 

--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -68,7 +68,7 @@ Draft the cover letter body in Markdown. Apply all style rules from Step 3 while
 - No em-dashes (anywhere, no exceptions)
 - No banned constructions ("The outcomes were concrete" and all variants)
 - Do not claim Mike "led a platform directorate" — use "led platform teams responsible for..." or "led programs within the platform organization"
-- Body word ceiling: 470 words
+- Body word ceiling: 400 words (body paragraphs only)
 - Output is Markdown only
 
 Use the model letter from Step 4 as a structural reference. Adapt tone and emphasis to the specific JD. Do not copy model letter text verbatim.
@@ -100,7 +100,7 @@ wc -w < "$TMPFILE"
 rm -f "$TMPFILE"
 ```
 
-The body must be under 470 words (subtract approximately 30–35 words for header, salutation, and sign-off from the total). If over, trim.
+The body must be under 400 words (count body paragraphs only — exclude header block, salutation, and sign-off). If over, trim.
 
 Report the final word count to the user.
 

--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: cover-letter
+description: Draft a cover letter for a job application following the full 10-step job-search workflow. Invokes Haiku subagents for fit screening and style self-check. Invoke as /cover-letter [job-description-text or file path].
+argument-hint: "[JD text or path to JD file]"
+allowed-tools: Read Edit Write Bash Glob Grep Agent
+---
+
+You are drafting a cover letter for Mike Brown's job search, following the canonical workflow defined in `CLAUDE.md`.
+
+Follow every step in order. Do not skip steps.
+
+The job description is provided in `$ARGUMENTS`. If it is a file path, read it. If it is inline text, use it directly. If neither is provided, ask the user for the JD before proceeding.
+
+## Step 1 — Fit Screening (Haiku subagent)
+
+Spawn a **Haiku** subagent with this task:
+
+> You are performing a fit screen for a job application. Read `C:/Users/brown/Git/job-search/context/session_instructions.md` — specifically the "Fit Screening Protocol", "Technical Stack Reference", and "Notable Gaps" sections. Then evaluate this job description against those rules and report:
+> 1. Any auto-skip triggers (list the rule and the JD text that triggered it)
+> 2. Any soft flags (compensation, seniority, stack mismatches)
+> 3. Overall recommendation: PROCEED, FLAG, or SKIP
+>
+> Job description:
+> <paste JD here>
+
+If the subagent returns SKIP, stop and report the result to the user. Do not proceed.
+If the subagent returns FLAG, surface the flags and ask the user whether to proceed.
+If PROCEED, continue.
+
+## Step 2 — Company log check
+
+Read `C:/Users/brown/Git/job-search/context/company_log.md`.
+Check the "Roles Completed" and "Roles Skipped" tables for the company and role.
+If already present, stop and tell the user: "This role is already logged as [completed/skipped]."
+
+## Step 3 — Read style rules
+
+Read `C:/Users/brown/Git/job-search/context/style_rules.md` in full. Internalize all rules before drafting. Do not proceed until read.
+
+## Step 4 — Select model letter
+
+Read `C:/Users/brown/Git/job-search/models/INDEX.md`.
+Identify the closest matching model letter for this role type.
+Read that model letter file.
+Tell the user which model you selected and why.
+
+## Step 5 — Check accomplishments
+
+Read `C:/Users/brown/Git/job-search/context/accomplishments.md`.
+Note which accomplishments are relevant to this JD. Only claim what is listed there.
+
+## Step 6 — Draft the letter (Sonnet — this session)
+
+Draft the cover letter body in Markdown. Apply all style rules from Step 3 while drafting:
+- No em-dashes (anywhere, no exceptions)
+- No banned constructions ("The outcomes were concrete" and all variants)
+- Do not claim Mike "led a platform directorate" — use "led platform teams responsible for..." or "led programs within the platform organization"
+- Body word ceiling: 470 words
+- Output is Markdown only
+
+Use the model letter from Step 4 as a structural reference. Adapt tone and emphasis to the specific JD. Do not copy model letter text verbatim.
+
+## Step 7 — Style self-check (Haiku subagent)
+
+Spawn a **Haiku** subagent with this task:
+
+> You are performing a style self-check on a cover letter draft. Read `C:/Users/brown/Git/job-search/context/style_rules.md` — the "Self-Check Before Presenting" section only. Then check the following letter body for every violation listed in that section. Report each violation with the offending text quoted and the rule it breaks. If no violations, report "PASS".
+>
+> Letter body:
+> <paste full draft here>
+
+Report the subagent's findings to the user.
+
+## Step 8 — Fix violations
+
+Apply every violation the self-check subagent flagged. Re-read each fixed passage to confirm it is clean.
+
+## Step 9 — Word count
+
+Run:
+```bash
+echo "<letter body>" | wc -w
+```
+Or count manually. The body must be under 470 words (subtract approximately 30–35 words for header, salutation, and sign-off). If over, trim.
+
+Report the final word count to the user.
+
+## Step 10 — Save the letter
+
+Determine the output path:
+- If this letter is intended as a new canonical model (a new role type not yet in `models/`), save to `C:/Users/brown/Git/job-search/models/` and update `models/INDEX.md`
+- Otherwise, save to `C:/Users/brown/Git/job-search/applications/cover_letters/`
+
+File name format: `MikeBrown_YYYYMMDD__Company__Role__Cover_Letter.md`
+Use today's date. Confirm company name and role title with the user if not clear from the JD.
+
+Write the file.
+
+## Step 11 — Log the application
+
+Read `C:/Users/brown/Git/job-search/context/company_log.md`.
+Add a row to the "Roles Completed" table with: company name, role title, date, and the file path of the saved letter.
+Write the updated file.
+
+## Step 12 — Report to user
+
+Tell the user:
+- Where the letter was saved
+- Final word count
+- Any flags raised during fit screening that are still relevant
+- Any open items (e.g., missing salary range, unclear hiring manager name)

--- a/claude/skills/fit-screen/SKILL.md
+++ b/claude/skills/fit-screen/SKILL.md
@@ -1,13 +1,24 @@
 ---
 name: fit-screen
-description: Run fit screening on a job description for Mike Brown's job search. Uses a Haiku subagent to check auto-skip triggers, soft flags, and compensation floor. Returns PROCEED, FLAG, or SKIP. Invoke as /fit-screen [JD text or file path].
-argument-hint: "[JD text or path to JD file]"
-allowed-tools: Read Bash Agent
+description: Run fit screening on a job description for Mike Brown's job search. Uses a Haiku subagent to check auto-skip triggers, soft flags, and compensation floor. Returns PROCEED, FLAG, or SKIP. Invoke as /fit-screen [JD text, file path, PDF path, or URL].
+argument-hint: "[JD text, file path, PDF path, or URL to job posting]"
+allowed-tools: Read Bash Agent WebFetch
 ---
 
 You are running a fit screen for Mike Brown's job search.
 
-The job description is provided in `$ARGUMENTS`. If it is a file path, read it. If it is inline text, use it directly. If neither is provided, ask the user for the JD before proceeding.
+## Step 0 — Load the job description
+
+The job description is provided in `$ARGUMENTS`. Determine input type and load accordingly:
+
+- **No argument / pasted text:** If `$ARGUMENTS` is empty or looks like inline prose (not a path or URL), use it directly as the JD text. If empty, ask the user to paste the JD.
+- **File path (`.md`, `.txt`, `.docx`):** Read the file.
+- **PDF path (`.pdf`):** Read the file using the Read tool — it handles PDF extraction.
+- **URL:** Fetch the page using WebFetch. Extract the job description text from the page body; discard navigation, footers, and cookie banners.
+
+Store the extracted JD text. If the JD text is under 50 words after extraction, tell the user the source may not have loaded correctly and ask them to paste the JD directly.
+
+## Step 1 — Spawn fit screening subagent
 
 Spawn a single **Haiku** subagent with this task:
 
@@ -35,12 +46,20 @@ Spawn a single **Haiku** subagent with this task:
 > Job description:
 > <JD text>
 
-After the subagent returns, present its report directly to the user without summarizing or editorializing. Then state the recommendation prominently:
+## Step 2 — Present results
+
+Present the subagent's full report directly to the user without summarizing or editorializing. Then state the recommendation prominently:
 
 ```
 Recommendation: [PROCEED / FLAG / SKIP]
 ```
 
-If FLAG, add: "Run /cover-letter once you've reviewed the flags and decided to proceed."
-If PROCEED, add: "Run /cover-letter to draft the letter."
-If SKIP, add: "Role logged as skipped? If you want to override, re-run /cover-letter manually."
+## Step 3 — Follow-up action
+
+**If PROCEED:** Tell the user "Run /cover-letter to draft the letter." Do not log anything.
+
+**If FLAG:** Tell the user "Review the flags above, then run /cover-letter if you decide to proceed." Do not log anything.
+
+**If SKIP:** Ask the user: "Log this role as skipped in `company_log.md`? (yes/no)"
+- If yes: Read `C:/Users/brown/Git/job-search/context/company_log.md`, add a row to the "Roles Skipped" table with company name, role title, date, and the skip reason (from the triggered auto-skip rule), then write the updated file and confirm.
+- If no: Do nothing.

--- a/claude/skills/fit-screen/SKILL.md
+++ b/claude/skills/fit-screen/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: fit-screen
+description: Run fit screening on a job description for Mike Brown's job search. Uses a Haiku subagent to check auto-skip triggers, soft flags, and compensation floor. Returns PROCEED, FLAG, or SKIP. Invoke as /fit-screen [JD text or file path].
+argument-hint: "[JD text or path to JD file]"
+allowed-tools: Read Bash Agent
+---
+
+You are running a fit screen for Mike Brown's job search.
+
+The job description is provided in `$ARGUMENTS`. If it is a file path, read it. If it is inline text, use it directly. If neither is provided, ask the user for the JD before proceeding.
+
+Spawn a single **Haiku** subagent with this task:
+
+> You are performing a fit screen for a job application for Mike Brown, targeting Director and Senior Manager of Engineering roles.
+>
+> Read `C:/Users/brown/Git/job-search/context/session_instructions.md` — specifically the sections: "Fit Screening Protocol", "Technical Stack Reference", "Notable Gaps", "Compensation Floor", and "Auto-Skip Triggers".
+>
+> Evaluate the following job description against those rules and produce a structured report:
+>
+> **Section 1 — Auto-Skip Triggers**
+> List each triggered rule with the exact JD text that triggered it. If none triggered, write "None."
+>
+> **Section 2 — Soft Flags**
+> List any concerns that do not auto-skip but warrant attention: compensation uncertainty, seniority mismatch, stack gaps, industry fit issues. For each, quote the relevant JD text and explain the concern briefly.
+>
+> **Section 3 — Fit Summary**
+> 2–3 sentences summarizing how well this role matches Mike's target profile.
+>
+> **Section 4 — Recommendation**
+> One of: PROCEED / FLAG / SKIP
+> - PROCEED: No blockers, role is a strong fit
+> - FLAG: Soft concerns worth discussing before proceeding
+> - SKIP: One or more auto-skip triggers fired
+>
+> Job description:
+> <JD text>
+
+After the subagent returns, present its report directly to the user without summarizing or editorializing. Then state the recommendation prominently:
+
+```
+Recommendation: [PROCEED / FLAG / SKIP]
+```
+
+If FLAG, add: "Run /cover-letter once you've reviewed the flags and decided to proceed."
+If PROCEED, add: "Run /cover-letter to draft the letter."
+If SKIP, add: "Role logged as skipped? If you want to override, re-run /cover-letter manually."


### PR DESCRIPTION
Adds two skills for the job-search project:

- `/cover-letter` — encodes the 10-step CLAUDE.md cover letter workflow with Haiku subagents for fit screening and style self-check
- `/fit-screen` — standalone fit screening skill that returns PROCEED / FLAG / SKIP via Haiku subagent

Both skills read from `context/session_instructions.md`, `context/style_rules.md`, and `context/accomplishments.md` in the job-search repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)