### PR TITLE
feat: journal open-prs tracking, manifest PR fields, and compose grouping

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -150,6 +150,12 @@ Use that path wherever `sessions/<project>/` appears below.
   Then continue with the user's actual request. Do not read stubs, do not compose, do not
   ask whether to compose.
 
+- **PR grouping heuristic.** When two or more stubs share a PR number (one stub has it in
+  `prs_opened`, another in `prs_closed`), compose them under a single H2 dialogue section
+  rather than producing a separate H2 per stub. Annotate with "→ merged in session N" at the
+  end of the section. This prevents the composed journal from fragmenting short create-then-review
+  session pairs into unrelated-looking sections.
+
 ---
 
 ### Stub file workflow
@@ -165,34 +171,53 @@ where `HHMMSS` is the UTC start time of the session (`date -u +%H%M%S`).
 **First session of the day:**
 1. `git -C C:/Users/brown/Git/engineering-journal checkout main && git pull`
 2. `git -C C:/Users/brown/Git/engineering-journal checkout -b draft/YYYY-MM-DD`
-3. Create `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` (see stub structure below)
-4. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
-5. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
-6. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
+3. Read `sessions/<project>/open-prs.jsonl` if it exists — include its PR list as session context before starting work.
+4. Create `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` (see stub structure below)
+5. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
+6. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
+7. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
 
 **Subsequent sessions:**
 1. `git -C C:/Users/brown/Git/engineering-journal pull origin draft/YYYY-MM-DD`
-2. Find the most recent stub and read only its `<!-- next-session-context -->` paragraph:
+2. Read `sessions/<project>/open-prs.jsonl` if it exists — include its PR list as session context before starting work.
+3. Find the most recent stub and read only its `<!-- next-session-context -->` paragraph:
    ```bash
    ls C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD_*.stub.md | sort | tail -1
    ```
-3. Create a new `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` with the current session block
-4. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
-5. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
-6. `git add`, `git commit -m "draft: YYYY-MM-DD session N"`, `git push`
+4. Create a new `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` with the current session block
+5. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
+6. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
+7. `git add`, `git commit -m "draft: YYYY-MM-DD session N"`, `git push`
 
 **Manifest format (`YYYY-MM-DD.manifest.jsonl`):**
 
 One JSON line per session, appended after the token comment is known (end of session):
 ```bash
-echo '{"stub":"YYYY-MM-DD_HHMMSS.stub.md","topic":"<H2 heading>","tokens":{"input":N,"output":N,"cost":N}}' \
+echo '{"stub":"YYYY-MM-DD_HHMMSS.stub.md","topic":"<H2 heading>","tokens":{"input":N,"output":N,"cost":N},"prs_opened":[],"prs_closed":[]}' \
   >> "C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD.manifest.jsonl"
 ```
 
-The manifest lets `/journal-compose` see the session count, topics, and token data without
-reading individual stubs. It is advisory: if the manifest is missing or has fewer entries
+- `prs_opened`: PR numbers opened during this session (e.g., `[54]`). Empty array if none.
+- `prs_closed`: PR numbers reviewed/merged during this session (e.g., `[54]`). Empty array if none.
+
+The manifest lets `/journal-compose` see the session count, topics, token data, and PR lifecycle
+without reading individual stubs. It is advisory: if the manifest is missing or has fewer entries
 than the stub glob, stubs are authoritative. Never commit the manifest separately from its stubs
 (include it in the same `git add` / commit step).
