### PR TITLE
feat(journal-compose): validate JSONL before composition begins

### DIFF
--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -40,6 +40,8 @@ Do not proceed to Step 1 until this plan is written. No tool calls before the re
 Before reading any stubs or manifests, run the JSONL validator:
 
 ```bash
+[ -f "C:/Users/brown/Git/engineering-journal/scripts/validate-jsonl.js" ] || \
+  { echo "validate-jsonl.js not found — merge the companion engineering-journal PR first"; exit 1; }
 node "C:/Users/brown/Git/engineering-journal/scripts/validate-jsonl.js"
 ```
 

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -35,6 +35,19 @@ Before reading any file or spawning any agent, write out:
 
 Do not proceed to Step 1 until this plan is written. No tool calls before the revision pass completes.
 
+## Step 0.8 — Validate JSONL files
+
+Before reading any stubs or manifests, run the JSONL validator:
+
+```bash
+node "C:/Users/brown/Git/engineering-journal/scripts/validate-jsonl.js"
+```
+
+- **Exit 0:** All `.jsonl` files under `sessions/` are valid — proceed to Step 1.
+- **Exit non-zero:** Stop immediately. Report the offending file(s) and line(s) printed by the validator. Do not proceed with composition until the errors are resolved — a malformed manifest line can cause sessions to be silently misread or omitted from the composed journal.
+
+---
+
 ## Step 1 — Locate stubs and acquire compose lock
 
 **Determine the date:**


### PR DESCRIPTION
## Summary
- Adds **Step 0.8** to the `journal-compose` skill, which runs `node scripts/validate-jsonl.js` before any stubs or manifests are read
- Catches malformed manifest/open-prs lines at the earliest possible point — before the compose lock is acquired — so failures surface cleanly with an actionable error message rather than as a mysterious gap in the composed output

## Why before Step 1
The manifest files are the primary input to composition (session count, topics, token data, PR lifecycle). A malformed line in a manifest silently drops or corrupts that session's data. Validating first means composition only runs on confirmed-clean input. It also avoids acquiring the compose lock on broken state, making cleanup trivial (no lock file to clear).

## Related
- Closes no issue (meta/config change — no meaningful issue scope per global CLAUDE.md)
- Companion to `engineering-journal` change adding `## Testing` and `scripts/validate-jsonl.js`
- Addresses the review finding from dev-env#76 (primary gate should be at composition time, not PR time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)