### PR TITLE
Add Windows bootstrap session prompt and harden setup.sh for fresh installs

### DIFF
--- a/claude/setup-prompt.md
+++ b/claude/setup-prompt.md
@@ -1,89 +1,46 @@
 # Windows Dev-Env Bootstrap
 
 Paste everything below the line as your opening message in a fresh Claude Code
-session on the new Windows machine. Claude will walk through each step and
-report results before moving on.
+session on the new Windows machine. Claude will clone the repo and run the
+setup script.
 
 ---
 
 Your task is to bootstrap this Windows machine with the `brownm09/dev-env`
 Claude Code configuration. Work through the steps below in order; report the
-output of each step before moving to the next. Stop and surface any error
-rather than continuing past it.
+result of each before moving on.
 
-## 1. Check prerequisites
-
-Run each command in Git Bash and report the output:
+## 1. Verify Git Bash is available
 
 ```bash
-git --version
-python3 --version
-node --version
-bash --version
+git --version && bash --version
 ```
 
-If `python3` is not found: tell me to install Python 3 from https://python.org/downloads (tick "Add python.exe to PATH") and re-run `python3 --version` after.
+If `git` is not found, stop and tell me to install Git for Windows from
+https://git-scm.com/download/win, then open a new Git Bash window.
 
-If `git` / `bash` are not found: tell me to install Git for Windows from https://git-scm.com/download/win and open a new Git Bash window.
-
-Do not proceed past step 1 until `git`, `python3`, and `bash` are all present.
-
-## 2. Check Developer Mode
-
-Symlinks (`mklink`) require either Developer Mode or an elevated shell.
-Check whether Developer Mode is on:
-
-```bash
-reg.exe query "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock" /v AllowDevelopmentWithoutDevLicense 2>/dev/null || echo "key not found"
-```
-
-If the value is not `0x1`: warn me and remind me to enable Developer Mode in
-Windows Settings → System → For Developers, then re-run this check before
-continuing. Alternatively, confirm that Git Bash is running as Administrator.
-
-## 3. Clone the repo
+## 2. Clone and run setup
 
 ```bash
 mkdir -p "$HOME/Git"
 if [ -d "$HOME/Git/dev-env/.git" ]; then
-  echo "Repo already present — pulling latest"
   git -C "$HOME/Git/dev-env" pull
 else
   git clone https://github.com/brownm09/dev-env.git "$HOME/Git/dev-env"
 fi
-```
-
-## 4. Run setup.sh
-
-```bash
 bash "$HOME/Git/dev-env/setup.sh"
 ```
 
-Read all output carefully. Stop and report any WARNING lines before continuing.
+`setup.sh` will:
+- Self-elevate via UAC if Administrator privileges are needed
+- Warn about any missing soft prerequisites (python3, bash on PATH)
+- Create all `~/.claude/` symlinks and junctions
+- Set `core.hooksPath` globally
+- Create `~/.claude/scratch/`
 
-## 5. Configure global git hooks path
+Read all output. Stop and surface any WARNING or error before continuing.
 
-Check for conflicts, then set:
-
-```bash
-SYSTEM_HOOKS="$(git config --system core.hooksPath 2>/dev/null || true)"
-GLOBAL_HOOKS="$(git config --global core.hooksPath 2>/dev/null || true)"
-
-echo "system hooks: ${SYSTEM_HOOKS:-<not set>}"
-echo "global hooks: ${GLOBAL_HOOKS:-<not set>}"
-```
-
-If `system hooks` is set to something other than `~/.claude/hooks`: stop and
-tell me — an enterprise policy may own it and overriding it could break things.
-
-Otherwise, set the global hooks path:
-
-```bash
-git config --global core.hooksPath "$HOME/.claude/hooks"
-git config --global core.hooksPath  # confirm
-```
-
-## 6. Verify
+## 3. Verify
 
 ```bash
 ls -la "$HOME/.claude/CLAUDE.md"
@@ -93,7 +50,9 @@ ls -la "$HOME/.claude/skills/"
 ls -la "$HOME/.claude/hooks/"
 ls -la "$HOME/.claude/scratch/"
 ls -la "$HOME/bin/"
+git config --global core.hooksPath
 ```
 
