### PR TITLE
feat: require plan-then-optimize pass before multi-step tasks

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -103,6 +103,14 @@ Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handle
 
 **Mechanical operations:** If a task is fully scriptable with known inputs, write the script rather than running an interactive session. Candidate operations: stale PR remediation, branch cleanup, rebase-and-merge sequences. Use `~/.claude/scripts/merge-stale-pr.sh` for engineering-journal stale draft PRs.
 
+**Plan-then-optimize before acting:** For any non-trivial task, state a numbered plan first, then do one explicit token-efficiency revision pass before taking any action. The revision pass must check:
+- Sequential tool calls that can be parallelized
+- `Agent` spawns: all independent subagents must go in a single message with `run_in_background: true` — no synchronous preflight agent that a parallel sibling will redo (root cause of dev-env#51)
+- File reads that can be skipped by reading an index or manifest instead of globbing
+- Data a downstream step will recompute anyway
+
+State the revised plan, then act.
+
 ---
 
 ## Documentation and Citations

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -103,13 +103,11 @@ Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handle
 
 **Mechanical operations:** If a task is fully scriptable with known inputs, write the script rather than running an interactive session. Candidate operations: stale PR remediation, branch cleanup, rebase-and-merge sequences. Use `~/.claude/scripts/merge-stale-pr.sh` for engineering-journal stale draft PRs.
 
-**Plan-then-optimize before acting:** For any non-trivial task, state a numbered plan first, then do one explicit token-efficiency revision pass before taking any action. The revision pass must check:
+**Plan-then-optimize before acting:** Any task involving an Agent spawn, a skill invocation, or reads across more than one file requires this protocol. State a numbered plan first, then do one explicit token-efficiency revision pass before taking any action. The revision pass must check:
 - Sequential tool calls that can be parallelized
 - `Agent` spawns: all independent subagents must go in a single message with `run_in_background: true` — no synchronous preflight agent that a parallel sibling will redo (root cause of dev-env#51)
 - File reads that can be skipped by reading an index or manifest instead of globbing
 - Data a downstream step will recompute anyway
-
-State the revised plan, then act.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a **Plan-then-optimize** rule to the global `CLAUDE.md` under the existing "Context & Token Efficiency" section
- Rule requires: state a numbered plan → explicit revision pass (parallelize calls, background agents, skip redundant reads) → then act
- Directly addresses dev-env#51: sync preflight Agent duplicated work a parallel background agent already did (~57K wasted tokens)

## Test plan
- [ ] Verify rule appears in `~/.claude/CLAUDE.md` (via symlink) after merge
- [ ] Confirm new sessions in any project repo load the rule from context

🤖 Generated with [Claude Code](https://claude.com/claude-code)