### PR TITLE
fix: remove bash -c wrapper from hook commands

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -7,11 +7,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/pre-commit-branch-check.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/pre-commit-branch-check.py"
           },
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/pre-pr-create-check.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/pre-pr-create-check.py"
           }
         ]
       }
@@ -21,15 +21,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/dev-env-sync.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/dev-env-sync.py"
           },
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/new-day-journal-check.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/new-day-journal-check.py"
           },
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/turn-count-hook.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/turn-count-hook.py"
           }
         ]
       }
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/token-tracker.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/token-tracker.py"
           }
         ]
       }
@@ -50,15 +50,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/pr-merge-reminder.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/pr-merge-reminder.py"
           },
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/post-tool-use.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/post-tool-use.py"
           },
           {
             "type": "command",
-            "command": "bash -c 'python3 C:/Users/brown/.claude/scripts/post-pr-merge-pull.py'"
+            "command": "python3 C:/Users/brown/.claude/scripts/post-pr-merge-pull.py"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `bash` is not on PATH in Claude Code hook execution environment on Windows
- The `PreToolUse` hook wrapped every Python script in `bash -c '...'`, which exited non-zero and blocked all Bash tool calls
- `UserPromptSubmit`/`PostToolUse`/`Stop` hooks had the same wrapper but failed silently (non-zero exits there do not block)
- Fix: call `python3 <script>` directly

## Root cause

Claude Code resolves hook commands against the system PATH, not the Git Bash PATH. `bash.exe` lives at `C:\Program Files\Git\bin\bash.exe` but is not in the Windows system PATH.

## Test plan

- Verified `python3` is available without the bash wrapper: both PreToolUse scripts exit 0 when invoked as `python3 <script>`
- `bash` confirmed absent from system PATH (`where.exe bash` returns exit 1)

No linked issue -- meta/config change with no meaningful issue scope.

Generated with [Claude Code](https://claude.com/claude-code)