### PR TITLE
[fix] journal-compose multi-project mode fixes

### DIFF
--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -119,8 +119,9 @@ Step 1 — Acquire compose lock for this project using this project-scoped path:
 Step 2 — Read stubs following SKILL.md Step 2 extraction format.
 
 Step 2b — Meta trigger check. Do NOT prompt the user, ask questions, or create any meta
-  draft files. Instead, scan each session block against the trigger table in SKILL.md Step 2b
-  and record any matches for the final report. Proceed immediately to Step 3.
+  draft files — the Phase 2 coordinator handles user interaction. Instead, scan each session
+  block against the trigger table in SKILL.md Step 2b and record any matches for the final
+  report. Proceed immediately to Step 3.
 
 Step 3 — Determine the slug. If unclear, synthesize from the session H2 headings; do not
   ask the user. Report your chosen slug.


### PR DESCRIPTION
## Summary
- Clarifies Step 0 isolation check: only pre-invocation turns count, not the skill's own tool calls
- Subagent Step 2b: replaces ambiguous instruction with explicit directive — do NOT prompt or ask questions; the Phase 2 coordinator handles user interaction
- Front-loads the "Do NOT" constraint so it is seen before the positive directive
- Makes lock path project-scoped in subagent Step 1 to prevent cross-project collisions
- Sanitizes project path (slashes → underscores) before using as temp filename in subagent Step 4
- Adds error gate in Phase 2 coordinator: stops before git/README work if any subagent returned `STATUS != done`
- Reframes CLAUDE.md "detected at session start" as "encountered during work" to match actual observation behavior

## Test plan
- [ ] Run `/journal-compose` in a session with prior turns — confirm isolation check does not false-positive on skill's own tool calls
- [ ] Confirm subagent does not prompt user when update triggers are detected mid-composition