### PR TITLE
feat: auto-sync dev-env repo on every prompt to prevent stale CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -296,7 +296,8 @@ Subsequent stubs begin directly at `<!-- session: <slug> -->`.
 ### Update triggers
 
 **Project journal** (`sessions/<project>/`):
-- Add to the current session's stub when a PR is merged or a strategic decision is made
+- **Auto-create stub without user prompt on these session-end events:** PR opened, PR merged — follow the Stub file workflow immediately, then stop
+- Add to the current session's stub when a strategic decision is made mid-session
 - Compose and publish the daily document at end of last session of the day
 
 **Meta journal** (`sessions/meta/`):

--- a/claude/scripts/dev-env-sync.py
+++ b/claude/scripts/dev-env-sync.py
@@ -6,6 +6,10 @@ Runs a fast-forward pull at session start so that CLAUDE.md and other
 symlinked tooling always reflect the latest merged changes. Silent on
 success; emits a warning if the repo has diverged and needs manual attention.
 
+Only acts when the repo has `main` checked out — exits silently when a
+feature branch is active so dev-env PR sessions are not spammed with
+false-positive divergence warnings.
+
 Exit 0 always — never block the user's prompt.
 """
 
@@ -33,14 +37,23 @@ def main() -> None:
     except Exception:
         pass
 
+    # Guard: repo must exist at the expected path.
+    if not DEV_ENV_REPO.is_dir():
+        sys.exit(0)
+
+    # Only act when main is checked out — feature branches are intentional.
+    branch = run(["git", "symbolic-ref", "--short", "HEAD"])
+    if branch.returncode != 0 or branch.stdout.strip() != "main":
+        sys.exit(0)
+
     # Fetch quietly so the local remote-tracking ref is current.
     fetch = run(["git", "fetch", "origin", "main", "--quiet"])
     if fetch.returncode != 0:
         # Network issue — don't block, don't spam on every turn.
         sys.exit(0)
 
-    # Compare HEAD to origin/main.
-    rev_local = run(["git", "rev-parse", "HEAD"])
+    # Compare local main to origin/main.
+    rev_local = run(["git", "rev-parse", "refs/heads/main"])
     rev_remote = run(["git", "rev-parse", "origin/main"])
     if rev_local.returncode != 0 or rev_remote.returncode != 0:
         sys.exit(0)
@@ -52,15 +65,15 @@ def main() -> None:
         # Already up-to-date.
         sys.exit(0)
 
-    # Check if local is an ancestor of remote (fast-forward possible).
-    merge_base = run(["git", "merge-base", "HEAD", "origin/main"])
+    # Check if local main is an ancestor of origin/main (fast-forward possible).
+    merge_base = run(["git", "merge-base", "refs/heads/main", "origin/main"])
     if merge_base.returncode != 0:
         sys.exit(0)
 
     base = merge_base.stdout.strip()
 
     if base != local:
-        # Local has commits not on origin/main — diverged.
+        # Local main has commits not on origin/main — diverged.
         print(
             "[dev-env-sync] WARNING: local dev-env repo has diverged from origin/main.\n"
             "CLAUDE.md and symlinked tooling may be stale. Run `git -C ~/Git/dev-env "
@@ -73,12 +86,15 @@ def main() -> None:
     if pull.returncode == 0:
         # Count how many commits were pulled.
         log = run(["git", "log", "--oneline", f"{local}..HEAD"])
-        lines = [l for l in log.stdout.strip().splitlines() if l]
+        lines = [line for line in log.stdout.strip().splitlines() if line]
         count = len(lines)
         summary = f"{count} commit{'s' if count != 1 else ''}"
+        shown = lines[:5]
+        trailer = f"  ... and {count - 5} more" if count > 5 else ""
         print(
             f"[dev-env-sync] Pulled {summary} from origin/main — CLAUDE.md and tooling are now current.\n"
-            + "\n".join(f"  {l}" for l in lines[:5])
+            + "\n".join(f"  {line}" for line in shown)
+            + (f"\n{trailer}" if trailer else "")
         )
     else:
         print(

--- a/claude/scripts/dev-env-sync.py
+++ b/claude/scripts/dev-env-sync.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: keep the local dev-env repo in sync with origin/main.
+
+Runs a fast-forward pull at session start so that CLAUDE.md and other
+symlinked tooling always reflect the latest merged changes. Silent on
+success; emits a warning if the repo has diverged and needs manual attention.
+
+Exit 0 always — never block the user's prompt.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+DEV_ENV_REPO = Path.home() / "Git" / "dev-env"
+
+
+def run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        args,
+        cwd=DEV_ENV_REPO,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        **kwargs,
+    )
+
+
+def main() -> None:
+    try:
+        sys.stdin.read()
+    except Exception:
+        pass
+
+    # Fetch quietly so the local remote-tracking ref is current.
+    fetch = run(["git", "fetch", "origin", "main", "--quiet"])
+    if fetch.returncode != 0:
+        # Network issue — don't block, don't spam on every turn.
+        sys.exit(0)
+
+    # Compare HEAD to origin/main.
+    rev_local = run(["git", "rev-parse", "HEAD"])
+    rev_remote = run(["git", "rev-parse", "origin/main"])
+    if rev_local.returncode != 0 or rev_remote.returncode != 0:
+        sys.exit(0)
+
+    local = rev_local.stdout.strip()
+    remote = rev_remote.stdout.strip()
+
+    if local == remote:
+        # Already up-to-date.
+        sys.exit(0)
+
+    # Check if local is an ancestor of remote (fast-forward possible).
+    merge_base = run(["git", "merge-base", "HEAD", "origin/main"])
+    if merge_base.returncode != 0:
+        sys.exit(0)
+
+    base = merge_base.stdout.strip()
+
+    if base != local:
+        # Local has commits not on origin/main — diverged.
+        print(
+            "[dev-env-sync] WARNING: local dev-env repo has diverged from origin/main.\n"
+            "CLAUDE.md and symlinked tooling may be stale. Run `git -C ~/Git/dev-env "
+            "status` to investigate before proceeding."
+        )
+        sys.exit(0)
+
+    # Fast-forward is safe — pull.
+    pull = run(["git", "pull", "--ff-only", "origin", "main"])
+    if pull.returncode == 0:
+        # Count how many commits were pulled.
+        log = run(["git", "log", "--oneline", f"{local}..HEAD"])
+        lines = [l for l in log.stdout.strip().splitlines() if l]
+        count = len(lines)
+        summary = f"{count} commit{'s' if count != 1 else ''}"
+        print(
+            f"[dev-env-sync] Pulled {summary} from origin/main — CLAUDE.md and tooling are now current.\n"
+            + "\n".join(f"  {l}" for l in lines[:5])
+        )
+    else:
+        print(
+            "[dev-env-sync] WARNING: fast-forward pull failed.\n"
+            + pull.stderr.strip()
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -17,6 +17,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/dev-env-sync.py'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/new-day-journal-check.py'"
           },
           {


### PR DESCRIPTION
Closes #68

## Summary
- Adds `claude/scripts/dev-env-sync.py`: a `UserPromptSubmit` hook that runs `git fetch` + fast-forward pull on the local dev-env repo at the start of every Claude Code session
- Registers the script as the first `UserPromptSubmit` hook in `claude/settings.json` so tooling is always current before journal-check and turn-count run
- Commits CLAUDE.md workflow rule updates (stop-after-PR, stop-after-merge, journal auto-stub) that were applied to the local file during the #68 incident session but never pushed to origin

## Behavior
- **Up-to-date:** silent — no output, exits 0
- **Behind:** pulls fast-forward, emits a one-liner with commit count and titles (up to 5)
- **Diverged:** emits a warning and exits 0 without attempting a merge
- **Network failure:** silent — never blocks the user's prompt

## Test plan
- [ ] Verify silent exit when repo is current
- [ ] Manually reset local dev-env HEAD behind origin and confirm the hook pulls and reports
- [ ] Confirm diverged scenario emits warning without blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)