### PR TITLE
feat: add routines/ as a managed ~/.claude path

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -66,7 +66,7 @@ Before writing a `gh` or other CLI automation script:
 | `~/.claude/scripts/` | `claude/scripts/` (directory junction) |
 | `~/.claude/skills/` | `claude/skills/` (directory junction) |
 | `~/.claude/hooks/` | `claude/hooks/` (directory junction) |
-| `~/.claude/routines/` | `claude/routines/` (directory junction) |
+| `~/.claude/scheduled-tasks/` | `claude/routines/` (directory junction to `~/.claude/scheduled-tasks/`) |
 | `~/.claude/settings.json` | `claude/settings.json` |
 
 **Machine-local only — never commit:**
@@ -75,7 +75,7 @@ Before writing a `gh` or other CLI automation script:
 
 **Rule:** Any addition or modification to a dev-env-owned artifact — new hook script, new skill, settings change, CLAUDE.md edit — must be committed to `brownm09/dev-env` via branch and PR before the session ends. Do not leave global tooling as untracked files.
 
-**Routines note:** The `anthropic-skills:schedule` tool writes new scheduled tasks to `~/.claude/scheduled-tasks/` by default. After creation, move the SKILL.md into `~/.claude/routines/<task-name>/`, disable or delete the `scheduled-tasks/` entry, and commit the file to dev-env under `claude/routines/`.
+**Routines note:** `claude/routines/` is a junction to `~/.claude/scheduled-tasks/`, so the scheduler tool writes directly to the version-controlled directory. After creating a new routine, commit it to dev-env under `claude/routines/`.
 
 **Repo path:** `C:/Users/brown/Git/dev-env`
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -75,7 +75,7 @@ Before writing a `gh` or other CLI automation script:
 
 **Rule:** Any addition or modification to a dev-env-owned artifact — new hook script, new skill, settings change, CLAUDE.md edit — must be committed to `brownm09/dev-env` via branch and PR before the session ends. Do not leave global tooling as untracked files.
 
-**Routines note:** `claude/routines/` is a junction to `~/.claude/scheduled-tasks/`, so the scheduler tool writes directly to the version-controlled directory. After creating a new routine, commit it to dev-env under `claude/routines/`.
+**Routines note:** `dev-env/claude/routines/` is a directory junction pointing at `~/.claude/scheduled-tasks/`, so the scheduler tool writes directly to the version-controlled path. After creating a new routine, commit it to dev-env under `claude/routines/`.
 
 **Repo path:** `C:/Users/brown/Git/dev-env`
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -66,6 +66,7 @@ Before writing a `gh` or other CLI automation script:
 | `~/.claude/scripts/` | `claude/scripts/` (directory junction) |
 | `~/.claude/skills/` | `claude/skills/` (directory junction) |
 | `~/.claude/hooks/` | `claude/hooks/` (directory junction) |
+| `~/.claude/routines/` | `claude/routines/` (directory junction) |
 | `~/.claude/settings.json` | `claude/settings.json` |
 
 **Machine-local only — never commit:**
@@ -73,6 +74,8 @@ Before writing a `gh` or other CLI automation script:
 `scratch/`, `projects/`, `sessions/`, `backups/`, `ide/`, `plans/`, `shell-snapshots/`
 
 **Rule:** Any addition or modification to a dev-env-owned artifact — new hook script, new skill, settings change, CLAUDE.md edit — must be committed to `brownm09/dev-env` via branch and PR before the session ends. Do not leave global tooling as untracked files.
+
+**Routines note:** The `anthropic-skills:schedule` tool writes new scheduled tasks to `~/.claude/scheduled-tasks/` by default. After creation, move the SKILL.md into `~/.claude/routines/<task-name>/`, disable or delete the `scheduled-tasks/` entry, and commit the file to dev-env under `claude/routines/`.
 
 **Repo path:** `C:/Users/brown/Git/dev-env`
 

