### PR TITLE
feat: global token-efficiency rules, turn-count hook, and merge-stale-pr script

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -95,6 +95,16 @@ Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handle
 
 ---
 
+## Context & Token Efficiency
+
+**Directory reads:** When reading from a directory with more than ~3 files, read `INDEX.md` or a top-level manifest first. Load individual files on demand, not by globbing the whole directory. Flag to the user before reading more than 5 files in a single pass.
+
+**Session length:** A `UserPromptSubmit` hook warns at turn 50 (and every 25 turns thereafter). When warned, consider running `/clear` or `/compact` if the task scope has shifted — accumulated context inflates cost toward the end of long sessions. The default threshold can be overridden per-project: add `"turn_threshold": N` to `.claude/hook-config.json`.
+
+**Mechanical operations:** If a task is fully scriptable with known inputs, write the script rather than running an interactive session. Candidate operations: stale PR remediation, branch cleanup, rebase-and-merge sequences. Use `~/.claude/scripts/merge-stale-pr.sh` for engineering-journal stale draft PRs.
+
+---
+
 ## Documentation and Citations
 
 When writing or updating any architectural documentation (ADRs, design docs, READMEs):

--- a/claude/scripts/merge-stale-pr.sh
+++ b/claude/scripts/merge-stale-pr.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# merge-stale-pr.sh — remediate a stale engineering-journal draft PR
+#
+# Usage: merge-stale-pr.sh <pr-number>
+#
+# Steps:
+#   1. Look up the branch from the PR
+#   2. Check out the branch, pull latest
+#   3. Warn if no composed journal file exists on the branch
+#   4. Delete orphaned *_draft.md files if present
+#   5. Rebase against main (resolve README conflicts by keeping branch version)
+#   6. Merge PR with squash, delete remote branch
+#
+# Prerequisites: gh CLI authenticated, run from the engineering-journal repo root
+# or set JOURNAL_REPO env var.
+
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "Usage: merge-stale-pr.sh <pr-number>" >&2
+  exit 1
+fi
+
+JOURNAL_REPO="${JOURNAL_REPO:-$HOME/Git/engineering-journal}"
+
+if [[ ! -d "$JOURNAL_REPO/.git" ]]; then
+  echo "Error: $JOURNAL_REPO is not a git repository." >&2
+  echo "Set JOURNAL_REPO env var to point at the engineering-journal repo." >&2
+  exit 1
+fi
+
+cd "$JOURNAL_REPO"
+
+# ── Step 1: resolve branch from PR ────────────────────────────────────────────
+echo "==> Fetching PR #${PR_NUMBER} details..."
+BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName' 2>/dev/null)
+if [[ -z "$BRANCH" ]]; then
+  echo "Error: could not resolve branch for PR #${PR_NUMBER}." >&2
+  exit 1
+fi
+echo "    Branch: $BRANCH"
+
+# ── Step 2: check out branch and pull ─────────────────────────────────────────
+echo "==> Checking out $BRANCH..."
+git fetch origin
+git checkout "$BRANCH"
+git pull origin "$BRANCH"
+
+# ── Step 3: check for composed journal ────────────────────────────────────────
+DATE_PART="${BRANCH#draft/}"  # e.g. "2026-04-19"
+COMPOSED_FILE=$(ls sessions/**/"${DATE_PART}"*.md 2>/dev/null | grep -v '_draft\.md' | grep -v '\.stub\.md' | head -1 || true)
+
+if [[ -z "$COMPOSED_FILE" ]]; then
+  echo "WARNING: No composed journal file found for $DATE_PART." >&2
+  echo "         The PR may not have been composed yet. Proceed anyway? [y/N]" >&2
+  read -r REPLY
+  if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
+    echo "Aborted." >&2
+    exit 1
+  fi
+else
+  echo "    Composed journal: $COMPOSED_FILE"
+fi
+
+# ── Step 4: delete orphaned _draft.md files ───────────────────────────────────
+DRAFTS=$(find sessions -name "*_draft.md" 2>/dev/null || true)
+if [[ -n "$DRAFTS" ]]; then
+  echo "==> Deleting orphaned draft files:"
+  echo "$DRAFTS" | while IFS= read -r f; do
+    echo "    $f"
+    rm -f "$f"
+  done
+  git add -u
+  git commit -m "chore: remove orphaned draft files from $DATE_PART" || true
+fi
+
+# ── Step 5: rebase against main ───────────────────────────────────────────────
+echo "==> Rebasing against main..."
+git fetch origin main
+
+# Attempt rebase; on conflict, try auto-resolution for README files
+if ! git rebase origin/main; then
+  CONFLICTS=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
+  echo "    Conflicts detected: $CONFLICTS"
+
+  ALL_RESOLVABLE=true
+  while IFS= read -r f; do
+    if [[ "$f" == *README* ]]; then
+      echo "    Resolving $f — keeping branch (ours) version..."
+      git checkout --theirs "$f"
+      git add "$f"
+    else
+      echo "    Cannot auto-resolve: $f" >&2
+      ALL_RESOLVABLE=false
+    fi
+  done <<< "$CONFLICTS"
+
+  if ! $ALL_RESOLVABLE; then
+    echo "Error: non-README conflicts remain. Resolve manually and re-run." >&2
+    git rebase --abort
+    exit 1
+  fi
+
+  git rebase --continue --no-edit
+fi
+
+echo "==> Pushing rebased branch..."
+git push --force-with-lease origin "$BRANCH"
+
+# ── Step 6: merge PR (squash) and delete branch ───────────────────────────────
+echo "==> Merging PR #${PR_NUMBER} (squash)..."
+gh pr merge "$PR_NUMBER" --squash --delete-branch
+
+echo ""
+echo "Done. PR #${PR_NUMBER} merged and branch $BRANCH deleted."

