### PR TITLE
feat: emit worktree list on every prompt when multiple worktrees active

### DIFF
--- a/claude/scripts/multi-worktree-alert.py
+++ b/claude/scripts/multi-worktree-alert.py
@@ -30,18 +30,18 @@ def parse_worktree_list(output: str) -> list[dict]:
       branch (str) — short branch name, or '<detached>' for detached-HEAD worktrees
     """
     worktrees: list[dict] = []
-    current: dict = {}
+    current: dict | None = None
     for line in output.splitlines():
         if line.startswith("worktree "):
-            if current:
+            if current is not None:
                 worktrees.append(current)
             current = {"path": line[len("worktree "):].strip(), "branch": ""}
-        elif line.startswith("branch "):
+        elif line.startswith("branch ") and current is not None:
             ref = line[len("branch "):].strip()
             current["branch"] = ref[len("refs/heads/"):] if ref.startswith("refs/heads/") else ref
-        elif line == "detached":
+        elif line == "detached" and current is not None:
             current["branch"] = "<detached>"
-    if current:
+    if current is not None:
         worktrees.append(current)
     return worktrees
 
@@ -99,7 +99,8 @@ def main() -> None:
         name = wt["branch"] or "<unknown>"
         labeled.append(f"*{name}*" if wt is current else name)
 
-    msg = f"[worktree-alert] {len(worktrees)} active worktrees: {', '.join(labeled)}"
+    location = "current unknown" if current is None else f"on *{current['branch'] or '<unknown>'}*"
+    msg = f"[worktree-alert] {len(worktrees)} active worktrees ({location}): {', '.join(labeled)}"
     print(json.dumps({"systemMessage": msg}))
     sys.exit(0)
 

--- a/claude/scripts/multi-worktree-alert.py
+++ b/claude/scripts/multi-worktree-alert.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Claude Code UserPromptSubmit hook — emits a systemMessage listing all
+active worktrees when the current repo has two or more, marking the current
+one with asterisks.
+
+Fires on every user prompt so the user always knows which worktree they are
+working in during a multi-worktree session. Exits silently when only one
+worktree is active.
+
+Stdin JSON shape (UserPromptSubmit):
+  {
+    "hook_event_name": "UserPromptSubmit",
+    "session_id": "...",
+    "cwd": "..."
+  }
+
+Exit 0 always — advisory only, never blocks.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_worktree_list(output: str) -> list[dict]:
+    """Parse `git worktree list --porcelain` output into a list of dicts.
+
+    Each dict has keys:
+      path   (str) — absolute path from the 'worktree' line
+      branch (str) — short branch name, or '<detached>' for detached-HEAD worktrees
+    """
+    worktrees: list[dict] = []
+    current: dict = {}
+    for line in output.splitlines():
+        if line.startswith("worktree "):
+            if current:
+                worktrees.append(current)
+            current = {"path": line[len("worktree "):].strip(), "branch": ""}
+        elif line.startswith("branch "):
+            ref = line[len("branch "):].strip()
+            current["branch"] = ref[len("refs/heads/"):] if ref.startswith("refs/heads/") else ref
+        elif line == "detached":
+            current["branch"] = "<detached>"
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+def find_current_worktree(worktrees: list[dict], cwd: str) -> dict | None:
+    """Return the worktree whose path matches cwd or is a parent of cwd.
+
+    Sorts by path length descending so the most-specific (deepest) match wins
+    when cwd is a subdirectory inside a worktree.
+    """
+    cwd_path = Path(cwd).resolve()
+    for wt in sorted(worktrees, key=lambda w: len(w["path"]), reverse=True):
+        try:
+            cwd_path.relative_to(Path(wt["path"]).resolve())
+            return wt
+        except ValueError:
+            continue
+    return None
+
+
+def main() -> None:
+    raw = sys.stdin.read().strip()
+    cwd = ""
+    if raw:
+        try:
+            cwd = json.loads(raw).get("cwd", "")
+        except json.JSONDecodeError:
+            pass
+
+    if not cwd:
+        sys.exit(0)
+
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        sys.exit(0)
+
+    if result.returncode != 0:
+        sys.exit(0)
+
+    worktrees = parse_worktree_list(result.stdout)
+    if len(worktrees) < 2:
+        sys.exit(0)
+
+    current = find_current_worktree(worktrees, cwd)
+
+    labeled = []
+    for wt in worktrees:
+        name = wt["branch"] or "<unknown>"
+        labeled.append(f"*{name}*" if wt is current else name)
+
+    msg = f"[worktree-alert] {len(worktrees)} active worktrees: {', '.join(labeled)}"
+    print(json.dumps({"systemMessage": msg}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -30,6 +30,10 @@
           {
             "type": "command",
             "command": "python3 C:/Users/brown/.claude/scripts/turn-count-hook.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/multi-worktree-alert.py"
           }
         ]
       }

--- a/docs/adr/001-hook-command-invocation.md
+++ b/docs/adr/001-hook-command-invocation.md
@@ -1,0 +1,55 @@
+# ADR 001 — Hook Command Invocation: Direct `python3` vs `bash -c` Wrapper
+
+**Date:** 2026-04-29  
+**Status:** Accepted
+
+---
+
+## Context
+
+Claude Code hook commands in `settings.json` are spawned by the Claude Code Desktop process, which runs in a non-interactive Windows context (not a Git Bash shell). This creates a PATH ambiguity for `python3`:
+
+- **Git Bash PATH** — resolves `python3` to the real Python binary managed by the user's shell profile.  
+- **Windows system PATH** — resolves `python3` to the Windows App Execution Alias stub (`C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\python3.exe`), which redirects to the Microsoft Store and cannot run scripts.
+
+Separately, `bash.exe` (Git Bash) is on the *Git Bash PATH* but **not** on the *Windows system PATH*.
+
+---
+
+## Decision History
+
+### 2026-04-19 — Wrapped in `bash -c '...'`
+
+All hook commands were wrapped as `bash -c 'python3 /path/to/script.py'` to re-enter the Git Bash PATH and avoid the Windows App Execution Alias stub.
+
+### 2026-04-27 — Removed `bash -c` wrapper (PR #81)
+
+The `bash -c` wrapper itself became the problem: Claude Code's hook runner could not locate `bash.exe` because it is not on the Windows system PATH. Every hook invocation failed, and `PreToolUse` failures blocked all `Bash` tool calls for the session.
+
+**Root cause:** `bash -c '...'` requires `bash` to be resolvable from the Windows system PATH. It is not — only Git Bash's own PATH (which the hook runner never loads) contains it.
+
+**Fix:** Removed the `bash -c` wrapper. Hook commands invoke `python3` directly, relying on Claude Code resolving it correctly.
+
+---
+
+## Decision
+
+Invoke hook scripts as **`python3 C:/path/to/script.py`** — no `bash -c` wrapper.
+
+If `python3` resolves to the Windows App Execution Alias stub in a future Claude Code version, the correct fix is to use an absolute path to the Python binary (e.g., `C:/Users/<user>/AppData/Local/Programs/Python/Python3x/python.exe`) — not to re-introduce the `bash -c` wrapper.
+
+---
+
+## Consequences
+
+- All hook entries in `settings.json` use bare `python3 C:/...` syntax.
+- Any new hook added to this repo must follow the same pattern — no `bash -c` wrapper.
+- If the Python resolution breaks again, check the Claude Code hook runner's PATH before adding wrappers.
+
+---
+
+## References
+
+- Engineering journal: `sessions/dev-env/2026-04-27-workflow-discipline-sprint.md` (root cause diagnosis)  
+- Engineering journal: `sessions/dev-env/2026-04-28-hook-fix-and-workflow-rules.md` (PR #81 review and merge)  
+- PR #81: `fix: remove bash -c wrapper from hook commands`


### PR DESCRIPTION
## Summary
- Adds `claude/scripts/multi-worktree-alert.py` — a `UserPromptSubmit` hook that runs `git worktree list --porcelain` and emits the full list of active branches when ≥2 worktrees are open for the current repo
- Current worktree is marked with `*asterisks*` in the message for quick scanning
- Wires the script into `claude/settings.json` under `UserPromptSubmit`
- Exits silently when only one worktree is active (no noise in normal single-session work)

## Test plan
- [x] Smoke-tested against dev-env (39 active worktrees): emits correct alert with current branch marked
- [x] Smoke-tested against non-git directory: exits silently
- [x] Smoke-tested from subdirectory within a worktree: correctly resolves parent worktree path

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)