### PR TITLE
feat: add retry wrapper script for nightly journal-compose

### DIFF
--- a/claude/scripts/journal-compose-with-retry.sh
+++ b/claude/scripts/journal-compose-with-retry.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Retry wrapper for the nightly journal-compose routine.
+# Invoked by Windows Task Scheduler; replaces the Claude Code scheduled routine.
+# Retries on non-zero exit up to MAX_RETRIES times with RETRY_DELAY seconds between attempts.
+
+MAX_RETRIES=3
+RETRY_DELAY=300  # 5 minutes — long enough for transient API issues to clear
+
+LOG_DIR="C:/Users/brown/.claude/scratch"
+LOG_FILE="$LOG_DIR/journal-compose-$(date -u +%Y-%m-%d).log"
+
+PROMPT="Run /journal-compose. Merge the result. Create a stub for today."
+
+log() {
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$LOG_FILE"
+}
+
+log "=== journal-compose-with-retry starting (max $MAX_RETRIES attempts) ==="
+
+for attempt in $(seq 1 $MAX_RETRIES); do
+    log "Attempt $attempt of $MAX_RETRIES"
+
+    claude --dangerously-skip-permissions -p "$PROMPT" >> "$LOG_FILE" 2>&1
+    exit_code=$?
+
+    if [ $exit_code -eq 0 ]; then
+        log "SUCCESS on attempt $attempt"
+        exit 0
+    fi
+
+    log "FAILED (exit $exit_code)"
+
+    if [ $attempt -lt $MAX_RETRIES ]; then
+        log "Retrying in ${RETRY_DELAY}s..."
+        sleep $RETRY_DELAY
+    fi
+done
+
+log "All $MAX_RETRIES attempts failed. Manual intervention required."
+exit 1


### PR DESCRIPTION
Adds `claude/scripts/journal-compose-with-retry.sh` — a bash script that wraps the `/journal-compose` skill invocation with up to 3 automatic retries (5-minute delay between attempts). Designed to be scheduled via Windows Task Scheduler, replacing the existing Claude Code `daily-journal-compose-local` routine.

## Why external scheduler over dual-routing
The Claude Code scheduled routine has no built-in retry. Dual-scheduling (two routines) creates implicit coupling to the skill's lock timeout and requires maintaining two prompts in sync. An external wrapper retries at the invocation layer, independent of skill internals.

## Setup
1. Run the PowerShell `Register-ScheduledTask` command (see PR description or session notes) to register the daily 2 AM job
2. Deactivate/delete `~/.claude/scheduled-tasks/daily-journal-compose-local/` to avoid double-runs

## Test plan
- [ ] Script exits 0 on successful `claude` invocation
- [ ] Script retries on non-zero exit and logs each attempt with timestamp
- [ ] Script exits 1 after MAX_RETRIES exhausted
- [ ] Log file written to `~/.claude/scratch/journal-compose-YYYY-MM-DD.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)