-Report any missing file or broken link. Setup is complete when all seven paths
-resolve without error.
+Report any missing file, broken link, or unexpected hooks path. Setup is
+complete when all seven paths resolve and `core.hooksPath` points to
+`~/.claude/hooks`.

--- a/claude/setup-prompt.md
+++ b/claude/setup-prompt.md
@@ -1,0 +1,99 @@
+# Windows Dev-Env Bootstrap
+
+Paste everything below the line as your opening message in a fresh Claude Code
+session on the new Windows machine. Claude will walk through each step and
+report results before moving on.
+
+---
+
+Your task is to bootstrap this Windows machine with the `brownm09/dev-env`
+Claude Code configuration. Work through the steps below in order; report the
+output of each step before moving to the next. Stop and surface any error
+rather than continuing past it.
+
+## 1. Check prerequisites
+
+Run each command in Git Bash and report the output:
+
+```bash
+git --version
+python3 --version
+node --version
+bash --version
+```
+
+If `python3` is not found: tell me to install Python 3 from https://python.org/downloads (tick "Add python.exe to PATH") and re-run `python3 --version` after.
+
+If `git` / `bash` are not found: tell me to install Git for Windows from https://git-scm.com/download/win and open a new Git Bash window.
+
+Do not proceed past step 1 until `git`, `python3`, and `bash` are all present.
+
+## 2. Check Developer Mode
+
+Symlinks (`mklink`) require either Developer Mode or an elevated shell.
+Check whether Developer Mode is on:
+
+```bash
+reg.exe query "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock" /v AllowDevelopmentWithoutDevLicense 2>/dev/null || echo "key not found"
+```
+
+If the value is not `0x1`: warn me and remind me to enable Developer Mode in
+Windows Settings → System → For Developers, then re-run this check before
+continuing. Alternatively, confirm that Git Bash is running as Administrator.
+
+## 3. Clone the repo
+
+```bash
+mkdir -p "$HOME/Git"
+if [ -d "$HOME/Git/dev-env/.git" ]; then
+  echo "Repo already present — pulling latest"
+  git -C "$HOME/Git/dev-env" pull
+else
+  git clone https://github.com/brownm09/dev-env.git "$HOME/Git/dev-env"
+fi
+```
+
+## 4. Run setup.sh
+
+```bash
+bash "$HOME/Git/dev-env/setup.sh"
+```
+
+Read all output carefully. Stop and report any WARNING lines before continuing.
+
+## 5. Configure global git hooks path
+
+Check for conflicts, then set:
+
+```bash
+SYSTEM_HOOKS="$(git config --system core.hooksPath 2>/dev/null || true)"
+GLOBAL_HOOKS="$(git config --global core.hooksPath 2>/dev/null || true)"
+
+echo "system hooks: ${SYSTEM_HOOKS:-<not set>}"
+echo "global hooks: ${GLOBAL_HOOKS:-<not set>}"
+```
+
+If `system hooks` is set to something other than `~/.claude/hooks`: stop and
+tell me — an enterprise policy may own it and overriding it could break things.
+
+Otherwise, set the global hooks path:
+
+```bash
+git config --global core.hooksPath "$HOME/.claude/hooks"
+git config --global core.hooksPath  # confirm
+```
+
+## 6. Verify
+
+```bash
+ls -la "$HOME/.claude/CLAUDE.md"
+ls -la "$HOME/.claude/settings.json"
+ls -la "$HOME/.claude/scripts/"
+ls -la "$HOME/.claude/skills/"
+ls -la "$HOME/.claude/hooks/"
+ls -la "$HOME/.claude/scratch/"
+ls -la "$HOME/bin/"
+```
+
+Report any missing file or broken link. Setup is complete when all seven paths
+resolve without error.

--- a/setup.sh
+++ b/setup.sh
@@ -1,154 +1,178 @@
 #!/usr/bin/env bash
-# dev-env setup — run once on each new machine after cloning this repo.
-# Creates symlinks from well-known config locations into this repo.
+# dev-env setup — run once per machine after cloning this repo.
 #