+
+**Open-PR tracking file (`sessions/<project>/open-prs.jsonl`):**
+
+Tracks PRs whose full lifecycle (open → review → merge) spans multiple sessions. Lives in the
+engineering-journal repo; carried forward from day to day via the draft branch merge to main.
+
+Schema — one JSON line per open PR:
+```json
+{"pr":54,"url":"https://github.com/brownm09/dev-env/pull/54","topic":"<H2 heading from stub>","stub":"YYYY-MM-DD_HHMMSS.stub.md","opened":"YYYY-MM-DD"}
+```
+
+- **When a session opens a PR:** append a line and commit it alongside the stub.
+- **When a session merges/closes a PR:** remove the matching line and commit the updated file alongside the stub.
+- `/journal-compose` preserves this file unchanged in the merge-to-main commit so it carries forward to the next day.
 
 **End of day (last session):**
 1. Run `/journal-compose` — it discovers all stubs via manifest (or glob fallback), merges them,

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -152,9 +152,12 @@ Use that path wherever `sessions/<project>/` appears below.
 
 - **PR grouping heuristic.** When two or more stubs share a PR number (one stub has it in
   `prs_opened`, another in `prs_closed`), compose them under a single H2 dialogue section
-  rather than producing a separate H2 per stub. Annotate with "→ merged in session N" at the
-  end of the section. This prevents the composed journal from fragmenting short create-then-review
-  session pairs into unrelated-looking sections.
+  rather than producing a separate H2 per stub. Annotate with "→ merged in session N" (where
+  N is the 1-based ordinal of the closing stub for that day) at the end of the section. Any
+  stub written on a day where `open-prs.jsonl` shows the same PR as open should also be grouped
+  under that H2, even if neither `prs_opened` nor `prs_closed` is set for that PR in its
+  manifest entry — this covers PRs that span more than two sessions. This prevents the composed
+  journal from fragmenting create-iterate-review sequences into unrelated-looking sections.
 
 ---
 
@@ -175,7 +178,8 @@ where `HHMMSS` is the UTC start time of the session (`date -u +%H%M%S`).
 4. Create `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` (see stub structure below)
 5. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
 6. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
-7. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
+7. `git add sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md sessions/<project>/YYYY-MM-DD.manifest.jsonl sessions/<project>/open-prs.jsonl`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
+   *(omit `open-prs.jsonl` from the add command if it was not modified this session)*
 
 **Subsequent sessions:**
 1. `git -C C:/Users/brown/Git/engineering-journal pull origin draft/YYYY-MM-DD`
@@ -187,7 +191,8 @@ where `HHMMSS` is the UTC start time of the session (`date -u +%H%M%S`).
 4. Create a new `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` with the current session block
 5. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block
 6. Append a manifest entry to `sessions/<project>/YYYY-MM-DD.manifest.jsonl` (see Manifest format below)
-7. `git add`, `git commit -m "draft: YYYY-MM-DD session N"`, `git push`
+7. `git add sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md sessions/<project>/YYYY-MM-DD.manifest.jsonl sessions/<project>/open-prs.jsonl`, `git commit -m "draft: YYYY-MM-DD session N"`, `git push`
+   *(omit `open-prs.jsonl` from the add command if it was not modified this session)*
 
 **Manifest format (`YYYY-MM-DD.manifest.jsonl`):**
 
