### PR TITLE
docs: explicitly exclude review sessions from auto-stub creation

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -301,6 +301,7 @@ Subsequent stubs begin directly at `<!-- session: <slug> -->`.
   - PR opened — follow the Stub file workflow immediately, then stop (see Git Workflow → Stop after PR creation)
   - PR merged (including auto-merge) — follow the Stub file workflow immediately, then stop (see Git Workflow → Stop after PR merge)
   - PR closed without merging — follow the Stub file workflow; stopping is optional (see Git Workflow → PR closed without merging)
+- Review-only sessions (`/review --post-comment`) do **not** auto-create a stub — review is not a session boundary
 - Add to the current session's stub when a strategic decision is made mid-session
 - Compose and publish the daily document at end of last session of the day
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -301,7 +301,9 @@ Subsequent stubs begin directly at `<!-- session: <slug> -->`.
   - PR opened — follow the Stub file workflow immediately, then stop (see Git Workflow → Stop after PR creation)
   - PR merged (including auto-merge) — follow the Stub file workflow immediately, then stop (see Git Workflow → Stop after PR merge)
   - PR closed without merging — follow the Stub file workflow; stopping is optional (see Git Workflow → PR closed without merging)
-- Review-only sessions (`/review --post-comment`) do **not** auto-create a stub — review is not a session boundary
+- The following do **not** auto-create a stub — they are not session boundaries:
+  - Review-only sessions (`/review --post-comment`)
+  - Pushing commits to an existing PR (e.g., addressing review findings) — if the session continues to a merge, the merge creates the stub
 - Add to the current session's stub when a strategic decision is made mid-session
 - Compose and publish the daily document at end of last session of the day
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -304,6 +304,7 @@ Subsequent stubs begin directly at `<!-- session: <slug> -->`.
 - The following do **not** auto-create a stub — they are not session boundaries:
   - Review-only sessions (`/review --post-comment`)
   - Pushing commits to an existing PR (e.g., addressing review findings) — if the session continues to a merge, the merge creates the stub
+
 - Add to the current session's stub when a strategic decision is made mid-session
 - Compose and publish the daily document at end of last session of the day
 


### PR DESCRIPTION
## Summary
- Adds a rule to CLAUDE.md that review-only sessions (`/review --post-comment`) do **not** auto-create a journal stub
- Review is not a session boundary — only PR creation and PR merge trigger stubs

## Test plan
- [ ] Verify CLAUDE.md diff is a single added line under Update triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)