-# Requirements (Windows):
-#   - Git for Windows (Git Bash)
-#   - Developer Mode enabled in Windows Settings → System → For Developers
-#     (allows mklink without elevation; alternative: run as Administrator)
+# Usage (Windows, Git Bash):  bash setup.sh
+# Usage (Linux/macOS):        bash setup.sh
+#
+# Windows: self-elevates via UAC if neither Administrator nor Developer Mode
+# is detected. No manual elevation step required.
 
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "Setting up dev-env from $REPO_DIR"
-echo ""
-
 # ---------------------------------------------------------------------------
-# Prerequisite: bash.exe on Windows PATH
-# Claude Code hook commands use "bash -c '...'" so that python3 (a Windows App
-# Execution Alias symlink) resolves correctly regardless of which process spawns
-# the hook. Verify that bash.exe is on the Windows PATH so non-interactive
-# processes (like the Claude Code Desktop hook runner) can find it.
+# Windows setup
 # ---------------------------------------------------------------------------
-BASH_PATH="$(cmd.exe /c "where bash 2>NUL" 2>/dev/null | tr -d '\r' | head -1)"
-if [ -z "$BASH_PATH" ]; then
-  echo "WARNING: bash.exe is not on the Windows PATH."
-  echo "  Claude Code hooks use 'bash -c ...' to invoke Python scripts."
-  echo "  Add Git Bash to your Windows PATH, e.g.:"
-  echo "    C:\\Program Files\\Git\\usr\\bin"
-  echo "  Then re-run this script."
+setup_windows() {
+  echo "dev-env setup (Windows) from $REPO_DIR"
   echo ""
-else
-  echo "  bash found at: $BASH_PATH"
-fi
 
-# ---------------------------------------------------------------------------
-# Prerequisite: python3
-# Required by every hook script in claude/scripts/.
-# ---------------------------------------------------------------------------
-if ! python3 --version &>/dev/null; then
-  echo ""
-  echo "WARNING: python3 not found."
-  echo "  Install Python 3 from https://python.org/downloads/ and ensure it is"
-  echo "  on your PATH. Then re-run this script."
-  echo ""
-else
-  echo "  python3 found: $(python3 --version 2>&1)"
-fi
+  # -- Elevation / Developer Mode check ------------------------------------
+  # mklink (file symlink) and mklink /D (dir symlink) require either
+  # Administrator or Developer Mode. mklink /J (junction) works without both.
+  # Self-elevate via UAC so the user never has to think about it.
 
-# ---------------------------------------------------------------------------
-# Prerequisite: Developer Mode or Administrator
-# mklink without /J requires Developer Mode or elevation.
-# ---------------------------------------------------------------------------
-DEV_MODE_KEY="HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"
-DEV_MODE_VAL="$(reg.exe query "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock" /v AllowDevelopmentWithoutDevLicense 2>/dev/null | grep -oP '0x\w+' || true)"
-if [ "$DEV_MODE_VAL" != "0x1" ]; then
-  IS_ADMIN="$(net.exe session 2>/dev/null && echo yes || echo no)"
-  if [ "$IS_ADMIN" != "yes" ]; then
-    echo ""
-    echo "WARNING: Developer Mode is not enabled and this session is not elevated."
-    echo "  Symlinks (mklink) require one of:"
-    echo "    - Windows Settings → System → For Developers → Developer Mode ON"
-    echo "    - Running Git Bash as Administrator"
-    echo "  Directory junctions (mklink /J, /D) are not affected."
-    echo "  CLAUDE.md and settings.json links may fail. Enable Developer Mode and re-run."
+  is_admin()    { net.exe session &>/dev/null 2>&1; }
+  has_dev_mode() {
+    local val
+    val="$(reg.exe query \
+      "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock" \
+      /v AllowDevelopmentWithoutDevLicense 2>/dev/null \
+      | tr -d '\r' | grep -oP '0x\w+' || echo "0x0")"
+    [[ "$val" == "0x1" ]]
+  }
+
+  if ! is_admin && ! has_dev_mode; then
+    SCRIPT_WIN="$(cygpath -w "${BASH_SOURCE[0]}")"
+    echo "Requires elevation (Administrator or Developer Mode)."
+    echo "Triggering UAC prompt — setup will complete in a new window..."
+    # -Wait keeps this process alive until the elevated one finishes.
+    powershell.exe -NoProfile -Command \
+      "Start-Process 'bash' -ArgumentList '\"$SCRIPT_WIN\"' -Verb RunAs -Wait"
+    exit 0
+  fi
+
+  # -- Soft prerequisites --------------------------------------------------
+  # These don't block setup but will cause hooks to fail at runtime.
+
+  if ! cmd.exe /c "where bash >NUL 2>&1"; then
+    echo "WARNING: bash.exe not on Windows PATH."
+    echo "  Add Git Bash: C:\\Program Files\\Git\\usr\\bin"
+    echo "  Claude Code hooks use 'bash -c ...' and won't fire until this is fixed."
     echo ""
   fi
-fi
 
-echo ""
-echo "Creating ~/.claude layout..."
+  if ! python3 --version &>/dev/null; then
+    echo "WARNING: python3 not found."
+    echo "  Install from https://python.org/downloads/ (tick 'Add python.exe to PATH')."
+    echo "  Hook scripts in claude/scripts/ won't run until this is fixed."
+    echo ""
+  fi
 
-# Claude Code global config dir
-mkdir -p "$HOME/.claude"
+  # -- ~/.claude layout ----------------------------------------------------
+  mkdir -p "$HOME/.claude"
+  echo "Creating ~/.claude layout..."
 
-# ---------------------------------------------------------------------------
-# CLAUDE.md (file symlink)
-# ---------------------------------------------------------------------------
-WIN_TARGET="$(cygpath -w "$REPO_DIR/claude/CLAUDE.md")"
-WIN_LINK="$(cygpath -w "$HOME/.claude/CLAUDE.md")"
+  win_link "$REPO_DIR/claude/CLAUDE.md"    "$HOME/.claude/CLAUDE.md"    file
+  echo "  Linked CLAUDE.md"
 
-rm -f "$HOME/.claude/CLAUDE.md"
-cmd.exe /c "mklink \"$WIN_LINK\" \"$WIN_TARGET\""
-echo "  Linked claude/CLAUDE.md -> ~/.claude/CLAUDE.md"
+  win_link "$REPO_DIR/claude/settings.json" "$HOME/.claude/settings.json" file
+  echo "  Linked settings.json"
 
-# ---------------------------------------------------------------------------
-# settings.json (file symlink)
-# ---------------------------------------------------------------------------
-WIN_SETTINGS_TARGET="$(cygpath -w "$REPO_DIR/claude/settings.json")"
-WIN_SETTINGS_LINK="$(cygpath -w "$HOME/.claude/settings.json")"
+  for subdir in scripts skills hooks; do
+    win_link "$REPO_DIR/claude/$subdir" "$HOME/.claude/$subdir" dir
+    echo "  Linked $subdir/"
+  done
 
-rm -f "$HOME/.claude/settings.json"
-cmd.exe /c "mklink \"$WIN_SETTINGS_LINK\" \"$WIN_SETTINGS_TARGET\""
-echo "  Linked claude/settings.json -> ~/.claude/settings.json"
+  mkdir -p "$HOME/.claude/scratch"
+  echo "  Created scratch/"
 
-# ---------------------------------------------------------------------------
-# scripts/ (directory junction)
-# ---------------------------------------------------------------------------
-WIN_SCRIPTS_TARGET="$(cygpath -w "$REPO_DIR/claude/scripts")"
-WIN_SCRIPTS_LINK="$(cygpath -w "$HOME/.claude/scripts")"
+  win_link "$REPO_DIR/bin" "$HOME/bin" junction
+  echo "  Linked ~/bin/"
 
-if [ -L "$HOME/.claude/scripts" ] || [ -d "$HOME/.claude/scripts" ]; then
-  cmd.exe /c "rmdir \"$WIN_SCRIPTS_LINK\"" 2>/dev/null || rm -rf "$HOME/.claude/scripts"
-fi
-cmd.exe /c "mklink /D \"$WIN_SCRIPTS_LINK\" \"$WIN_SCRIPTS_TARGET\""
-echo "  Linked claude/scripts/ -> ~/.claude/scripts/"
+  set_hooks_path
 
-# ---------------------------------------------------------------------------
-# skills/ (directory junction)
-# ---------------------------------------------------------------------------
-WIN_SKILLS_TARGET="$(cygpath -w "$REPO_DIR/claude/skills")"
-WIN_SKILLS_LINK="$(cygpath -w "$HOME/.claude/skills")"
+  echo ""
+  echo "Done. Open a new Git Bash window so ~/bin is on PATH."
+}
 
