### PR TITLE
feat: journal stub manifest and auto-merge on compose

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -166,7 +166,8 @@ where `HHMMSS` is the UTC start time of the session (`date -u +%H%M%S`).
 1. `git -C C:/Users/brown/Git/engineering-journal checkout main && git pull`
 2. `git -C C:/Users/brown/Git/engineering-journal checkout -b draft/YYYY-MM-DD`
 3. Create `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` (see stub structure below)
-4. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
+4. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
+5. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
 
 **Subsequent sessions:**
 1. `git -C C:/Users/brown/Git/engineering-journal pull origin draft/YYYY-MM-DD`
@@ -176,11 +177,25 @@ where `HHMMSS` is the UTC start time of the session (`date -u +%H%M%S`).
    ```
 3. Create a new `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` with the current session block
 4. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
-5. `git add`, `git commit -m "draft: YYYY-MM-DD session N"`, `git push`
+5. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
+6. `git add`, `git commit -m "draft: YYYY-MM-DD session N"`, `git push`
+
+**Manifest format (`YYYY-MM-DD.manifest.jsonl`):**
+
+One JSON line per session, appended after the token comment is known (end of session):
+```bash
+echo '{"stub":"YYYY-MM-DD_HHMMSS.stub.md","topic":"<H2 heading>","tokens":{"input":N,"output":N,"cost":N}}' \
+  >> "C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD.manifest.jsonl"
+```
+
+The manifest lets `/journal-compose` see the session count, topics, and token data without
+reading individual stubs. It is advisory: if the manifest is missing or has fewer entries
+than the stub glob, stubs are authoritative. Never commit the manifest separately from its stubs
+(include it in the same `git add` / commit step).
 
 **End of day (last session):**
-1. Run `/journal-compose` — it discovers all stubs, sorts them, merges them, and produces
-   the canonical 11-section document; it also deletes stubs and opens the PR
+1. Run `/journal-compose` — it discovers all stubs via manifest (or glob fallback), merges them,
+   produces the canonical 11-section document, and auto-merges the PR
 
 ---
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -166,8 +166,9 @@ where `HHMMSS` is the UTC start time of the session (`date -u +%H%M%S`).
 1. `git -C C:/Users/brown/Git/engineering-journal checkout main && git pull`
 2. `git -C C:/Users/brown/Git/engineering-journal checkout -b draft/YYYY-MM-DD`
 3. Create `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` (see stub structure below)
-4. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
-5. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
+4. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
+5. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
+6. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
 
 **Subsequent sessions:**
 1. `git -C C:/Users/brown/Git/engineering-journal pull origin draft/YYYY-MM-DD`

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -37,6 +37,19 @@ git -C C:/Users/brown/Git/engineering-journal branch --show-current
 ```
 The branch name is `draft/YYYY-MM-DD`. Extract `YYYY-MM-DD` from it.
 
+**Check for a manifest (fast path):**
+
+```bash
+ls C:/Users/brown/Git/engineering-journal/sessions/*/YYYY-MM-DD.manifest.jsonl 2>/dev/null
+```
+
+If one or more manifests exist, read them to get a session overview before touching stubs:
+- Number of sessions per project (manifest line count)
+- Topics (for slug synthesis and day structure)
+- Token data per session (supplemental for Step 4 — JSONL log is still authoritative)
+
+If the manifest count differs from the stub glob count below, treat stubs as authoritative.
+
 **Find stub files:**
 
 ```bash
@@ -725,16 +738,21 @@ EOF
 )"
 ```
 
-Return the PR URL to the user.
-
-**After the PR is squash-merged**, delete the remote branch to prevent the stale-branch
-hook from false-positive firing (squash merges don't appear in `git branch --merged`):
+**Auto-merge the PR immediately after creation:**
 
 ```bash
-# substitute the actual date, e.g. draft/2026-04-24
-git -C C:/Users/brown/Git/engineering-journal push origin --delete draft/YYYY-MM-DD
+gh pr merge <PR-URL> \
+  --repo brownm09/engineering-journal \
+  --squash \
+  --delete-branch
+```
+
+This squash-merges the draft branch and deletes the remote branch in one step, preventing
+the stale-branch hook from false-positive firing. Wait for the merge to complete, then
+delete the local draft branch:
+
+```bash
 git -C C:/Users/brown/Git/engineering-journal branch -d draft/YYYY-MM-DD 2>/dev/null || true
 ```
 
-If the user asks you to merge or confirms the PR is merged, run these commands immediately.
-If you are not present at merge time, include the commands as a reminder in your final message.
+Tell the user: "Merged: <PR-URL>. Journal published."

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -129,6 +129,9 @@ Step 1 — Acquire compose lock for this project using this project-scoped path:
   C:/Users/brown/Git/engineering-journal/sessions/<project>/.draft-compose.lock
   Follow the lock check/create procedure in SKILL.md Step 1 ("Acquire the compose lock").
 
+Step 1b — If a manifest exists at `sessions/<project>/YYYY-MM-DD.manifest.jsonl`, read it
+  for a session overview (topics, token data) before reading individual stubs.
+
 Step 2 — Read stubs following SKILL.md Step 2 extraction format.
 
 Step 2b — Meta trigger check. Do NOT prompt the user, ask questions, or create any meta
@@ -691,6 +694,7 @@ under `## Projects` using this format.
 Delete all stubs for the date and release the compose lock:
 ```bash
 rm C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD_*.stub.md
+rm -f C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD.manifest.jsonl
 rm -f C:/Users/brown/Git/engineering-journal/sessions/<project>/.draft-compose.lock
 ```
 
@@ -744,7 +748,8 @@ EOF
 gh pr merge <PR-URL> \
   --repo brownm09/engineering-journal \
   --squash \
-  --delete-branch
+  --delete-branch \
+  --yes
 ```
 
 This squash-merges the draft branch and deletes the remote branch in one step, preventing


### PR DESCRIPTION
Closes #55

## Summary

- Each session appends a one-line JSONL manifest entry (`stub`, `topic`, `tokens`) alongside the stub commit — gives `journal-compose` a session overview without reading individual stubs
- `journal-compose` Step 1 reads the manifest first; falls back to glob if the manifest is absent or count mismatches
- `journal-compose` Step 11 now calls `gh pr merge --squash --delete-branch --yes` immediately after PR creation, eliminating the manual merge step and the separate remote-branch-delete reminder
- Added explicit token-comment step to first-session workflow for parity with subsequent sessions
- Step 9 cleanup now deletes manifest alongside stubs
- Multi-project subagent prompts updated to use manifest in Step 1b

## Test plan

- [ ] Write a stub for today, verify manifest entry appended correctly
- [ ] Run `/journal-compose` — confirm manifest is read in Step 1 output, stub glob still used as fallback
- [ ] Confirm PR is auto-merged and remote branch deleted at end of compose
- [ ] Verify manifest file is absent after compose completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)