### PR TITLE
fix: resolve cover-letter file link correctly in git worktrees

### DIFF
--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -123,8 +123,21 @@ Write the updated file.
 
 ## Step 12 — Report to user
 
+Before reporting the file path, compute a path relative to the current working directory so the link resolves correctly in the UI (this matters when the session runs in a git worktree):
+
+```bash
+python3 -c "
+import os
+abs_path = 'ABSOLUTE_SAVED_PATH'
+rel = os.path.relpath(abs_path, os.getcwd()).replace('\\\\', '/')
+print(rel)
+"
+```
+
+Use the resulting relative path as the markdown link href.
+
 Tell the user:
-- Where the letter was saved
+- Where the letter was saved (as a clickable markdown link using the relative path computed above)
 - Final word count
 - Any flags raised during fit screening that are still relevant
 - Any open items (e.g., missing salary range, unclear hiring manager name)

--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -123,18 +123,17 @@ Write the updated file.
 
 ## Step 12 — Report to user
 
-Before reporting the file path, compute a path relative to the current working directory so the link resolves correctly in the UI (this matters when the session runs in a git worktree):
+Before reporting the file path, compute a path relative to the current working directory so the link resolves correctly in the UI (this matters when the session runs in a git worktree).
+
+Replace `<abs>` with the absolute path written in Step 10, then run:
 
 ```bash
-python3 -c "
-import os
-abs_path = 'ABSOLUTE_SAVED_PATH'
-rel = os.path.relpath(abs_path, os.getcwd()).replace('\\\\', '/')
-print(rel)
-"
+ABS="<abs>"
+PYBIN=$(command -v python3 || command -v python)
+"$PYBIN" -c "import os; print(os.path.relpath('$ABS', os.getcwd()).replace('\\', '/'))"
 ```
 
-Use the resulting relative path as the markdown link href.
+Use the printed path as the markdown link href — e.g., `[filename](relative/path/filename.md)`.
 
 Tell the user:
 - Where the letter was saved (as a clickable markdown link using the relative path computed above)


### PR DESCRIPTION
## Problem

When the cover-letter skill runs inside a git worktree, the absolute path written in Step 10 doesn't resolve as a clickable link in the Claude Code UI — the link is computed relative to the main worktree root, not the active session's CWD.

## Fix

Added guidance in Step 12 to compute a CWD-relative path via Python before constructing the markdown link. The relative path is used as the link href, ensuring it resolves correctly regardless of whether the session runs in the main repo or a worktree.

## Changes

- `claude/skills/cover-letter/SKILL.md` — Step 12 now includes a Python snippet to compute the relative path and uses it in the file link reported to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)