-if [ -L "$HOME/.claude/skills" ] || [ -d "$HOME/.claude/skills" ]; then
-  cmd.exe /c "rmdir \"$WIN_SKILLS_LINK\"" 2>/dev/null || rm -rf "$HOME/.claude/skills"
-fi
-cmd.exe /c "mklink /D \"$WIN_SKILLS_LINK\" \"$WIN_SKILLS_TARGET\""
-echo "  Linked claude/skills/ -> ~/.claude/skills/"
+# win_link <target> <link> <type: file|dir|junction>
+win_link() {
+  local src="$1" dst="$2" type="$3"
+  local src_win dst_win flag
 
-# ---------------------------------------------------------------------------
-# hooks/ (directory junction)
-# ---------------------------------------------------------------------------
-WIN_HOOKS_TARGET="$(cygpath -w "$REPO_DIR/claude/hooks")"
-WIN_HOOKS_LINK="$(cygpath -w "$HOME/.claude/hooks")"
+  src_win="$(cygpath -w "$src")"
+  dst_win="$(cygpath -w "$dst")"
 
-if [ -L "$HOME/.claude/hooks" ] || [ -d "$HOME/.claude/hooks" ]; then
-  cmd.exe /c "rmdir \"$WIN_HOOKS_LINK\"" 2>/dev/null || rm -rf "$HOME/.claude/hooks"
-fi
-cmd.exe /c "mklink /D \"$WIN_HOOKS_LINK\" \"$WIN_HOOKS_TARGET\""
-echo "  Linked claude/hooks/ -> ~/.claude/hooks/"
+  case "$type" in
+    file)     flag="" ;;
+    dir)      flag="/D" ;;
+    junction) flag="/J" ;;
+  esac
+
+  rm -f "$dst" 2>/dev/null || true
+  if [ -d "$dst" ]; then
+    cmd.exe /c "rmdir \"$dst_win\"" 2>/dev/null || rm -rf "$dst"
+  fi
+
+  cmd.exe /c "mklink $flag \"$dst_win\" \"$src_win\""
+}
 
 # ---------------------------------------------------------------------------
