### PR TITLE
[config] Set default model to claude-sonnet-4-6

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "claude-sonnet-4-6",
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary
- Adds `"model": "claude-sonnet-4-6"` to `~/.claude/settings.json`
- Prevents sessions from defaulting to Opus when no model is explicitly set

> **Note:** Claude Code requires an exact model ID — no `latest` alias is supported.
> Update this value when a new Sonnet version ships (e.g., `claude-sonnet-4-7`).

## Test plan
- [ ] Open a new Claude Code session and confirm the model indicator shows Sonnet