@@ -215,8 +220,22 @@ Schema — one JSON line per open PR:
 {"pr":54,"url":"https://github.com/brownm09/dev-env/pull/54","topic":"<H2 heading from stub>","stub":"YYYY-MM-DD_HHMMSS.stub.md","opened":"YYYY-MM-DD"}
 ```
 
-- **When a session opens a PR:** append a line and commit it alongside the stub.
-- **When a session merges/closes a PR:** remove the matching line and commit the updated file alongside the stub.
+- `stub`: the stub filename that opened this PR — used by `/journal-compose` to cross-reference the opening session when a PR spans multiple days.
+
+- **When a session opens a PR:** append a line and commit it alongside the stub (see step 7 above).
+- **When a session merges/closes a PR:** remove the matching line using `node -e`, then commit:
+  ```bash
+  node -e "
+    const fs = require('fs');
+    const path = 'C:/Users/brown/Git/engineering-journal/sessions/<project>/open-prs.jsonl';
+    if (!fs.existsSync(path)) process.exit(0);
+    const kept = fs.readFileSync(path,'utf8').trim().split('\n')
+      .filter(l => l && JSON.parse(l).pr !== <PR_NUMBER>);
+    if (kept.length) fs.writeFileSync(path, kept.join('\n') + '\n');
+    else fs.unlinkSync(path);
+  "
+  ```
+  If the last line is removed, the script deletes the file rather than leaving it empty.
 - `/journal-compose` preserves this file unchanged in the merge-to-main commit so it carries forward to the next day.
 
 **End of day (last session):**

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -50,6 +50,19 @@ If one or more manifests exist, read them to get a session overview before touch
 
 If the manifest count differs from the stub glob count below, treat stubs as authoritative.
 
+**Check for open-PR context:**
+
+```bash
+ls C:/Users/brown/Git/engineering-journal/sessions/*/open-prs.jsonl 2>/dev/null
+```
+
+If found, read each file and record the open-PR list as `OPEN_PRS`. This is used in Step 5
+to group sessions that span multiple days under the same PR. For each entry:
+- If the PR's `prs_closed` appears in today's manifest, the PR was opened in a previous session
+  (possibly a previous day). The `stub` field identifies the opening session for cross-referencing.
+- If the PR has no `prs_closed` in today's manifest, it is still open — do not group anything
+  for it; the file carries forward unchanged to the next day.
+
 **Find stub files:**
 
 ```bash
@@ -410,6 +423,21 @@ Link to issues/PRs where referenced in the draft.
 ---
 
 ### Section 5 — Dialogue sections
+
+**PR grouping (before writing any H2s):** Scan the manifest(s) for `prs_opened` and
+`prs_closed` fields, and check `OPEN_PRS` (from Step 1). For any PR number that either:
+- appears in both `prs_opened` and `prs_closed` in today's manifests (same-day lifecycle), or
+- appears in `OPEN_PRS` and also in `prs_closed` in today's manifests (cross-day lifecycle),
+
+group all related session blocks under one `## Session N — <PR topic>` H2 instead of
+producing a separate H2 per stub. Order: opening session content first, any iteration sessions
+next, closing session content last. Annotate the end of the section with "→ merged in session N"
+where N is the 1-based ordinal of the closing stub for the day. For cross-day PRs, the opening
+stub is identified by the `stub` field in `OPEN_PRS` — note the original session date inline:
+"(opened YYYY-MM-DD — see [stub-filename])".
+
+Any stub that has neither `prs_opened` nor `prs_closed` set for a grouped PR but was written
+on a day when that PR was open in `OPEN_PRS` should also be merged into that H2.
 
 One `## Session N — <Title>` per session block, drawn from the draft's H2s.
 Use H3s for sub-topics within a session.


### PR DESCRIPTION
## Summary

- Adds `prs_opened`/`prs_closed` arrays to the manifest JSONL format so `/journal-compose` can link create and review sessions by PR number without reading individual stubs
- Documents `open-prs.jsonl` per-project tracking file: schema, write/remove rules, cross-day persistence via draft-branch merge to main
- Adds an explicit `open-prs.jsonl` read step to both first-session and subsequent-session workflows (replaces copy-pasting PR URLs between sessions)
- Adds a PR grouping heuristic to composition rules: stubs sharing a PR number compose under one H2 rather than producing separate fragmented sections

Closes #62

## Test plan

- [ ] Start a new journal session, verify `open-prs.jsonl` read step is followed
- [ ] Open a PR in a session; confirm `open-prs.jsonl` line is appended and manifest `prs_opened` is set
- [ ] Review/merge a PR in a subsequent session; confirm the `open-prs.jsonl` line is removed and `prs_closed` is set
- [ ] Run `/journal-compose` on a day with both create and review stubs for the same PR; verify they land under one H2

🤖 Generated with [Claude Code](https://claude.com/claude-code)