### PR TITLE
feat(review): default post-comment, duplicate guard, model attribution

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -68,7 +68,7 @@ If the project has no automated tests, the section must say so explicitly and de
 - **Never commit directly to `main`.** All changes go through a branch and PR, regardless of repo.
 - **Branch naming:** `feat/`, `fix/`, `config/`, `chore/`, `draft/` prefixes — match the convention already in use in the repo.
 - **PR first, then merge.** Open the PR immediately after pushing the branch; do not prompt the user to run `gh pr create` themselves.
-- **Stop after PR creation.** After opening any PR, report the PR URL, create the journal stub for this session (no user prompt — see Engineering Journal > Stub file workflow), then **stop — the session is complete.** Do not run `/review`, do not summarize next steps, do not continue with any further work. Instruct the user to run `/review <PR-URL> --post-comment` in a new session. Rationale: the review skill reads the PR directly from GitHub and needs no implementation context; running it in the same session adds 30–80k unnecessary input tokens. The review skill applies the `reviewed-by-claude` label; a PR without that label has not been reviewed.
+- **Stop after PR creation.** After opening any PR, report the PR URL, create the journal stub for this session (no user prompt — see Engineering Journal > Stub file workflow), then **stop — the session is complete.** Do not run `/review`, do not summarize next steps, do not continue with any further work. Instruct the user to run `/review <PR-URL>` in a new session. Rationale: the review skill reads the PR directly from GitHub and needs no implementation context; running it in the same session adds 30–80k unnecessary input tokens. The review skill applies the `reviewed-by-claude` label; a PR without that label has not been reviewed.
 - **Stop after PR merge.** After merging a PR (via `gh pr merge`, auto-merge, or equivalent), create the journal stub for this session without prompting, then **stop — the session is complete.** Do not continue with any further work. A merge is a session boundary.
 - **PR closed without merging.** If a PR is closed without merging, create the journal stub for this session without prompting. Stopping is optional — the session may continue if follow-up work remains.
 - **Exception:** Local-only repos with no remote may commit to main directly.
@@ -329,7 +329,7 @@ Subsequent stubs begin directly at `<!-- session: <slug> -->`.
   - PR merged (including auto-merge) — follow the Stub file workflow immediately, then stop (see Git Workflow → Stop after PR merge)
   - PR closed without merging — follow the Stub file workflow; stopping is optional (see Git Workflow → PR closed without merging)
 - The following do **not** auto-create a stub — they are not session boundaries:
-  - Review-only sessions (`/review --post-comment`)
+  - Review-only sessions (`/review <PR-URL>`)
   - Pushing commits to an existing PR (e.g., addressing review findings) — if the session continues to a merge, the merge creates the stub
 
 - Add to the current session's stub when a strategic decision is made mid-session

--- a/claude/skills/review/SKILL.md
+++ b/claude/skills/review/SKILL.md
@@ -47,9 +47,9 @@ Store **PR_TITLE**, **PR_BODY**, **ADDITIONS**, **DELETIONS**, **CHANGED_FILES**
 **Duplicate-review guard:** If `reviewed-by-claude` appears in LABELS, tell the user:
 
 > "⚠️ This PR already has the `reviewed-by-claude` label — it appears to have been reviewed.
-> Re-review anyway? (y/n)"
+> Re-review anyway? (y/n) [default: n]"
 
-If the user answers `n`, stop. If `y`, continue.
+If the user answers `y`, continue. Otherwise (answer is `n`, no response, or non-interactive context), stop.
 
 Then fetch the diff:
 

--- a/claude/skills/review/SKILL.md
+++ b/claude/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
-description: Review a PR or diff for correctness, security, reliability, and maintainability. Produces a structured report with blocking findings, non-blocking findings, questions for the author, and optional style notes. Invoke as /review <PR-URL> [--no-style] [--author junior|mid|senior] [--focus security|correctness|perf] [--post-comment].
-argument-hint: "<PR-URL | --diff> [--no-style] [--author <level>] [--focus <area>] [--post-comment]"
+description: Review a PR or diff for correctness, security, reliability, and maintainability. Produces a structured report with blocking findings, non-blocking findings, questions for the author, and optional style notes. Invoke as /review <PR-URL> [--no-style] [--author junior|mid|senior] [--focus security|correctness|perf] [--no-comment].
+argument-hint: "<PR-URL | --diff> [--no-style] [--author <level>] [--focus <area>] [--no-comment]"
 allowed-tools: Bash Read Grep Agent
 ---
 
