### PR TITLE
docs: add Hook Safety section to CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -106,6 +106,32 @@ If the project has no automated tests, the section must say so explicitly and de
 
 ---
 
+## Hook Safety
+
+PreToolUse hooks that exit non-zero **block the matched tool call silently** — the user sees the
+tool refused with no error pointing to the hook. This has caused complete Bash outages more than
+once. Three invariants prevent recurrence:
+
+1. **Atomic commits.** A `settings.json` hook entry and its script file must land in the **same
+   commit**. Never push a settings.json change that references a script not yet in
+   `claude/scripts/` on main. Verify before committing:
+   ```bash
+   python3 claude/scripts/<new-hook>.py < /dev/null; echo "exit: $?"
+   # Must print "exit: 0"
+   ```
+
+2. **Safe-exit guard.** Advisory hooks (hooks that emit a systemMessage reminder but do not
+   intend to block) must exit 0 on **every** code path — happy path, empty stdin, malformed
+   JSON, and unhandled exception. Wrap stdin reading and JSON parsing in bare `try/except` that
+   calls `sys.exit(0)`. Never add `sys.exit(N)` where N > 0 to an advisory hook.
+
+3. **No `bash -c` wrappers.** Hook commands call the interpreter directly:
+   `python3 C:/Users/brown/.claude/scripts/foo.py` — never `bash -c 'python3 ...'`. The
+   wrapper adds an exit-code-propagation layer and can fail independently on Windows (quoting
+   issues, PATH differences). This was the root cause of dev-env#81.
+
+---
+
 ## Model Selection
 
 Route tasks to the least powerful model that can handle them reliably:

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -114,7 +114,9 @@ once. Three invariants prevent recurrence:
 
 1. **Atomic commits.** A `settings.json` hook entry and its script file must land in the **same
    commit**. Never push a settings.json change that references a script not yet in
-   `claude/scripts/` on main. Verify before committing:
+   `claude/scripts/` on main. Verify by running the script **from the dev-env repo root**
+   (not via `~/.claude/scripts/` — that junction resolves against the main worktree checkout,
+   not the branch being tested):
    ```bash
    python3 claude/scripts/<new-hook>.py < /dev/null; echo "exit: $?"
    # Must print "exit: 0"
@@ -122,8 +124,15 @@ once. Three invariants prevent recurrence:
 
 2. **Safe-exit guard.** Advisory hooks (hooks that emit a systemMessage reminder but do not
    intend to block) must exit 0 on **every** code path — happy path, empty stdin, malformed
-   JSON, and unhandled exception. Wrap stdin reading and JSON parsing in bare `try/except` that
-   calls `sys.exit(0)`. Never add `sys.exit(N)` where N > 0 to an advisory hook.
+   JSON, and unhandled exception. Use a top-level exception handler so no code path escapes:
+   ```python
+   if __name__ == "__main__":
+       try:
+           main()
+       except Exception:
+           sys.exit(0)
+   ```
+   Never add `sys.exit(N)` where N > 0 to an advisory hook.
 
 3. **No `bash -c` wrappers.** Hook commands call the interpreter directly:
    `python3 C:/Users/brown/.claude/scripts/foo.py` — never `bash -c 'python3 ...'`. The


### PR DESCRIPTION
## Summary

- Adds a `## Hook Safety` section to `claude/CLAUDE.md` documenting three invariants that prevent hook scripts from silently blocking all Bash tool calls
- Root cause documented: `settings.json` referencing a script before it's committed to the junction-resolved path causes Python to exit 2, which Claude Code treats as a PreToolUse block

## Three invariants

1. **Atomic commits** — script file + `settings.json` entry in the same commit, verified with `python3 <script> < /dev/null; echo "exit: $?"`
2. **Safe-exit guard** — advisory hooks exit 0 on every code path (empty stdin, malformed JSON, exceptions)
3. **No `bash -c` wrappers** — `python3 ...` directly, never `bash -c 'python3 ...'` (root cause of dev-env#81)

## Test plan

- [ ] Read the new `## Hook Safety` section in `claude/CLAUDE.md` — confirm three invariants are present
- [ ] Verify `claude/scripts/pre-pr-create-check.py` exists and `python3 pre-pr-create-check.py < /dev/null` exits 0
- [ ] Open a new Claude Code session and confirm Bash tool is not blocked

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)