### PR TITLE
feat: migrate journal workflow to per-session stub files

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -117,59 +117,58 @@ Use that path wherever `sessions/<project>/` appears below.
 
 ---
 
-### Draft file workflow
+### Stub file workflow
 
-One draft file per calendar day, living on a dedicated branch in the engineering-journal repo.
-Slug is determined at day end when the overall theme is clear.
+Each session writes an isolated stub file — no shared mutable draft. This eliminates write
+contention when multiple sessions run in parallel. Slug is determined at day end.
 
 **Branch:** `draft/YYYY-MM-DD` — created at the first session of the day, merged to main at day end.
+
+**Stub filename:** `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md`
+where `HHMMSS` is the UTC start time of the session (`date -u +%H%M%S`).
 
 **First session of the day:**
 1. `git -C C:/Users/brown/Git/engineering-journal checkout main && git pull`
 2. `git -C C:/Users/brown/Git/engineering-journal checkout -b draft/YYYY-MM-DD`
-3. Create `sessions/<project>/YYYY-MM-DD_draft.md` with the opening brief and first
-   `<!-- session: <slug> -->` block
+3. Create `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` (see stub structure below)
 4. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
 
 **Subsequent sessions:**
 1. `git -C C:/Users/brown/Git/engineering-journal pull origin draft/YYYY-MM-DD`
-2. Get the file's line count (`wc -l`), then `Read` with offset to retrieve only the last
-   `<!-- next-session-context -->` block — do not read the full draft
-3. Append the new `<!-- session: <slug> -->` block and `<!-- next-session-context -->` paragraph
-   using `Edit`
-4. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block,
-   drawn from the Claude Code CLI session summary
+2. Find the most recent stub and read only its `<!-- next-session-context -->` paragraph:
+   ```bash
+   ls -t C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD_*.stub.md | head -1
+   ```
+3. Create a new `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` with the current session block
+4. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
 5. `git add`, `git commit -m "draft: YYYY-MM-DD session N"`, `git push`
 
 **End of day (last session):**
-1. Read the full draft once to compose the final 11-section document
-2. Write as `sessions/<project>/YYYY-MM-DD-<slug>.md`
-3. Delete the draft file
-4. `git add`, `git commit -m "[docs] Add YYYY-MM-DD journal: <slug>"`
-5. Open a PR from `draft/YYYY-MM-DD` into `main`, squash merge, delete branch
+1. Run `/journal-compose` — it discovers all stubs, sorts them, merges them, and produces
+   the canonical 11-section document; it also deletes stubs and opens the PR
 
 ---
 
-### Draft structure during the day
+### Stub structure
+
+Each stub file contains exactly one session block:
 
 ```
-<!-- draft: YYYY-MM-DD -->
-Opening brief: ...
+<!-- stub: YYYY-MM-DD HHMMSS -->
 
-<!-- session: <first-slug> -->
+<!-- opening-brief (first stub of the day only) -->
+Opening brief: <Next Session Context from the previous day, or "First session — no prior context.">
+
+<!-- session: <slug> -->
 ## <Topic>
 ...
 <!-- tokens: input=12,450 output=3,200 cost≈$0.08 -->
 <!-- next-session-context -->
-<one paragraph — copy to open next session>
-
-<!-- session: <second-slug> -->
-## <Topic>
-...
-<!-- tokens: input=18,900 output=4,100 cost≈$0.12 -->
-<!-- next-session-context -->
-<one paragraph — copy to open next session>
+<one paragraph — for the next session to read and open with>
 ```
+
+The `<!-- opening-brief -->` block appears **only in the first stub of the day**.
+Subsequent stubs begin directly at `<!-- session: <slug> -->`.
 
 ---
 
@@ -188,7 +187,7 @@ Opening brief: ...
 8. Token Optimization Suggestions (2–4 per-session observations grouped under a `### Session N`
    heading; close with a `### Cross-Session Patterns` subsection for generalizable findings
    that apply across multiple sessions)
