### PR TITLE
feat: new-branch helper and pre-push hook to prevent squash-merge divergence

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -50,7 +50,7 @@ Before writing a `gh` or other CLI automation script:
 - **Auto-review on PR creation.** After opening any PR, immediately run `/review <PR-URL>` before reporting the task as complete. Do not skip this step.
 - **Exception:** Local-only repos with no remote may commit to main directly.
 - **Branch creation in squash-merge repos:** Use `new-branch <name>` (source `~/.claude/scripts/new-branch.sh` in `.bashrc`) or `git checkout -b <name> origin/main` explicitly. Never cut from a branch that has been squash-merged — its commits no longer exist on main and a rebase will fail. Verify with `git merge-base HEAD origin/main` — output should equal `git rev-parse origin/main`.
-- **Pre-push hook wiring (one-time setup):** `git config --global core.hooksPath ~/.claude/hooks` — activates the divergence warning hook across all repos.
+- **Pre-push hook wiring (one-time setup):** Before setting, check for an existing value: `git config --system core.hooksPath` and `git config --global core.hooksPath`. If a system-level path exists (enterprise-managed hooks), migrate its hooks into `~/.claude/hooks/` rather than overriding. If another tool (Husky, Lefthook) owns the global value, coordinate rather than overwrite — two tools cannot share `core.hooksPath`. Once clear: `git config --global core.hooksPath ~/.claude/hooks`. The hook chains to any per-repo `.git/hooks/pre-push` so existing repo-level hooks are preserved.
 
 ---
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -49,6 +49,8 @@ Before writing a `gh` or other CLI automation script:
 - **PR first, then merge.** Open the PR immediately after pushing the branch; do not prompt the user to run `gh pr create` themselves.
 - **Auto-review on PR creation.** After opening any PR, immediately run `/review <PR-URL>` before reporting the task as complete. Do not skip this step.
 - **Exception:** Local-only repos with no remote may commit to main directly.
+- **Branch creation in squash-merge repos:** Use `new-branch <name>` (source `~/.claude/scripts/new-branch.sh` in `.bashrc`) or `git checkout -b <name> origin/main` explicitly. Never cut from a branch that has been squash-merged — its commits no longer exist on main and a rebase will fail. Verify with `git merge-base HEAD origin/main` — output should equal `git rev-parse origin/main`.
+- **Pre-push hook wiring (one-time setup):** `git config --global core.hooksPath ~/.claude/hooks` — activates the divergence warning hook across all repos.
 
 ---
 
@@ -63,6 +65,7 @@ Before writing a `gh` or other CLI automation script:
 | `~/.claude/CLAUDE.md` | `claude/CLAUDE.md` |
 | `~/.claude/scripts/` | `claude/scripts/` (directory junction) |
 | `~/.claude/skills/` | `claude/skills/` (directory junction) |
+| `~/.claude/hooks/` | `claude/hooks/` (directory junction) |
 | `~/.claude/settings.json` | `claude/settings.json` |
 
 **Machine-local only — never commit:**

--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -22,4 +22,10 @@ while read local_ref local_sha remote_ref remote_sha; do
   fi
 done
 
+# Chain to per-repo hook if one exists (preserves Husky, git-secrets, corporate hooks, etc.)
+REPO_HOOK="$(git rev-parse --git-dir)/hooks/pre-push"
+if [ -x "$REPO_HOOK" ]; then
+  "$REPO_HOOK" "$@"
+fi
+
 exit 0

--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -1,0 +1,25 @@
+#!/bin/bash
+# pre-push hook: warn when branch merge base diverges from origin/main
+#
+# Catches the squash-merge divergence case: if this repo uses squash merges,
+# a branch cut from a pre-squash ancestor will have a merge base that doesn't
+# match origin/main's tip. The PR will target the wrong base and rebase will fail.
+#
+# This hook WARNS only (exit 0) — it does not block the push.
+# Install globally: git config --global core.hooksPath ~/.claude/hooks
+
+while read local_ref local_sha remote_ref remote_sha; do
+  # skip deletes
+  [ "$local_sha" = "0000000000000000000000000000000000000000" ] && continue
+
+  merge_base=$(git merge-base "$local_sha" origin/main 2>/dev/null)
+  main_tip=$(git rev-parse origin/main 2>/dev/null)
+
+  if [ -n "$merge_base" ] && [ "$merge_base" != "$main_tip" ]; then
+    echo "WARNING: Branch merge base (${merge_base:0:8}) != origin/main tip (${main_tip:0:8})." >&2
+    echo "If this repo uses squash merges, the PR may target the wrong base." >&2
+    echo "Consider cherry-picking onto a fresh branch from origin/main." >&2
+  fi
+done
+
+exit 0

--- a/claude/scripts/new-branch.sh
+++ b/claude/scripts/new-branch.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# new-branch: create a branch always rooted at origin/main
+#
+# Usage (after sourcing):  new-branch <branch-name>
+#
+# In squash-merge repos, cutting from a branch that has already been merged
+# leaves the new branch rooted at a commit that no longer exists on main.
+# This function always checks out from origin/main, warning if HEAD has diverged.
+
+new-branch() {
+  local branch_name="$1"
+  if [ -z "$branch_name" ]; then
+    echo "Usage: new-branch <branch-name>" >&2
+    return 1
+  fi
+
+  git fetch origin
+
+  local merge_base main_tip
+  merge_base=$(git merge-base HEAD origin/main)
+  main_tip=$(git rev-parse origin/main)
+
+  if [ "$merge_base" != "$main_tip" ]; then
+    echo "WARNING: HEAD is not based on origin/main tip." >&2
+    echo "  merge-base : ${merge_base:0:8}" >&2
+    echo "  origin/main: ${main_tip:0:8}" >&2
+    echo "Creating branch from origin/main (recommended). Ctrl-C to cancel." >&2
+    sleep 2
+  fi
+
+  git checkout -b "$branch_name" origin/main
+}


### PR DESCRIPTION
## Summary

- Adds `claude/scripts/new-branch.sh` — a sourceable shell function that always cuts branches from `origin/main`, warning with a 2-second pause if HEAD has diverged
- Adds `claude/hooks/pre-push` — a non-blocking git hook that warns at push time when the branch merge base differs from `origin/main` tip (squash-merge divergence signal)
- Updates `claude/CLAUDE.md` — adds the `hooks/` directory to the Dev-Env symlink table, and adds two Git Workflow bullets covering `new-branch` usage and the one-time `core.hooksPath` setup

## One-time setup required after merge

```bash
# Create the hooks directory junction (mirrors the scripts/ pattern)
cmd /c mklink /J C:\Users\brown\.claude\hooks C:\Users\brown\Git\dev-env\claude\hooks

# Wire up git to use it globally
git config --global core.hooksPath ~/.claude/hooks
```

## Test plan

- [ ] `source ~/.claude/scripts/new-branch.sh && new-branch test/foo` from a clean main checkout — no warning, creates branch at origin/main tip
- [ ] Same from a stale ancestor — warning prints, 2-second pause, then branch created from origin/main
- [ ] `git push` on a branch cut from origin/main — no hook output
- [ ] `git push` on a branch whose merge-base != origin/main — warning lines appear on stderr, push succeeds

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)