### PR TITLE
fix: stop false-positive incomplete-journal warnings from stale local draft branches

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -145,7 +145,13 @@ Use that path wherever `sessions/<project>/` appears below.
 
 - **Never compose proactively.** If a `draft/YYYY-MM-DD` branch is encountered during any
   work (e.g., while running `git branch`, checking git status, or reading branch output),
-  emit a single line at the next natural pause:
+  first check whether it exists on the remote before warning:
+  ```bash
+  git -C C:/Users/brown/Git/engineering-journal ls-remote --heads origin draft/YYYY-MM-DD
+  ```
+  A local-only draft branch means the PR was already squash-merged and the local ref was not
+  cleaned up — ignore it silently. Only if the remote branch exists, emit a single line at
+  the next natural pause:
   > "Incomplete journal detected — run `/journal-compose` in a dedicated session."
   Then continue with the user's actual request. Do not read stubs, do not compose, do not
   ask whether to compose.

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -757,7 +757,7 @@ the stale-branch hook from false-positive firing. Wait for the merge to complete
 delete the local draft branch:
 
 ```bash
-git -C C:/Users/brown/Git/engineering-journal branch -d draft/YYYY-MM-DD 2>/dev/null || true
+git -C C:/Users/brown/Git/engineering-journal branch -D draft/YYYY-MM-DD 2>/dev/null || true
 ```
 
 Tell the user: "Merged: <PR-URL>. Journal published."


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: detection rule now calls `ls-remote` before warning; a local-only `draft/YYYY-MM-DD` branch is silently ignored since it means the PR was already squash-merged
- **journal-compose SKILL.md**: `git branch -d` → `-D` so the post-merge local cleanup actually succeeds (squash-merge leaves commits unreachable from main, causing `-d` to refuse)

Closes #58

## Test plan

- [ ] After merging a journal PR, verify `git branch` in engineering-journal shows no leftover `draft/*` local branch
- [ ] In a fresh session, create a stale local draft branch manually; confirm no warning fires when `ls-remote` returns empty
- [ ] Confirm a genuinely open draft branch (remote exists) still triggers the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)