-# scratch/ (machine-local temp dir; not version-controlled)
+# Linux / macOS setup
 # ---------------------------------------------------------------------------
-mkdir -p "$HOME/.claude/scratch"
-echo "  Created ~/.claude/scratch/"
+setup_unix() {
+  echo "dev-env setup ($(uname -s)) from $REPO_DIR"
+  echo ""
+
+  # settings.json contains Windows-specific absolute paths in hook commands.
+  echo "NOTE: claude/settings.json has Windows paths in hook commands."
+  echo "  Hooks will not fire correctly until those paths are updated for this OS."
+  echo ""
+
+  mkdir -p "$HOME/.claude"
+  echo "Creating ~/.claude layout..."
+
+  for item in CLAUDE.md settings.json; do
+    ln -sf "$REPO_DIR/claude/$item" "$HOME/.claude/$item"
+    echo "  Linked $item"
+  done
+
+  for subdir in scripts skills hooks; do
+    ln -sf "$REPO_DIR/claude/$subdir" "$HOME/.claude/$subdir"
+    echo "  Linked $subdir/"
+  done
+
+  mkdir -p "$HOME/.claude/scratch"
+  echo "  Created scratch/"
+
+  ln -sf "$REPO_DIR/bin" "$HOME/bin"
+  echo "  Linked ~/bin/"
+
+  set_hooks_path
+
+  echo ""
+  echo "Done. Reload your shell so ~/bin is on PATH (or open a new terminal)."
+}
 
 # ---------------------------------------------------------------------------