--- a/claude/scripts/merge-stale-pr.sh
+++ b/claude/scripts/merge-stale-pr.sh
@@ -15,6 +15,7 @@
 # or set JOURNAL_REPO env var.
 
 set -euo pipefail
+shopt -s globstar
 
 PR_NUMBER="${1:-}"
 if [[ -z "$PR_NUMBER" ]]; then
@@ -86,8 +87,10 @@ if ! git rebase origin/main; then
 
   ALL_RESOLVABLE=true
   while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
     if [[ "$f" == *README* ]]; then
-      echo "    Resolving $f — keeping branch (ours) version..."
+      # During rebase, --theirs = commits being replayed from our branch (--ours = upstream).
+      echo "    Resolving $f — keeping our branch's version..."
       git checkout --theirs "$f"
       git add "$f"
     else
@@ -102,7 +105,8 @@ if ! git rebase origin/main; then
     exit 1
   fi
 
-  git rebase --continue --no-edit
+  # GIT_EDITOR=true skips the commit-message editor; --no-edit is invalid for rebase --continue.
+  GIT_EDITOR=true git rebase --continue
 fi
 
 echo "==> Pushing rebased branch..."

--- a/claude/scripts/turn-count-hook.py
+++ b/claude/scripts/turn-count-hook.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: count turns in the current session and warn at threshold.
+
+Warns at DEFAULT_THRESHOLD turns (default: 50), then every REPEAT_INTERVAL turns
+after that. The threshold can be overridden per-project by adding
+"turn_threshold": N to .claude/hook-config.json in the project root.
+
+Session turn counts are stored in ~/.claude/scratch/turn-count-<session_id>.txt.
+These files accumulate over time — clean them up periodically or ignore them.
+
+Exit 0 always — never block the user's prompt.
+Stdout is injected as context Claude sees before processing the user's message.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+SCRATCH = Path.home() / ".claude" / "scratch"
+DEFAULT_THRESHOLD = 50
+REPEAT_INTERVAL = 25
+CONFIG_FILE = ".claude/hook-config.json"
+
+
+def load_threshold(cwd: str) -> int:
+    """Return turn threshold from project hook-config.json, or the default."""
+    path = os.path.join(cwd, CONFIG_FILE)
+    try:
+        with open(path, encoding="utf-8") as f:
+            config = json.load(f)
+        return int(config.get("turn_threshold", DEFAULT_THRESHOLD))
+    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+        return DEFAULT_THRESHOLD
+
+
+def main() -> None:
+    raw = sys.stdin.read().strip()
+    data: dict = {}
+    if raw:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+
+    session_id = data.get("session_id", "unknown")
+    cwd = data.get("cwd", os.getcwd())
+
+    threshold = load_threshold(cwd)
+
+    # Read and increment counter
+    counter_file = SCRATCH / f"turn-count-{session_id}.txt"
+    try:
+        count = int(counter_file.read_text().strip()) + 1
+    except (FileNotFoundError, ValueError):
+        count = 1
+
+    try:
+        counter_file.write_text(str(count))
+    except Exception:
+        pass  # scratch dir missing or unwritable — degrade silently
+
+    # Warn at threshold and every REPEAT_INTERVAL turns after
+    if count >= threshold and (count - threshold) % REPEAT_INTERVAL == 0:
+        print(
+            f"[turn-count-hook] Session is at turn {count} "
+            f"(threshold: {threshold}). "
+            f"If the task scope has shifted, consider running /clear or /compact "
+            f"to reduce accumulated context cost."
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/scripts/turn-count-hook.py
+++ b/claude/scripts/turn-count-hook.py
@@ -16,12 +16,14 @@ Stdout is injected as context Claude sees before processing the user's message.
 import json
 import os
 import sys
+import time
 from pathlib import Path
 
 SCRATCH = Path.home() / ".claude" / "scratch"
 DEFAULT_THRESHOLD = 50
 REPEAT_INTERVAL = 25
 CONFIG_FILE = ".claude/hook-config.json"
+COUNTER_MAX_AGE_DAYS = 30
 
 
 def load_threshold(cwd: str) -> int:
@@ -35,7 +37,20 @@ def load_threshold(cwd: str) -> int:
         return DEFAULT_THRESHOLD
 
 
+def cleanup_stale_counters() -> None:
+    """Delete counter files older than COUNTER_MAX_AGE_DAYS."""
+    cutoff = time.time() - COUNTER_MAX_AGE_DAYS * 86400
+    try:
+        for f in SCRATCH.glob("turn-count-*.txt"):
+            if f.stat().st_mtime < cutoff:
+                f.unlink(missing_ok=True)
+    except Exception:
+        pass  # degrade silently — cleanup is best-effort
+
+
 def main() -> None:
+    cleanup_stale_counters()
+
     raw = sys.stdin.read().strip()
     data: dict = {}
     if raw:

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -17,6 +17,10 @@
           {
             "type": "command",
             "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/new-day-journal-check.py'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/turn-count-hook.py'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Closes #40. Addresses three recurring failure modes identified from 2026-04-20 token analysis ($38.05 across 7 sessions):

- **Finding 1 — Directory scope guard:** New `Context & Token Efficiency` section in `CLAUDE.md` with a rule to read `INDEX.md` or a manifest first when a directory has >3 files, load files on demand, and flag before reading >5 files in a single pass.
- **Finding 2 — Session length warning:** New `turn-count-hook.py` (`UserPromptSubmit` hook) warns at turn 50 (configurable via `turn_threshold` in `.claude/hook-config.json`), then every 25 turns after. Wired into `settings.json`.
- **Finding 3 — Mechanical git operations:** New `merge-stale-pr.sh` automates the stale draft PR remediation sequence for `engineering-journal` (check journal composed → delete orphaned `_draft.md` → rebase → auto-resolve README conflicts → squash merge + delete branch). CLAUDE.md documents when to use it.

## Test plan

- [ ] Turn-count hook: open a session and submit 50 prompts; confirm warning appears in context
- [ ] Turn-count hook: add `"turn_threshold": 10` to a project's `.claude/hook-config.json`; confirm override works
- [ ] `merge-stale-pr.sh`: dry-run against a test PR on engineering-journal to verify step output
- [ ] CLAUDE.md: confirm symlink at `~/.claude/CLAUDE.md` reflects the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)