### PR TITLE
fix: extend plan-then-optimize rule to mid-session task switches

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -127,7 +127,7 @@ Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handle
 
 **Mechanical operations:** If a task is fully scriptable with known inputs, write the script rather than running an interactive session. Candidate operations: stale PR remediation, branch cleanup, rebase-and-merge sequences. Use `~/.claude/scripts/merge-stale-pr.sh` for engineering-journal stale draft PRs.
 
-**Plan-then-optimize before acting:** Any task involving an Agent spawn, a skill invocation, or reads across more than one file requires this protocol. State a numbered plan first, then apply two explicit revision passes before taking any action.
+**Plan-then-optimize before acting:** Any task involving an Agent spawn, a skill invocation, reads across more than one file, or a switch to a new primary objective within the same session (e.g., moving from a `/review` or other skill output to addressing findings, or from one issue to another) requires this protocol. State a numbered plan first, then apply two explicit revision passes before taking any action.
 
 **Pass 1 — Token efficiency:** check:
 - Sequential tool calls that can be parallelized


### PR DESCRIPTION
## Summary

- Extends the plan-then-optimize trigger in `claude/CLAUDE.md` to also fire when switching to a new task within the same session (e.g., moving from `/review` or another skill output to implementing findings)
- Updates the memory file to match the expanded rule

## Test plan

- [ ] In a future session: run a skill, then pivot to implementation work — verify the plan + revision pass fires at the task-switch boundary before any file writes
- [ ] Memory index reflects the updated trigger description

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)