-# ~/bin (directory junction to dev-env/bin/)
+# Shared: configure global git hooks path
 # ---------------------------------------------------------------------------
-WIN_BIN_TARGET="$(cygpath -w "$REPO_DIR/bin")"
-WIN_BIN_LINK="$(cygpath -w "$HOME/bin")"
+set_hooks_path() {
+  local system_hooks
+  system_hooks="$(git config --system core.hooksPath 2>/dev/null || true)"
 
-if [ -L "$HOME/bin" ] || [ -d "$HOME/bin" ]; then
-  cmd.exe /c "rmdir \"$WIN_BIN_LINK\"" 2>/dev/null || rm -rf "$HOME/bin"
-fi
-cmd.exe /c "mklink /J \"$WIN_BIN_LINK\" \"$WIN_BIN_TARGET\""
-echo "  Linked bin/ -> ~/bin/"
+  if [ -n "$system_hooks" ] && [ "$system_hooks" != "$HOME/.claude/hooks" ]; then
+    echo ""
+    echo "WARNING: system-level core.hooksPath already set to: $system_hooks"
+    echo "  This may be enterprise-managed — skipping global hooks config."
+    echo "  Set manually if safe: git config --global core.hooksPath ~/.claude/hooks"
+    return
+  fi
 
-echo ""
-echo "Done. Next steps if not already complete:"
-echo "  1. Set global git hooks path:"
-echo "       git config --global core.hooksPath ~/.claude/hooks"
-echo "  2. Reload your shell (or open a new Git Bash window) so ~/bin is on PATH."
+  git config --global core.hooksPath "$HOME/.claude/hooks"
+  echo "  Set core.hooksPath -> ~/.claude/hooks"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+OS="$(uname -s)"
+case "$OS" in
+  MINGW*|CYGWIN*|MSYS*) setup_windows ;;
+  Linux|Darwin)          setup_unix ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    exit 1 ;;
+esac

--- a/setup.sh
+++ b/setup.sh
@@ -2,21 +2,27 @@
 # dev-env setup — run once on each new machine after cloning this repo.
 # Creates symlinks from well-known config locations into this repo.
 #
-# Requires: Git Bash on Windows with Developer Mode enabled (for mklink without elevation).
+# Requirements (Windows):
+#   - Git for Windows (Git Bash)
+#   - Developer Mode enabled in Windows Settings → System → For Developers
+#     (allows mklink without elevation; alternative: run as Administrator)
 
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Setting up dev-env from $REPO_DIR"
+echo ""
 
+# ---------------------------------------------------------------------------
+# Prerequisite: bash.exe on Windows PATH
 # Claude Code hook commands use "bash -c '...'" so that python3 (a Windows App
 # Execution Alias symlink) resolves correctly regardless of which process spawns
 # the hook. Verify that bash.exe is on the Windows PATH so non-interactive
 # processes (like the Claude Code Desktop hook runner) can find it.
+# ---------------------------------------------------------------------------
 BASH_PATH="$(cmd.exe /c "where bash 2>NUL" 2>/dev/null | tr -d '\r' | head -1)"
 if [ -z "$BASH_PATH" ]; then
-  echo ""
   echo "WARNING: bash.exe is not on the Windows PATH."
   echo "  Claude Code hooks use 'bash -c ...' to invoke Python scripts."
   echo "  Add Git Bash to your Windows PATH, e.g.:"
@@ -27,11 +33,49 @@ else
   echo "  bash found at: $BASH_PATH"
 fi
 
