### PR TITLE
feat: mandate test verification before PR creation

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -42,8 +42,28 @@ Before writing a `gh` or other CLI automation script:
 
 ---
 
+## Per-Project CLAUDE.md Requirements
+
+Every project CLAUDE.md **must** include a `## Testing` section specifying the command(s) used to verify a solution before opening a PR. Examples:
+
+```markdown
+## Testing
+Run `npm test` to execute the full test suite.
+Run `npm run build` first if touching compiled output.
+```
+
+```markdown
+## Testing
+Run `pytest` from the repo root. Integration tests require `DATABASE_URL` set.
+```
+
+If the project has no automated tests, the section must say so explicitly and describe the manual verification steps instead. The `## Testing` section is used by the global "Test before PR" rule — without it, Claude cannot comply with that rule and will fall back to an undocumented manual check.
+
+---
+
 ## Git Workflow
 
+- **Test before PR.** Before running `gh pr create`, execute the project's test command defined in `## Testing` in the project CLAUDE.md. Tests must pass (or the failure must be explained and documented). Include what was tested and the outcome in the PR body. If no project test command is defined, state that explicitly and describe any manual verification performed instead.
 - **Never commit directly to `main`.** All changes go through a branch and PR, regardless of repo.
 - **Branch naming:** `feat/`, `fix/`, `config/`, `chore/`, `draft/` prefixes — match the convention already in use in the repo.
 - **PR first, then merge.** Open the PR immediately after pushing the branch; do not prompt the user to run `gh pr create` themselves.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -57,13 +57,13 @@ Run `npm run build` first if touching compiled output.
 Run `pytest` from the repo root. Integration tests require `DATABASE_URL` set.
 ```
 
-If the project has no automated tests, the section must say so explicitly and describe the manual verification steps instead. The `## Testing` section is used by the global "Test before PR" rule — without it, Claude cannot comply with that rule and will fall back to an undocumented manual check.
+If the project has no automated tests, the section must say so explicitly and describe the manual verification steps instead. The `## Testing` section is used by the global "Test before PR" rule — **if no `## Testing` section exists in the project CLAUDE.md, stop before running `gh pr create` and ask the user to add one. Do not open the PR until the section is present.**
 
 ---
 
 ## Git Workflow
 
-- **Test before PR.** Before running `gh pr create`, execute the project's test command defined in `## Testing` in the project CLAUDE.md. Tests must pass (or the failure must be explained and documented). Include what was tested and the outcome in the PR body. If no project test command is defined, state that explicitly and describe any manual verification performed instead.
+- **Test before PR.** Before running `gh pr create`, execute the project's test command defined in `## Testing` in the project CLAUDE.md. Tests must pass (or the failure must be explained and documented). Include what was tested and the outcome in the PR body. **If no `## Testing` section exists in the project CLAUDE.md, stop and ask the user to add one — do not open the PR until it is present.**
 - **Never commit directly to `main`.** All changes go through a branch and PR, regardless of repo.
 - **Branch naming:** `feat/`, `fix/`, `config/`, `chore/`, `draft/` prefixes — match the convention already in use in the repo.
 - **PR first, then merge.** Open the PR immediately after pushing the branch; do not prompt the user to run `gh pr create` themselves.

--- a/claude/scripts/pre-pr-create-check.py
+++ b/claude/scripts/pre-pr-create-check.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook — detects 'gh pr create' in Bash commands and
+emits a systemMessage checklist requiring test verification before the PR lands.
+
+Does NOT block the PR creation (exit 0). The checklist appears in the Claude
+Code UI as a hard reminder; the CLAUDE.md testing mandate is the enforcement
+mechanism.
+
+Stdin JSON shape (PreToolUse):
+  {
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Bash",
+    "tool_input": {"command": "...", "description": "..."},
+    "session_id": "...",
+    "cwd": "..."
+  }
+
+Exit 0 — always; hook is advisory only.
+"""
+import json
+import re
+import sys
+
+_GH_PR_CREATE_RE = re.compile(
+    r"(?:^|&&|\|\||;|\n)\s*gh\s+pr\s+create\b"
+)
+
+
+def main() -> None:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        sys.exit(0)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    if data.get("tool_name") != "Bash":
+        sys.exit(0)
+
+    command = data.get("tool_input", {}).get("command", "")
+    if not _GH_PR_CREATE_RE.search(command):
+        sys.exit(0)
+
+    checklist = (
+        "[pre-pr-check] Before this PR is created, confirm:\n"
+        "  1. Ran the project test command (see ## Testing in project CLAUDE.md)\n"
+        "  2. Tests passed (or documented why they are not applicable)\n"
+        "  3. PR body includes what was tested and the outcome"
+    )
+    print(json.dumps({"systemMessage": checklist}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/scripts/pre-pr-create-check.py
+++ b/claude/scripts/pre-pr-create-check.py
@@ -2,9 +2,12 @@
 """Claude Code PreToolUse hook — detects 'gh pr create' in Bash commands and
 emits a systemMessage checklist requiring test verification before the PR lands.
 
-Does NOT block the PR creation (exit 0). The checklist appears in the Claude
-Code UI as a hard reminder; the CLAUDE.md testing mandate is the enforcement
-mechanism.
+Enforcement model (layered):
+  - This hook is advisory only (always exits 0). It fires a systemMessage
+    reminder visible in the Claude Code UI.
+  - Hard enforcement is handled by CLAUDE.md instruction: Claude must not
+    run `gh pr create` until the project's ## Testing section is satisfied.
+    The hook is a secondary reminder, not the gate.
 
 Stdin JSON shape (PreToolUse):
   {
@@ -22,7 +25,7 @@ import re
 import sys
 
 _GH_PR_CREATE_RE = re.compile(
-    r"(?:^|&&|\|\||;|\n)\s*gh\s+pr\s+create\b"
+    r"(?:^|&&|\|+|;|\n)\s*gh\s+pr\s+create\b"
 )
 
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/pre-commit-branch-check.py'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/pre-pr-create-check.py'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Adds a **`## Testing` requirement** to every project CLAUDE.md — without it Claude cannot comply with the test mandate and falls back to undocumented manual checks
- Adds a **\"Test before PR\" rule** to the global Git Workflow section, requiring Claude to run the project test command and document results in the PR body before opening a PR
- Adds **`pre-pr-create-check.py`** — a PreToolUse hook that fires a three-point checklist `systemMessage` whenever `gh pr create` appears in a Bash call, surfacing the rule as a runtime reminder
- Hardens the missing-section fallback to a **hard stop** — Claude must ask the user to add `## Testing` before `gh pr create` is allowed to run

## Related
- #79 — add `## Testing` section to dev-env CLAUDE.md itself (follow-on, unblocked after this merges)

## Test plan
- [ ] Hook fires when a Bash call contains `gh pr create` and outputs the checklist systemMessage
- [ ] Hook does not fire for unrelated Bash commands
- [ ] CLAUDE.md changes render correctly (check Per-Project Requirements section and Git Workflow bullet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)