### PR TITLE
fix: remove --yes from gh pr merge (flag does not exist)

### DIFF
--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -748,8 +748,7 @@ EOF
 gh pr merge <PR-URL> \
   --repo brownm09/engineering-journal \
   --squash \
-  --delete-branch \
-  --yes
+  --delete-branch
 ```
 
 This squash-merges the draft branch and deletes the remote branch in one step, preventing


### PR DESCRIPTION
`--yes` was added in #54 to suppress interactive prompts on `gh pr merge`, but the flag does not exist — it causes a fatal error on invocation (discovered when merging #54 itself).

Removed. `gh pr merge` runs non-interactively when not attached to a TTY, which covers all compose-session invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)