### PR TITLE
feat: add Step 0.5 plan-then-optimize to journal-compose skill

### DIFF
--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -26,6 +26,15 @@ If any user turns or assistant responses exist in the conversation before the
 
 Do not proceed to Step 1.
 
+## Step 0.5 — Plan-then-optimize (required)
+
+Before reading any file or spawning any agent, write out:
+1. The steps you are about to execute (numbered)
+2. Which file reads can be skipped (manifest vs. stubs — prefer manifest; grep vs. full read — prefer grep)
+3. Which agent spawns will be batched in a single message with `run_in_background: true`
+
+Do not proceed to Step 1 until this plan is written. No tool calls before the revision pass completes.
+
 ## Step 1 — Locate stubs and acquire compose lock
 
 **Determine the date:**
@@ -137,6 +146,12 @@ You are composing the engineering journal for one project. Follow these steps ex
 **Date:** YYYY-MM-DD
 **Project path:** sessions/<project>/
 **Stub files (in order):** <stub1>, <stub2>, ...
+
+Step 0.5 — Plan-then-optimize (required). Before any tool call, write out:
+  1. The steps you will execute (numbered)
+  2. Which reads can be skipped (manifest vs. stubs — prefer manifest; grep vs. full read)
+  3. Confirm no sequential tool calls exist that could run in parallel
+  Do not proceed until this plan is written.
 
 Step 1 — Acquire compose lock for this project using this project-scoped path:
   C:/Users/brown/Git/engineering-journal/sessions/<project>/.draft-compose.lock

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -30,7 +30,7 @@ Do not proceed to Step 1.
 
 Before reading any file or spawning any agent, write out:
 1. The steps you are about to execute (numbered)
-2. Which file reads can be skipped (manifest vs. stubs — prefer manifest; grep vs. full read — prefer grep)
+2. Which file reads can be skipped entirely (e.g., if manifest data is sufficient, skip the stub read)
 3. Which agent spawns will be batched in a single message with `run_in_background: true`
 
 Do not proceed to Step 1 until this plan is written. No tool calls before the revision pass completes.
@@ -147,9 +147,10 @@ You are composing the engineering journal for one project. Follow these steps ex
 **Project path:** sessions/<project>/
 **Stub files (in order):** <stub1>, <stub2>, ...
 
+<!-- mirrors Step 0.5 in main flow — keep in sync; intentional differences: item 2 scoped to skip/read (not grep), item 3 broader (all parallel tool calls, not only agent spawns) -->
 Step 0.5 — Plan-then-optimize (required). Before any tool call, write out:
   1. The steps you will execute (numbered)
-  2. Which reads can be skipped (manifest vs. stubs — prefer manifest; grep vs. full read)
+  2. Which reads can be skipped entirely (e.g., if manifest data is sufficient, skip the stub read)
   3. Confirm no sequential tool calls exist that could run in parallel
   Do not proceed until this plan is written.
 


### PR DESCRIPTION
Closes #72

Adds a mandatory Step 0.5 to `journal-compose/SKILL.md` that requires a written plan + token-efficiency revision pass before any tool call. The step is added in two places:

1. Main skill flow — between Step 0 (session isolation check) and Step 1 (locate stubs)
2. Multi-project subagent prompt template — before Step 1 of each subagent, scoped to that subagent's local steps

This creates a forcing function in the execution path rather than relying on the model recalling CLAUDE.md rules voluntarily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)