### PR TITLE
fix: detect squash-merged journal branches correctly

### DIFF
--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -37,45 +37,44 @@ def stale_draft_artifacts() -> list[str]:
     return stale
 
 
-def unmerged_draft_branches() -> list[str]:
-    """Return remote draft/* branch names not yet merged into origin/main.
+def composed_dates_on_main() -> set[str]:
+    """Return YYYY-MM-DD dates that have a composed journal file on origin/main.
 
-    Fast path: check local remote-tracking refs (zero network cost).
-    Verification pass: for any branch that appears unmerged locally, confirm it
-    still exists on the remote via ls-remote. This prunes false positives caused
-    by stale tracking refs left behind after squash-merge + branch deletion,
-    while avoiding a network call when there is nothing to verify.
+    A composed file is any sessions/**/*.md that is NOT a stub (*.stub.md).
+    This is the squash-merge signal: squash merges don't leave branch commits in
+    main's ancestry, so git branch --merged is unreliable. Checking for the
+    composed file on main is the authoritative indicator.
     """
     try:
-        # Fast path — local tracking refs, no network
         result = subprocess.run(
-            ["git", "branch", "-r", "--list", "origin/draft/*"],
+            ["git", "ls-tree", "-r", "--name-only", "origin/main", "sessions/"],
             cwd=JOURNAL_REPO,
             capture_output=True,
             text=True,
             timeout=10,
         )
-        candidates = []
-        for b in result.stdout.splitlines():
-            b = b.strip()
-            date_part = b.replace("origin/draft/", "")
-            if date_part and date_part != TODAY:
-                merged = subprocess.run(
-                    ["git", "branch", "-r", "--merged", "origin/main", "--list", b],
-                    cwd=JOURNAL_REPO,
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                )
-                if b not in merged.stdout:
-                    candidates.append(date_part)
+        dates = set()
+        for line in result.stdout.splitlines():
+            fname = line.split("/")[-1]
+            if fname.endswith(".stub.md") or not fname.endswith(".md"):
+                continue
+            # Composed files are named YYYY-MM-DD-<slug>.md
+            if len(fname) >= 10 and fname[4] == "-" and fname[7] == "-":
+                dates.add(fname[:10])
+        return dates
+    except Exception:
+        return set()
 
-        if not candidates:
-            return []
 
-        # Verification pass — one ls-remote call only when candidates exist.
-        # Squash-merge + delete means "branch still on remote = not yet merged".
-        ls = subprocess.run(
+def unmerged_draft_branches() -> list[str]:
+    """Return remote draft/* branch names not yet merged into origin/main.
+
+    Uses composed_dates_on_main() as the merge signal — squash merges don't
+    leave branch commits in main's ancestry, making git branch --merged
+    unreliable. A composed journal file on main is the authoritative indicator.
+    """
+    try:
+        result = subprocess.run(
             ["git", "ls-remote", "--heads", "origin", "refs/heads/draft/*"],
             cwd=JOURNAL_REPO,
             capture_output=True,
@@ -83,13 +82,19 @@ def unmerged_draft_branches() -> list[str]:
             timeout=15,
         )
         remote_dates = set()
-        for line in ls.stdout.splitlines():
+        for line in result.stdout.splitlines():
             if "\t" in line:
                 ref = line.split("\t", 1)[1].strip()
                 remote_dates.add(ref.replace("refs/heads/draft/", ""))
 
-        unmerged = [d for d in candidates if d in remote_dates]
-        unmerged.sort(reverse=True)
+        if not remote_dates:
+            return []
+
+        merged = composed_dates_on_main()
+        unmerged = sorted(
+            [d for d in remote_dates if d != TODAY and d not in merged],
+            reverse=True,
+        )
         return unmerged
     except Exception:
         return []

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -44,6 +44,10 @@ def composed_dates_on_main() -> set[str]:
     This is the squash-merge signal: squash merges don't leave branch commits in
     main's ancestry, so git branch --merged is unreliable. Checking for the
     composed file on main is the authoritative indicator.
+
+    Note: reads the local remote-tracking ref (origin/main) without fetching —
+    results reflect the last fetch. A stale ref could produce a false positive
+    (flagging a merged date as unmerged), but the next fetch will self-correct.
     """
     try:
         result = subprocess.run(
@@ -91,6 +95,9 @@ def unmerged_draft_branches() -> list[str]:
             return []
 
         merged = composed_dates_on_main()
+        # TODAY is always excluded from automatic detection — today's active
+        # branch is never stale. Use /journal-compose YYYY-MM-DD explicitly
+        # to compose and merge the current day's journal.
         unmerged = sorted(
             [d for d in remote_dates if d != TODAY and d not in merged],
             reverse=True,

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -725,5 +725,15 @@ EOF
 )"
 ```
 
-Return the PR URL to the user. After the PR is merged (squash merge), delete the
-`draft/YYYY-MM-DD` branch.
+Return the PR URL to the user.
+
+**After the PR is squash-merged**, delete the remote branch to prevent the stale-branch
+hook from false-positive firing (squash merges don't appear in `git branch --merged`):
+
+```bash
+git -C C:/Users/brown/Git/engineering-journal push origin --delete draft/YYYY-MM-DD
+git -C C:/Users/brown/Git/engineering-journal branch -d draft/YYYY-MM-DD 2>/dev/null || true
+```
+
+If the user asks you to merge or confirms the PR is merged, run these commands immediately.
+If you are not present at merge time, include the commands as a reminder in your final message.

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -731,6 +731,7 @@ Return the PR URL to the user.
 hook from false-positive firing (squash merges don't appear in `git branch --merged`):
 
 ```bash
+# substitute the actual date, e.g. draft/2026-04-24
 git -C C:/Users/brown/Git/engineering-journal push origin --delete draft/YYYY-MM-DD
 git -C C:/Users/brown/Git/engineering-journal branch -d draft/YYYY-MM-DD 2>/dev/null || true
 ```


### PR DESCRIPTION
## Summary

- Replaces the unreliable `git branch --merged` check with a composed-files-on-main check — a date is considered merged if `origin/main` contains a non-stub `.md` file matching `YYYY-MM-DD-<slug>.md`
- Adds a `composed_dates_on_main()` helper that does one `git ls-tree` call on `origin/main` to enumerate composed journal files
- Updates `journal-compose` Step 11 to include the explicit `git push origin --delete draft/YYYY-MM-DD` commands after a squash merge, with a reminder if not present at merge time

## Test plan

- [ ] Verify that after squash-merging a `draft/YYYY-MM-DD` PR, the hook no longer flags that date as unmerged on the next session
- [ ] Verify that a branch with a stub but no composed file on main is still correctly flagged
- [ ] Confirm `composed_dates_on_main()` handles empty `sessions/` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)