-# Claude Code global config
+# ---------------------------------------------------------------------------
+# Prerequisite: python3
+# Required by every hook script in claude/scripts/.
+# ---------------------------------------------------------------------------
+if ! python3 --version &>/dev/null; then
+  echo ""
+  echo "WARNING: python3 not found."
+  echo "  Install Python 3 from https://python.org/downloads/ and ensure it is"
+  echo "  on your PATH. Then re-run this script."
+  echo ""
+else
+  echo "  python3 found: $(python3 --version 2>&1)"
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisite: Developer Mode or Administrator
+# mklink without /J requires Developer Mode or elevation.
+# ---------------------------------------------------------------------------
+DEV_MODE_KEY="HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"
+DEV_MODE_VAL="$(reg.exe query "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock" /v AllowDevelopmentWithoutDevLicense 2>/dev/null | grep -oP '0x\w+' || true)"
+if [ "$DEV_MODE_VAL" != "0x1" ]; then
+  IS_ADMIN="$(net.exe session 2>/dev/null && echo yes || echo no)"
+  if [ "$IS_ADMIN" != "yes" ]; then
+    echo ""
+    echo "WARNING: Developer Mode is not enabled and this session is not elevated."
+    echo "  Symlinks (mklink) require one of:"
+    echo "    - Windows Settings → System → For Developers → Developer Mode ON"
+    echo "    - Running Git Bash as Administrator"
+    echo "  Directory junctions (mklink /J, /D) are not affected."
+    echo "  CLAUDE.md and settings.json links may fail. Enable Developer Mode and re-run."
+    echo ""
+  fi
+fi
+
+echo ""
+echo "Creating ~/.claude layout..."
+
+# Claude Code global config dir
 mkdir -p "$HOME/.claude"
 
-# Git Bash ln -sf creates a copy, not a native Windows symlink, unless
-# MSYS=winsymlinks:nativestrict is set. Use cmd.exe mklink instead.
+# ---------------------------------------------------------------------------
+# CLAUDE.md (file symlink)
+# ---------------------------------------------------------------------------
 WIN_TARGET="$(cygpath -w "$REPO_DIR/claude/CLAUDE.md")"
 WIN_LINK="$(cygpath -w "$HOME/.claude/CLAUDE.md")"
 
@@ -39,18 +83,31 @@ rm -f "$HOME/.claude/CLAUDE.md"
 cmd.exe /c "mklink \"$WIN_LINK\" \"$WIN_TARGET\""
 echo "  Linked claude/CLAUDE.md -> ~/.claude/CLAUDE.md"
 
-# Claude Code scripts — symlink the whole directory
+# ---------------------------------------------------------------------------
+# settings.json (file symlink)
+# ---------------------------------------------------------------------------
+WIN_SETTINGS_TARGET="$(cygpath -w "$REPO_DIR/claude/settings.json")"
+WIN_SETTINGS_LINK="$(cygpath -w "$HOME/.claude/settings.json")"
+
+rm -f "$HOME/.claude/settings.json"
+cmd.exe /c "mklink \"$WIN_SETTINGS_LINK\" \"$WIN_SETTINGS_TARGET\""
+echo "  Linked claude/settings.json -> ~/.claude/settings.json"
+
+# ---------------------------------------------------------------------------
+# scripts/ (directory junction)
+# ---------------------------------------------------------------------------
 WIN_SCRIPTS_TARGET="$(cygpath -w "$REPO_DIR/claude/scripts")"
 WIN_SCRIPTS_LINK="$(cygpath -w "$HOME/.claude/scripts")"
 
-# Remove existing directory or symlink before creating new one
 if [ -L "$HOME/.claude/scripts" ] || [ -d "$HOME/.claude/scripts" ]; then
   cmd.exe /c "rmdir \"$WIN_SCRIPTS_LINK\"" 2>/dev/null || rm -rf "$HOME/.claude/scripts"
 fi
 cmd.exe /c "mklink /D \"$WIN_SCRIPTS_LINK\" \"$WIN_SCRIPTS_TARGET\""
 echo "  Linked claude/scripts/ -> ~/.claude/scripts/"
 
-# Claude Code skills — symlink the whole directory
+# ---------------------------------------------------------------------------
+# skills/ (directory junction)
+# ---------------------------------------------------------------------------
 WIN_SKILLS_TARGET="$(cygpath -w "$REPO_DIR/claude/skills")"
 WIN_SKILLS_LINK="$(cygpath -w "$HOME/.claude/skills")"
 
