### PR TITLE
fix: detect squash-merged journal branches via git log

### DIFF
--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -45,20 +45,23 @@ def unmerged_draft_branches() -> list[str]:
         )
         branches = [b.strip() for b in result.stdout.splitlines() if b.strip()]
 
-        # Find which are not merged into origin/main
+        # Find which are not merged into origin/main.
+        # Use git log --grep instead of --merged because journals are squash-merged:
+        # the original branch commits are not ancestors of main's tip, so --merged
+        # always reports them as unmerged even after the squash PR lands.
         unmerged = []
         for branch in branches:
             date_part = branch.replace("origin/draft/", "")
             if date_part == TODAY:
                 continue  # current day is always open
-            merged_result = subprocess.run(
-                ["git", "branch", "-r", "--merged", "origin/main", "--list", branch],
+            log_result = subprocess.run(
+                ["git", "log", "origin/main", "--oneline", f"--grep={date_part}", "-1"],
                 cwd=JOURNAL_REPO,
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
-            if branch not in merged_result.stdout:
+            if not log_result.stdout.strip():
                 unmerged.append(date_part)
 
         unmerged.sort(reverse=True)


### PR DESCRIPTION
## Summary
- `claude/scripts/new-day-journal-check.py`: replace `git branch -r --merged` check with `git log origin/main --grep=<date>` to detect squash merges

`git branch --merged` only works for regular merges where the original commits become ancestors of main. Journal PRs are squash-merged, so that check always reported old branches as unmerged — generating false-positive hook warnings on every prompt.

## Test plan
- [ ] Start a new session after draft/2026-04-15 and draft/2026-04-16 have been cleaned up — hook should be silent
- [ ] Create a genuine unmerged draft branch — hook should still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)