### PR TITLE
fix: replace stop-after-PR-creation with compact-then-review in same session

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -68,7 +68,7 @@ If the project has no automated tests, the section must say so explicitly and de
 - **Never commit directly to `main`.** All changes go through a branch and PR, regardless of repo.
 - **Branch naming:** `feat/`, `fix/`, `config/`, `chore/`, `draft/` prefixes — match the convention already in use in the repo.
 - **PR first, then merge.** Open the PR immediately after pushing the branch; do not prompt the user to run `gh pr create` themselves.
-- **Stop after PR creation.** After opening any PR, report the PR URL, create the journal stub for this session (no user prompt — see Engineering Journal > Stub file workflow), then **stop — the session is complete.** Do not run `/review`, do not summarize next steps, do not continue with any further work. Instruct the user to run `/review <PR-URL>` in a new session. Rationale: the review skill reads the PR directly from GitHub and needs no implementation context; running it in the same session adds 30–80k unnecessary input tokens. The review skill applies the `reviewed-by-claude` label; a PR without that label has not been reviewed.
+- **Review in the same session after /compact.** After opening a PR, report the PR URL, then prompt the user to run `/compact`. Once compaction is complete, immediately run `/review <PR-URL> --post-comment`. Address any blocking findings and merge in the same session. Do not write the journal stub until merge. Rationale: `/compact` reduces implementation context to a small summary before review fires, preserving most token savings without a session break. The review skill applies the `reviewed-by-claude` label; a PR without that label has not been reviewed.
 - **Stop after PR merge.** After merging a PR (via `gh pr merge`, auto-merge, or equivalent), create the journal stub for this session without prompting, then **stop — the session is complete.** Do not continue with any further work. A merge is a session boundary.
 - **PR closed without merging.** If a PR is closed without merging, create the journal stub for this session without prompting. Stopping is optional — the session may continue if follow-up work remains.
 - **Exception:** Local-only repos with no remote may commit to main directly.
@@ -334,7 +334,7 @@ Subsequent stubs begin directly at `<!-- session: <slug> -->`.
 
 **Project journal** (`sessions/<project>/`):
 - **Auto-create stub without user prompt on these session-end events:**
-  - PR opened — follow the Stub file workflow immediately, then stop (see Git Workflow → Stop after PR creation)
+  - PR opened without same-session merge (e.g., waiting on CI, human review required) — follow the Stub file workflow and stop; this captures work done so far
   - PR merged (including auto-merge) — follow the Stub file workflow immediately, then stop (see Git Workflow → Stop after PR merge)
   - PR closed without merging — follow the Stub file workflow; stopping is optional (see Git Workflow → PR closed without merging)
 - The following do **not** auto-create a stub — they are not session boundaries:


### PR DESCRIPTION
Closes #92

## Summary
- Removes the hard session stop after PR creation
- Replaces it with: run `/compact` after PR, then run `/review <PR-URL> --post-comment` in the same session, address findings, and merge
- Updates the journal update-triggers: PR open is only a session boundary when merge can't happen in the same session (e.g., waiting on CI)
- Merge remains the primary session-end event; stub gets written at merge

## Motivation
The previous rule required two sessions per PR (implement+PR / review+merge). `/compact` reduces implementation context to a small summary before review fires, preserving most token savings without the session break.

## Testing
No automated tests — CLAUDE.md is a config document. Verified diff is correct and coherent with surrounding rules.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)