--- a/claude/routines/daily-journal-compose/SKILL.md
+++ b/claude/routines/daily-journal-compose/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: daily-journal-compose
+description: Assemble all today's session stubs across all projects into canonical daily journal entries and open PRs.
+---
+
+Compose today's engineering journal entries for all active projects.
+
+**Objective:** Run /journal-compose for today's date once per project that has stubs, merging session stubs into canonical daily documents and opening a PR per project (or one combined PR if the skill handles all projects together).
+
+**Steps:**
+1. Determine today's date: run `date -u +%Y-%m-%d` in Git Bash (call it DATE).
+2. Find all projects with stubs for today:
+   ```bash
+   ls C:/Users/brown/Git/engineering-journal/sessions/*/DATE_*.stub.md 2>/dev/null
+   ```
+   Extract unique project directory names from the results.
+3. If no stubs exist for any project, exit silently.
+4. For each project that has stubs, invoke the journal-compose skill:
+   `/journal-compose DATE`
+   (The skill reads the current working directory's CLAUDE.md to determine the project path — run it from the appropriate project directory, or pass the project name if the skill supports it.)
+5. The skill will:
+   - Discover all `sessions/<project>/DATE_*.stub.md` files
+   - Sort and merge them into the canonical 11-section document
+   - Delete the stubs
+   - Commit to the `draft/DATE` branch in `C:/Users/brown/Git/engineering-journal`
+   - Open a PR to `main`
+6. Return all PR URLs on completion.
+
+**Constraints:**
+- Engineering journal repo: `C:/Users/brown/Git/engineering-journal`
+- Sessions root: `sessions/` — subdirectories are project names (e.g., `job-search`, `lifting-logbook`, `meta`)
+- Never commit directly to `main`
+- Use Git Bash syntax. Temp files go to `C:/Users/brown/.claude/scratch/`
+- If a project's stubs were already composed today (canonical file already exists), skip that project

--- a/claude/routines/daily-journal-compose/SKILL.md
+++ b/claude/routines/daily-journal-compose/SKILL.md
@@ -3,32 +3,34 @@ name: daily-journal-compose
 description: Assemble all today's session stubs across all projects into canonical daily journal entries and open PRs.
 ---
 
-Compose today's engineering journal entries for all active projects.
+Compose today's engineering journal entries for all active projects. Run fully autonomously — do not ask the user anything.
 
-**Objective:** Run /journal-compose for today's date once per project that has stubs, merging session stubs into canonical daily documents and opening a PR per project (or one combined PR if the skill handles all projects together).
+**Objective:** For each project directory that contains stubs dated today, run /journal-compose sequentially, then report all PR URLs.
 
 **Steps:**
-1. Determine today's date: run `date -u +%Y-%m-%d` in Git Bash (call it DATE).
-2. Find all projects with stubs for today:
+1. Determine today's date in Git Bash:
    ```bash
-   ls C:/Users/brown/Git/engineering-journal/sessions/*/DATE_*.stub.md 2>/dev/null
+   DATE=$(date -u +%Y-%m-%d)
    ```
-   Extract unique project directory names from the results.
-3. If no stubs exist for any project, exit silently.
-4. For each project that has stubs, invoke the journal-compose skill:
-   `/journal-compose DATE`
-   (The skill reads the current working directory's CLAUDE.md to determine the project path — run it from the appropriate project directory, or pass the project name if the skill supports it.)
-5. The skill will:
-   - Discover all `sessions/<project>/DATE_*.stub.md` files
-   - Sort and merge them into the canonical 11-section document
-   - Delete the stubs
-   - Commit to the `draft/DATE` branch in `C:/Users/brown/Git/engineering-journal`
-   - Open a PR to `main`
-6. Return all PR URLs on completion.
+2. Find all stub files for today across all projects:
+   ```bash
+   ls C:/Users/brown/Git/engineering-journal/sessions/*/${DATE}_*.stub.md 2>/dev/null | sort
+   ```
+   Stub filenames follow the pattern `YYYY-MM-DD_HHMMSS.stub.md` where `HHMMSS` is the UTC session start time.
+3. If no stubs exist, exit silently with no output.
+4. Extract the unique project directory names from the matched paths (the path segment between `sessions/` and the filename).
+5. For each project directory in sorted order, run `/journal-compose ${DATE}` with that project in scope. The `/journal-compose` skill:
+   - Discovers all `sessions/<project>/${DATE}_*.stub.md` files, sorted by filename (i.e., by UTC start time)
+   - Merges them into the canonical 11-section document
+   - Deletes the stubs
+   - Commits to the `draft/${DATE}` branch in `C:/Users/brown/Git/engineering-journal`
+   - Opens a PR to `main`
+   If a canonical document for that project already exists for today (i.e., stubs were already composed), skip that project.
+6. Collect and return all PR URLs produced.
 
 **Constraints:**
 - Engineering journal repo: `C:/Users/brown/Git/engineering-journal`
 - Sessions root: `sessions/` — subdirectories are project names (e.g., `job-search`, `lifting-logbook`, `meta`)
 - Never commit directly to `main`
 - Use Git Bash syntax. Temp files go to `C:/Users/brown/.claude/scratch/`
-- If a project's stubs were already composed today (canonical file already exists), skip that project
+- Never prompt the user. If stubs span multiple projects, compose each one sequentially without asking.

--- a/claude/routines/daily-journal-compose/SKILL.md
+++ b/claude/routines/daily-journal-compose/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: daily-journal-compose
 description: Assemble all today's session stubs across all projects into canonical daily journal entries and open PRs.
+schedule: "0 0 * * *"
 ---
 
 Compose today's engineering journal entries for all active projects. Run fully autonomously — do not ask the user anything.


### PR DESCRIPTION
## Summary

- Adds `claude/routines/` as a version-controlled directory for scheduled task SKILL.md files
- Wires it as a directory junction at `~/.claude/routines/`
- Adds `daily-journal-compose` as the first routine (midnight nightly journal assembly across all projects in `brownm09/engineering-journal`)
- Updates `CLAUDE.md` managed-paths table and adds a migration note for tasks created by `anthropic-skills:schedule`

Closes #38

## Test plan

- [ ] Verify `~/.claude/routines/` junction resolves to `dev-env/claude/routines/`
- [ ] Confirm `daily-journal-compose/SKILL.md` is readable via the junction
- [ ] Verify scheduled task fires at midnight and composes stubs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)