@@ -60,15 +117,27 @@ fi
 cmd.exe /c "mklink /D \"$WIN_SKILLS_LINK\" \"$WIN_SKILLS_TARGET\""
 echo "  Linked claude/skills/ -> ~/.claude/skills/"
 
-# Claude Code global settings
-WIN_SETTINGS_TARGET="$(cygpath -w "$REPO_DIR/claude/settings.json")"
-WIN_SETTINGS_LINK="$(cygpath -w "$HOME/.claude/settings.json")"
+# ---------------------------------------------------------------------------
+# hooks/ (directory junction)
+# ---------------------------------------------------------------------------
+WIN_HOOKS_TARGET="$(cygpath -w "$REPO_DIR/claude/hooks")"
+WIN_HOOKS_LINK="$(cygpath -w "$HOME/.claude/hooks")"
 
-rm -f "$HOME/.claude/settings.json"
-cmd.exe /c "mklink \"$WIN_SETTINGS_LINK\" \"$WIN_SETTINGS_TARGET\""
-echo "  Linked claude/settings.json -> ~/.claude/settings.json"
+if [ -L "$HOME/.claude/hooks" ] || [ -d "$HOME/.claude/hooks" ]; then
+  cmd.exe /c "rmdir \"$WIN_HOOKS_LINK\"" 2>/dev/null || rm -rf "$HOME/.claude/hooks"
+fi
+cmd.exe /c "mklink /D \"$WIN_HOOKS_LINK\" \"$WIN_HOOKS_TARGET\""
+echo "  Linked claude/hooks/ -> ~/.claude/hooks/"
 
-# ~/bin — personal CLI wrappers (junction to dev-env/bin/)
+# ---------------------------------------------------------------------------
+# scratch/ (machine-local temp dir; not version-controlled)
+# ---------------------------------------------------------------------------
+mkdir -p "$HOME/.claude/scratch"
+echo "  Created ~/.claude/scratch/"
+
+# ---------------------------------------------------------------------------
+# ~/bin (directory junction to dev-env/bin/)
+# ---------------------------------------------------------------------------
 WIN_BIN_TARGET="$(cygpath -w "$REPO_DIR/bin")"
 WIN_BIN_LINK="$(cygpath -w "$HOME/bin")"
 
@@ -78,4 +147,8 @@ fi
 cmd.exe /c "mklink /J \"$WIN_BIN_LINK\" \"$WIN_BIN_TARGET\""
 echo "  Linked bin/ -> ~/bin/"
 
-echo "Done."
+echo ""
+echo "Done. Next steps if not already complete:"
+echo "  1. Set global git hooks path:"
+echo "       git config --global core.hooksPath ~/.claude/hooks"
+echo "  2. Reload your shell (or open a new Git Bash window) so ~/bin is on PATH."


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`claude/setup-prompt.md`**: A paste-and-go prompt for bootstrapping Claude Code on a new Windows machine with no prior scaffolding. Guides Claude through prerequisite checks (Git Bash, Python 3, Developer Mode), cloning the repo, running `setup.sh`, wiring up the global git hooks path, and verifying all seven symlinks.
- **`setup.sh`**: Hardened for fresh installs — adds `python3` check, Developer Mode / elevation check, `hooks/` directory junction (was documented in `CLAUDE.md` but missing from the script), `scratch/` directory creation, and a next-steps reminder at the end.

## Test plan

- [ ] On a fresh Windows machine (or VM), navigate to `claude/setup-prompt.md` on GitHub, paste the prompt into a new Claude Code session, and confirm Claude walks through all six steps cleanly
- [ ] Verify all seven paths resolve after setup: `CLAUDE.md`, `settings.json`, `scripts/`, `skills/`, `hooks/`, `scratch/`, `~/bin/`
- [ ] Run `setup.sh` directly in Git Bash and confirm no regressions on an already-configured machine (idempotent re-run)
- [ ] Confirm `~/.claude/hooks/pre-push` is reachable after the `hooks/` junction is created

https://claude.ai/code/session_01EeBrNVaJ4qmufhUH6BAgCe
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeBrNVaJ4qmufhUH6BAgCe)_