@@ -26,11 +26,11 @@ Parse rules:
    - `--no-style` → **STYLE=false** (default: true)
    - `--author <level>` → **AUTHOR_LEVEL** = junior | mid | senior (default: mid)
    - `--focus <area>` → **FOCUS** = security | correctness | perf (default: all)
-   - `--post-comment` → **POST_COMMENT=true** (default: false) — post the review as a PR comment after emitting it
+   - `--no-comment` → **POST_COMMENT=false** (default: true) — skip posting the review as a PR comment
 
 Tell the user what you parsed:
 - "Reviewing: `<PR_URL>`" (or "Diff mode — paste your diff")
-- Flags in effect (omit defaults): e.g., "--no-style, author=junior, focus=security, --post-comment"
+- Flags in effect (omit defaults): e.g., "--no-style, author=junior, focus=security, --no-comment"
 
 ---
 
@@ -39,8 +39,17 @@ Tell the user what you parsed:
 **If PR_URL is set:**
 
 ```bash
-gh pr view "<PR_URL>" --json title,body,additions,deletions,changedFiles,baseRefName,headRefName
+gh pr view "<PR_URL>" --json title,body,additions,deletions,changedFiles,baseRefName,headRefName,labels
 ```
+
+Store **PR_TITLE**, **PR_BODY**, **ADDITIONS**, **DELETIONS**, **CHANGED_FILES**, and **LABELS**.
+
+**Duplicate-review guard:** If `reviewed-by-claude` appears in LABELS, tell the user:
+
+> "⚠️ This PR already has the `reviewed-by-claude` label — it appears to have been reviewed.
+> Re-review anyway? (y/n)"
+
+If the user answers `n`, stop. If `y`, continue.
 
 Then fetch the diff:
 
@@ -49,7 +58,6 @@ gh pr diff "<PR_URL>"
 ```
 
 Store:
-- **PR_TITLE**, **PR_BODY**, **ADDITIONS**, **DELETIONS**, **CHANGED_FILES**
 - **DIFF** — the full diff text
 - **DIFF_SIZE** = ADDITIONS + DELETIONS
 
@@ -206,11 +214,15 @@ the cap, state the count here.>
 ### Style Notes
 <Grouped, not itemized. One short paragraph per concern.>
 <Omit section if STYLE=false or no style findings.>
+
+---
+
+*Reviewed by `<your model ID>` via Claude Code*
 ```
 
 ---
 
-## Step 9 — Post comment (if --post-comment)
+## Step 9 — Post comment (skipped only if --no-comment)
 
 Step 8 always emits the review to the terminal. If **POST_COMMENT=true** and **PR_URL** is set,
 also post it as a PR comment and apply the `reviewed-by-claude` label so both are always present.
@@ -231,7 +243,7 @@ still emitted to the terminal.
 
 Report: "Review posted as comment: <PR_URL>"
 
-If POST_COMMENT is false, or DIFF_MODE is true, skip this step.
+If POST_COMMENT is false (i.e., `--no-comment` was passed), or DIFF_MODE is true, skip this step.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Default `--post-comment`** — posting the review is now the default behavior; pass `--no-comment` to skip. Eliminates the silent failure mode where reviews run without leaving a label or comment.
- **Duplicate-review guard** — fetches `labels` in the existing `gh pr view` call before downloading the diff; if `reviewed-by-claude` is already present, warns and asks whether to continue. Saves all diff-fetch + analysis tokens on re-runs.
- **Model attribution** — appends `*Reviewed by \`<model-id>\` via Claude Code*` footer to every review (terminal and posted comment).
- **CLAUDE.md references** updated from `--post-comment` to match the new default.

## Test plan

- [ ] No automated test suite exists for skill files — manual smoke test
- [ ] Run `/review <PR-URL>` (no flags) on a PR without the label; confirm comment posted, label applied, model footer visible
- [ ] Run again on the same PR; confirm duplicate-guard warning fires before diff is fetched
- [ ] Run `/review <PR-URL> --no-comment`; confirm no comment posted, model footer still appears in terminal

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)