### PR TITLE
fix: harden journal-compose multi-project mode

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -137,11 +137,12 @@ Use that path wherever `sessions/<project>/` appears below.
   > "Journal composition must run in its own session. Open a new Claude Code session and invoke `/journal-compose` there."
   Then stop — do not compose.
 
-- **Never compose proactively.** If an incomplete journal draft branch (`draft/YYYY-MM-DD`) is
-  detected at session start, emit a single line:
+- **Never compose proactively.** If a `draft/YYYY-MM-DD` branch is encountered during any
+  work (e.g., while running `git branch`, checking git status, or reading branch output),
+  emit a single line at the next natural pause:
   > "Incomplete journal detected — run `/journal-compose` in a dedicated session."
-  Then proceed with the user's actual request. Do not read stubs, do not compose, do not ask
-  whether to compose.
+  Then continue with the user's actual request. Do not read stubs, do not compose, do not
+  ask whether to compose.
 
 ---
 

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -118,10 +118,9 @@ Step 1 — Acquire compose lock for this project using this project-scoped path:
 
 Step 2 — Read stubs following SKILL.md Step 2 extraction format.
 
-Step 2b — Meta trigger check. Scan each session block against the trigger table in
-  SKILL.md Step 2b. If triggers match, record them for the final report.
-  Do NOT present options, ask questions, or create any meta draft files — the Phase 2
-  coordinator handles user interaction. Proceed immediately to Step 3.
+Step 2b — Meta trigger check. Do NOT prompt the user, ask questions, or create any meta
+  draft files. Instead, scan each session block against the trigger table in SKILL.md Step 2b
+  and record any matches for the final report. Proceed immediately to Step 3.
 
 Step 3 — Determine the slug. If unclear, synthesize from the session H2 headings; do not
   ask the user. Report your chosen slug.

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -14,12 +14,12 @@ Supporting files:
 
 ## Step 0 — Session isolation check
 
-Before doing anything else, verify this session has not processed prior task work.
-If the conversation contains any prior assistant response other than this skill's invocation,
-treat that as evidence of prior task work.
+Before doing anything else, check the conversation history *prior to the message that
+triggered this skill invocation*. Tool calls made during this skill's own execution do not
+count. Only pre-invocation user turns and assistant responses are evidence of prior task work.
 
-If any tool calls or user turns exist in this session *before* the `/journal-compose`
-invocation (i.e., other tasks were handled first), stop immediately and respond:
+If any user turns or assistant responses exist in the conversation before the
+`/journal-compose` invocation (i.e., other tasks were handled first), stop immediately and respond:
 
 > "Journal composition must run in a dedicated session with no prior task work.
 > Open a fresh Claude Code session and invoke `/journal-compose` there."
@@ -112,19 +112,24 @@ You are composing the engineering journal for one project. Follow these steps ex
 **Project path:** sessions/<project>/
 **Stub files (in order):** <stub1>, <stub2>, ...
 
-Step 1 — Acquire compose lock for this project only, exactly as described in
-  ~/.claude/skills/journal-compose/SKILL.md Step 1 ("Acquire the compose lock" subsection).
+Step 1 — Acquire compose lock for this project using this project-scoped path:
+  C:/Users/brown/Git/engineering-journal/sessions/<project>/.draft-compose.lock
+  Follow the lock check/create procedure in SKILL.md Step 1 ("Acquire the compose lock").
 
-Step 2 — Read stubs. Read ~/.claude/skills/journal-compose/SKILL.md Steps 2 and 2b
-  for the extraction format. In Step 2b, do NOT prompt the user — instead record any
-  meta trigger findings in your final report (see below).
+Step 2 — Read stubs following SKILL.md Step 2 extraction format.
+
+Step 2b — Meta trigger check. Scan each session block against the trigger table in
+  SKILL.md Step 2b. If triggers match, record them for the final report.
+  Do NOT present options, ask questions, or create any meta draft files — the Phase 2
+  coordinator handles user interaction. Proceed immediately to Step 3.
 
 Step 3 — Determine the slug. If unclear, synthesize from the session H2 headings; do not
   ask the user. Report your chosen slug.
 
-Step 4 — Fetch real token data. Run:
+Step 4 — Fetch real token data. Sanitize the project name first (slashes → underscores):
+  PROJECT_SAFE=$(echo "<project>" | tr '/' '_')
   python3 ~/.claude/scripts/token-report.py --date YYYY-MM-DD --format json > \
-    "C:/Users/brown/.claude/scratch/tmp_tokens_<project>_$$.json"
+    "C:/Users/brown/.claude/scratch/tmp_tokens_${PROJECT_SAFE}_$$.json"
   then parse as shown in SKILL.md Step 4.
 
 Step 5 — Compose the 11-section document. Follow SKILL.md Step 5 exactly.
@@ -147,6 +152,11 @@ When done, report exactly this structure:
 
 After all subagents complete, collect `OUTPUT_FILE`, `SLUG`, and `META_TRIGGERS` from each.
 
+**Error check first:** If any subagent did not return `STATUS=done`, stop immediately and
+report which project(s) failed before touching any README or running git commands. Do not
+proceed with a partial set — a missing output file will cause the commit to fail silently.
+
+If all subagents returned `STATUS=done`, check meta triggers.
 If any subagent reported `META_TRIGGERS` (non-none), present them to the user now:
 ```
 Meta triggers found in <project> session(s): <list>


### PR DESCRIPTION
## Summary

- **Step 0:** Clarify that only pre-invocation conversation turns count for the isolation check; tool calls made during the skill's own execution are excluded
- **Subagent Step 2b:** Replace ambiguous parenthetical with an explicit positive instruction — scan triggers, record findings, do not prompt the user or create meta draft files
- **Subagent Step 1:** Make the compose lock path explicitly project-scoped in the prompt
- **Subagent Step 4:** Sanitize the project path (slashes → underscores) before using it as a temp filename
- **Phase 2 coordinator:** Add error gate — stop before any README or git work if any subagent returned `STATUS != done`
- **CLAUDE.md:** Reframe "detected at session start" as "encountered during work" to match how Claude actually observes branch names

## Test plan

- [ ] Confirm subagent prompt Step 2b no longer triggers interactive flow when meta triggers are found
- [ ] Confirm temp file names are safe when project path contains a slash (e.g. `sessions/lifting-logbook`)
- [ ] Confirm Phase 2 halts cleanly if a simulated subagent failure is injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)