### PR TITLE
fix: wrap hook commands with bash -c for python3 resolution

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 C:/Users/brown/.claude/scripts/pre-commit-branch-check.py"
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/pre-commit-branch-check.py'"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 C:/Users/brown/.claude/scripts/new-day-journal-check.py"
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/new-day-journal-check.py'"
           }
         ]
       }
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 C:/Users/brown/.claude/scripts/token-tracker.py"
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/token-tracker.py'"
           }
         ]
       }
@@ -37,15 +37,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 C:/Users/brown/.claude/scripts/pr-merge-reminder.py"
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/pr-merge-reminder.py'"
           },
           {
             "type": "command",
-            "command": "python3 C:/Users/brown/.claude/scripts/post-tool-use.py"
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/post-tool-use.py'"
           },
           {
             "type": "command",
-            "command": "python3 C:/Users/brown/.claude/scripts/post-pr-merge-pull.py"
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/post-pr-merge-pull.py'"
           }
         ]
       }

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,23 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Setting up dev-env from $REPO_DIR"
 
+# Claude Code hook commands use "bash -c '...'" so that python3 (a Windows App
+# Execution Alias symlink) resolves correctly regardless of which process spawns
+# the hook. Verify that bash.exe is on the Windows PATH so non-interactive
+# processes (like the Claude Code Desktop hook runner) can find it.
+BASH_PATH="$(cmd.exe /c "where bash 2>NUL" 2>/dev/null | tr -d '\r' | head -1)"
+if [ -z "$BASH_PATH" ]; then
+  echo ""
+  echo "WARNING: bash.exe is not on the Windows PATH."
+  echo "  Claude Code hooks use 'bash -c ...' to invoke Python scripts."
+  echo "  Add Git Bash to your Windows PATH, e.g.:"
+  echo "    C:\\Program Files\\Git\\usr\\bin"
+  echo "  Then re-run this script."
+  echo ""
+else
+  echo "  bash found at: $BASH_PATH"
+fi
+
 # Claude Code global config
 mkdir -p "$HOME/.claude"
 


### PR DESCRIPTION
## Summary

- `python3` in `settings.json` hooks was invoking the Windows App Execution Alias (`WindowsApps/python3.exe`), which is a symlink that only resolves correctly in a Git Bash context
- Claude Code's hook runner on Windows invokes commands outside Git Bash, causing the Stop hook (and latently all hooks) to fail on `python3`
- Wrapped all hook commands with `bash -c '...'` so Git Bash resolves `python3` consistently regardless of which process invokes the hook

## Test plan

- [ ] Start a new Claude Code session — confirm `UserPromptSubmit` hook fires without error
- [ ] Run a Bash tool call — confirm `PreToolUse` and `PostToolUse` hooks fire
- [ ] End a session — confirm `Stop` hook writes to `~/.claude/scratch/token-sessions.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)