-9. Next Session Context (the final `<!-- next-session-context -->` block from the draft)
+9. Next Session Context (the final `<!-- next-session-context -->` block from the stubs)
 10. Reflection (gaps, risks, strategic questions — written last)
 11. Further Reading (1–3 primary sources per session that explain the reasoning behind key
     decisions; intended for deliberate study between sessions — link + one sentence on why
@@ -199,7 +198,7 @@ Opening brief: ...
 ### Update triggers
 
 **Project journal** (`sessions/<project>/`):
-- Append to draft when a PR is merged or a strategic decision is made
+- Add to the current session's stub when a PR is merged or a strategic decision is made
 - Compose and publish the daily document at end of last session of the day
 
 **Meta journal** (`sessions/meta/`):

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -137,7 +137,7 @@ where `HHMMSS` is the UTC start time of the session (`date -u +%H%M%S`).
 1. `git -C C:/Users/brown/Git/engineering-journal pull origin draft/YYYY-MM-DD`
 2. Find the most recent stub and read only its `<!-- next-session-context -->` paragraph:
    ```bash
-   ls -t C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD_*.stub.md | head -1
+   ls C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD_*.stub.md | sort | tail -1
    ```
 3. Create a new `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` with the current session block
 4. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
@@ -157,7 +157,8 @@ Each stub file contains exactly one session block:
 <!-- stub: YYYY-MM-DD HHMMSS -->
 
 <!-- opening-brief (first stub of the day only) -->
-Opening brief: <Next Session Context from the previous day, or "First session — no prior context.">
+Opening brief: <paste the Next Session Context from the previous day's published journal verbatim;
+               use "First session — no prior context." only if this is the project's very first entry>
 
 <!-- session: <slug> -->
 ## <Topic>

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -28,7 +28,8 @@ def stale_draft_artifacts() -> list[str]:
     artifacts = []
     for pattern in (
         str(JOURNAL_REPO / "sessions" / "**" / "*_draft.md"),
-        str(JOURNAL_REPO / "sessions" / "**" / "*.stub.md"),
+        # Match only convention-named stubs: YYYY-MM-DD_HHMMSS.stub.md
+        str(JOURNAL_REPO / "sessions" / "**" / "????-??-??_*.stub.md"),
     ):
         artifacts.extend(glob.glob(pattern, recursive=True))
     stale = [f for f in artifacts if not os.path.basename(f).startswith(TODAY)]

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -23,11 +23,15 @@ JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
 TODAY = date.today().strftime("%Y-%m-%d")
 
 
-def stale_draft_files() -> list[str]:
-    """Return paths of *_draft.md files from before today."""
-    pattern = str(JOURNAL_REPO / "sessions" / "**" / "*_draft.md")
-    drafts = glob.glob(pattern, recursive=True)
-    stale = [f for f in drafts if not os.path.basename(f).startswith(TODAY)]
+def stale_draft_artifacts() -> list[str]:
+    """Return paths of *_draft.md or *.stub.md files from before today."""
+    artifacts = []
+    for pattern in (
+        str(JOURNAL_REPO / "sessions" / "**" / "*_draft.md"),
+        str(JOURNAL_REPO / "sessions" / "**" / "*.stub.md"),
+    ):
+        artifacts.extend(glob.glob(pattern, recursive=True))
+    stale = [f for f in artifacts if not os.path.basename(f).startswith(TODAY)]
     stale.sort(key=lambda f: os.path.basename(f), reverse=True)
     return stale
 
@@ -99,15 +103,15 @@ def main() -> None:
 
     messages = []
 
-    stale = stale_draft_files()
+    stale = stale_draft_artifacts()
     if stale:
-        draft_path = Path(stale[0]).as_posix()
-        draft_date = os.path.basename(stale[0]).replace("_draft.md", "")
+        artifact_path = Path(stale[0]).as_posix()
+        artifact_date = os.path.basename(stale[0])[:10]  # YYYY-MM-DD prefix
         messages.append(
-            f"[journal-hook] Stale draft file detected: {draft_path}\n"
-            f"The engineering journal draft from {draft_date} was never composed.\n"
+            f"[journal-hook] Stale draft artifact detected: {artifact_path}\n"
+            f"The engineering journal draft from {artifact_date} was never composed.\n"
             f"Before responding to the user's message, invoke the journal-compose skill "
-            f"to close out the {draft_date} session. Then proceed with the user's request."
+            f"to close out the {artifact_date} session. Then proceed with the user's request."
         )
 
     unmerged = unmerged_draft_branches()

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: journal-compose
-description: Compose the end-of-day engineering journal from today's draft file. Produces the canonical 11-section document, updates READMEs, commits, and prompts for a PR. Invoke as /journal-compose [draft-file-path].
-argument-hint: "[sessions/<project>/YYYY-MM-DD_draft.md]"
+description: Compose the end-of-day engineering journal from today's stub files. Discovers all YYYY-MM-DD_*.stub.md files, sorts and merges them, produces the canonical 11-section document, updates READMEs, commits, and opens the PR. Invoke as /journal-compose [YYYY-MM-DD].
+argument-hint: "[YYYY-MM-DD]"
 allowed-tools: Read Edit Write Bash Glob Grep Agent
 ---
 
@@ -12,38 +12,81 @@ Supporting files:
 - `~/.claude/skills/sources.md` — shared primary source library, organized by topic tag;
   use Grep on this file before spawning any research subagent (see Section 11)
 
-## Step 1 — Locate the draft file
+## Step 1 — Locate stubs and acquire compose lock
 
-If `$ARGUMENTS` is provided, use it as the draft file path (relative to the repo root
-`C:/Users/brown/Git/engineering-journal`).
+**Determine the date:**
 
-If no argument is given, detect from the current branch:
+If `$ARGUMENTS` is provided and matches `YYYY-MM-DD`, use it as the date. Otherwise, detect
+from the current branch:
 ```bash
 git -C C:/Users/brown/Git/engineering-journal branch --show-current
 ```
-The branch name is `draft/YYYY-MM-DD`. List draft files on that branch:
+The branch name is `draft/YYYY-MM-DD`. Extract `YYYY-MM-DD` from it.
+
+**Find stub files:**
+
 ```bash
-find C:/Users/brown/Git/engineering-journal/sessions -name "*_draft.md"
+ls C:/Users/brown/Git/engineering-journal/sessions/*/YYYY-MM-DD_*.stub.md 2>/dev/null | sort
 ```
-If multiple draft files exist (multiple projects active today), ask the user which one to
-compose. If exactly one draft file is found, proceed with it.
 
-Confirm the path and tell the user: "Composing journal from: `<path>`"
+If no stubs are found, fall back to a legacy draft:
+```bash
+find C:/Users/brown/Git/engineering-journal/sessions -name "YYYY-MM-DD_draft.md"
+```
+If a legacy draft is found, use it as a monolithic draft (skip the lock step below and proceed
+as in the old single-file workflow — read it once in Step 2).
 
-## Step 2 — Read the draft file once
+If stubs span multiple project directories (e.g., both `sessions/lifting-logbook/` and
+`sessions/meta/`), ask the user which project to compose (or compose both sequentially).
 
-Read the entire draft file in a single `Read` call. Do not read it again during composition.
-Capture all content in memory for use in all subsequent steps.
+**Acquire the compose lock:**
 
-From the draft file, extract:
-- **Date** — from the `<!-- draft: YYYY-MM-DD -->` comment
-- **Project path** — the `sessions/<project>/` directory component of the draft file path
-- **Opening brief** — the text after `Opening brief:` at the top, before the first `<!-- session: ... -->`
-- **Session blocks** — each `<!-- session: <slug> -->` … `<!-- tokens: ... -->` … `<!-- next-session-context -->` unit
+Check for a lock at `sessions/<project>/.draft-compose.lock`:
+```bash
+LOCK="C:/Users/brown/Git/engineering-journal/sessions/<project>/.draft-compose.lock"
+if [ -f "$LOCK" ]; then
+  LOCK_TIME=$(cat "$LOCK")
+  LOCK_EPOCH=$(date -d "$LOCK_TIME" +%s 2>/dev/null || echo 0)
+  NOW_EPOCH=$(date +%s)
+  AGE=$(( NOW_EPOCH - LOCK_EPOCH ))
+  if [ "$AGE" -lt 600 ]; then
+    echo "LOCK_ACTIVE=true AGE=$AGE"
+  else
+    echo "LOCK_STALE=true AGE=$AGE"
+  fi
+fi
+```
+
+- **`LOCK_ACTIVE`:** Abort. Tell the user: "Compose is already running (lock age: ${AGE}s). If
+  this is stale, delete `sessions/<project>/.draft-compose.lock` and retry."
+- **`LOCK_STALE`:** Warn the user ("Stale compose lock (${AGE}s old) — overriding."), then continue.
+- **No lock:** Continue.
+
+Create the lock:
+```bash
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > \
+  "C:/Users/brown/Git/engineering-journal/sessions/<project>/.draft-compose.lock"
+```
+
+Tell the user: "Composing journal from N stub(s): `<stub1>`, `<stub2>`, ..."
+
+## Step 2 — Read all stubs
+
+Read each stub file in ascending filename order (which equals chronological session order).
+Do not re-read stubs after this step.
+
+From the stubs, extract:
+- **Date** — the `YYYY-MM-DD` prefix from any stub filename
+- **Project path** — the `sessions/<project>/` directory component of the stub paths
+- **Opening brief** — from the `<!-- opening-brief -->` block in the **first** stub only.
+  If absent, use `"First session for this project — no prior Next Session Context."`
+- **Session blocks** — from each stub, in filename order:
+  `<!-- session: <slug> -->` … `<!-- tokens: ... -->` … `<!-- next-session-context -->` unit
   - Session slug, H2 heading, body content
   - Token comment (may be absent — note if missing)
   - Next-session-context paragraph
-- **Last next-session-context** — the final one in the file (used in Section 9)
+- **Last next-session-context** — the final `<!-- next-session-context -->` paragraph across
+  all stubs (used in Section 9)
 
 ## Step 2b — Check for meta-relevant content (project drafts only)
 
@@ -508,14 +551,20 @@ Top-level entry format (description + link only, no table):
 If the project does not yet appear in the README, add a new `### <Project>` section
 under `## Projects` using this format.
 
-## Step 9 — Delete the draft file
+## Step 9 — Delete stub files and release lock
 
-Delete the draft file:
+Delete all stubs for the date and release the compose lock:
+```bash
+rm C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD_*.stub.md
+rm -f C:/Users/brown/Git/engineering-journal/sessions/<project>/.draft-compose.lock
+```
+
+For legacy single-file compose, delete the draft file instead:
 ```bash
 rm C:/Users/brown/Git/engineering-journal/<draft-file-path>
 ```
 
-Tell the user: "Draft file deleted."
+Tell the user: "Stub files deleted."
 
 ## Step 10 — Commit
 
@@ -523,6 +572,8 @@ Tell the user: "Draft file deleted."
 git -C C:/Users/brown/Git/engineering-journal add sessions/<project>/YYYY-MM-DD-<slug>.md
 git -C C:/Users/brown/Git/engineering-journal add sessions/<project>/README.md
 git -C C:/Users/brown/Git/engineering-journal add README.md
+# Stage deleted stubs (and any other modifications/deletions in sessions/<project>/)
+git -C C:/Users/brown/Git/engineering-journal add -u sessions/<project>/
 git -C C:/Users/brown/Git/engineering-journal commit -m "[docs] Add YYYY-MM-DD journal: <slug>"
 git -C C:/Users/brown/Git/engineering-journal push
 ```

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -70,6 +70,10 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > \
 
 Tell the user: "Composing journal from N stub(s): `<stub1>`, `<stub2>`, ..."
 
+**Note for retries after a crash:** If compose was interrupted and you are re-running it, first
+delete the lock file manually (`rm sessions/<project>/.draft-compose.lock`) and verify that no
+partial output file (e.g., `YYYY-MM-DD-<slug>.md`) was written before restarting from Step 1.
+
 ## Step 2 — Read all stubs
 
 Read each stub file in ascending filename order (which equals chronological session order).
@@ -564,7 +568,12 @@ For legacy single-file compose, delete the draft file instead:
 rm C:/Users/brown/Git/engineering-journal/<draft-file-path>
 ```
 
-Tell the user: "Stub files deleted."
+Tell the user: "Draft artifacts deleted."
+
+**Lock file hygiene:** `.draft-compose.lock` is ephemeral and must never be committed. If it
+appears in `git status` as an untracked file during compose, that is expected — `git add -u`
+(Step 10) will not stage it because it has never been committed. Do not run `git add .` or
+`git add sessions/<project>/` (without `-u`) — that would stage the lock file.
 
 ## Step 10 — Commit
 

--- a/claude/skills/sources.md
+++ b/claude/skills/sources.md
@@ -168,6 +168,18 @@ posts on company engineering blogs, and books with canonical URLs.
 
 ---
 
+## Git & Platform Tooling
+
+**tags: git, hooks, core.hooksPath, windows, bash, path, junction, symlink**
+
+- **git-config man page — core.hooksPath** | Git project (Junio C Hamano, maintainer) | https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath |
+  Canonical specification for `core.hooksPath` (introduced Git 2.9); defines that the configured path *fully replaces* the default `.git/hooks/` lookup — which is precisely why any global hook must explicitly chain to `$(git rev-parse --git-dir)/hooks/<hook-name>` to preserve per-repo hooks.
+
+- **Environment variables in Windows** | Microsoft | https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables |
+  Documents that child processes inherit the environment of their parent at spawn time, not the interactive user session's environment; this is the underlying mechanism that causes Windows App Execution Alias stubs (python3, node via Store) to be invisible to non-interactive hook runners — cite when any hook command relies on the Git Bash PATH.
+
+---
+
 ## Claude Code & AI-Assisted Development
 
 **tags: claude-code, llm, ai-dev, token, hooks, skills, mcp**


### PR DESCRIPTION
## Summary

- Replaces the shared `YYYY-MM-DD_draft.md` with isolated `YYYY-MM-DD_HHMMSS.stub.md` files (one per session) — eliminates write contention when parallel sessions run simultaneously
- `/journal-compose` now globs all stubs for the date, sorts by filename (UTC timestamp = chronological), and merges them at compose time
- Compose step acquires a lock file (`sessions/<project>/.draft-compose.lock`) with a 10-minute TTL and stale-lock override to prevent concurrent compose runs
- `new-day-journal-check.py` extended to detect stale `*.stub.md` files from previous days alongside the existing `*_draft.md` check
- Legacy `*_draft.md` files are still handled as a fallback in the compose skill (backwards compat)

Closes brownm09/engineering-journal#20

## Test plan

- [ ] Start a new session on `draft/YYYY-MM-DD` and verify it creates `YYYY-MM-DD_HHMMSS.stub.md` (not `_draft.md`)
- [ ] Run `/journal-compose YYYY-MM-DD` against a date with multiple stubs and verify correct sort-and-merge order
- [ ] Verify lock file is created at compose start and deleted at Step 9
- [ ] Verify stale lock (> 10 min) is overridden with a warning rather than aborting
- [ ] Verify hook detects stale `.stub.md` from a previous day

🤖 Generated with [Claude Code](https://claude.com/claude-code)