### PR TITLE
docs: backfill ADRs 001–008 from engineering journal

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -7,6 +7,8 @@
 This file is loaded automatically in every session, across all projects.
 Project-specific CLAUDE.md files extend these conventions — they do not repeat them.
 
+> **ADRs:** The design decisions behind the rules in this file are recorded in [`docs/adr/`](../docs/adr/INDEX.md) in the dev-env repo. Consult the relevant ADR before overriding any rule, hook, skill, or config.
+
 ---
 
 ## Platform & Environment

--- a/docs/adr/001-per-session-stub-files.md
+++ b/docs/adr/001-per-session-stub-files.md
@@ -1,0 +1,39 @@
+# ADR 001 — Per-Session Stub Files for Journal Composition
+
+**Date:** 2026-03-27  
+**Status:** Accepted
+
+---
+
+## Context
+
+The original engineering journal approach used a single mutable draft file per day (`YYYY-MM-DD-draft.md`). All sessions on a given day appended to that one file. This created two problems:
+
+1. **Write contention:** Multiple parallel sessions (e.g., two PRs open simultaneously in separate worktrees) would overwrite each other's content on push.
+2. **Unstructured composition:** `/journal-compose` had to parse an unstructured, potentially inconsistent draft to produce the canonical day document. Any mid-session edit or partial commit left the draft in an ambiguous state.
+
+---
+
+## Decision
+
+Each session writes its own immutable stub file: `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md`, where `HHMMSS` is the UTC session start time. A companion `YYYY-MM-DD.manifest.jsonl` tracks session metadata (topic, tokens, PRs opened/closed) without reading individual stubs.
+
+`/journal-compose` discovers all stubs for a day via the manifest (or a glob fallback), merges them in order, and produces the canonical 11-section document at day end.
+
+---
+
+## Consequences
+
+- Parallel sessions never conflict — each writes to a unique filename.
+- Stubs are append-only and immutable after commit; no partial-write ambiguity.
+- Journal composition is always a dedicated, clean-slate operation (see ADR 002).
+- The manifest lets `/journal-compose` reconstruct session order and token data without reading stub content upfront.
+- Adding a session to an existing day requires only a new stub + manifest append — no rewrite of existing files.
+
+---
+
+## References
+
+- Engineering journal: `sessions/meta/2026-04-05-workflow-and-journal-setup.md` (stub structure documentation)
+- `dev-env` commit `1bd387f` — `feat: migrate journal workflow to per-session stub files`
+- `claude/skills/journal-compose/SKILL.md` — composition logic

--- a/docs/adr/002-journal-compose-session-isolation.md
+++ b/docs/adr/002-journal-compose-session-isolation.md
@@ -1,0 +1,43 @@
+# ADR 002 — Journal-Compose Session Isolation
+
+**Date:** 2026-04-04  
+**Status:** Accepted
+
+---
+
+## Context
+
+`/journal-compose` is a heavyweight operation: it reads all stub files for a day, cross-references open PRs, constructs the 11-section canonical document, updates READMEs, and opens a PR. Early usage ran it at the end of implementation sessions alongside other work. Two failure modes emerged:
+
+1. **Context contamination:** Implementation context (code, test output, PR diffs) inflated the session token budget and bled into the journal's "Reflection" and "Key Decisions" sections, producing inaccurate narratives.
+2. **Inconsistency:** Changes made after composition began (e.g., a PR merged mid-compose) were not captured, leaving the composed document out of date the moment it was written.
+
+---
+
+## Decision
+
+`/journal-compose` must run in a **dedicated session** with no prior work in that session. If composition is requested mid-session (after other work has been done), the response is:
+
+> "Journal composition must run in its own session. Open a new Claude Code session and invoke `/journal-compose` there."
+
+Then stop — do not compose.
+
+This rule is enforced both in `claude/CLAUDE.md` and as a hard check at Step 0 of the `journal-compose` skill.
+
+---
+
+## Consequences
+
+- Day-end journal composition always starts with a clean context window — lower token cost and higher accuracy.
+- Users must explicitly open a new session to compose; this is a deliberate friction point.
+- The skill's Step 0 check catches accidental in-session invocations before any reads are performed.
+- Review-only sessions (`/review <PR-URL>`) and push-only sessions (addressing review findings) are explicitly excluded from the auto-stub rule and do not trigger a new composition session.
+
+---
+
+## References
+
+- Engineering journal: `sessions/meta/2026-04-05-workflow-and-journal-setup.md` (composition rules)
+- `dev-env` commit `781da17` — `feat: enforce journal-compose session isolation`
+- `claude/skills/journal-compose/SKILL.md` — Step 0 isolation check
+- `claude/CLAUDE.md` § Engineering Journal — Composition rules

--- a/docs/adr/003-config-in-version-control.md
+++ b/docs/adr/003-config-in-version-control.md
@@ -1,0 +1,48 @@
+# ADR 003 — Config Artifacts in Version Control via Symlinks
+
+**Date:** 2026-04-13  
+**Status:** Accepted
+
+---
+
+## Context
+
+Claude Code's global configuration lives in `~/.claude/` by default. Files edited there are machine-local: invisible to git, unauditable, and prone to drift across reinstalls or machines. Early in this setup, CLAUDE.md and settings.json were edited directly at `~/.claude/`, and changes were occasionally lost or inconsistently applied across sessions.
+
+The challenge: Claude Code reads config from fixed paths (`~/.claude/CLAUDE.md`, `~/.claude/settings.json`) and there is no built-in mechanism to point it elsewhere.
+
+---
+
+## Decision
+
+All version-controlled Claude Code artifacts are maintained in the `dev-env` repo under `claude/` and **symlinked** into `~/.claude/`:
+
+| `~/.claude/` path | Source in `dev-env` |
+|---|---|
+| `CLAUDE.md` | `claude/CLAUDE.md` |
+| `settings.json` | `claude/settings.json` |
+| `scripts/` | `claude/scripts/` (directory junction) |
+| `skills/` | `claude/skills/` (directory junction) |
+| `hooks/` | `claude/hooks/` (directory junction) |
+| `scheduled-tasks/` | `claude/routines/` (directory junction) |
+
+Machine-local paths (`scratch/`, `projects/`, `plans/`, `sessions/`, `backups/`, `ide/`, `shell-snapshots/`) are excluded from version control and listed in `.gitignore`.
+
+`setup.sh` creates the symlinks/junctions on a fresh machine.
+
+---
+
+## Consequences
+
+- Every change to global Claude Code config must go through a `dev-env` PR — changes are auditable, reviewable, and rollback-able.
+- Editing `~/.claude/CLAUDE.md` directly is incorrect; the source of truth is `dev-env/claude/CLAUDE.md`. Both files carry a comment header warning against direct edits.
+- On Windows, directory junctions (`New-Item -ItemType Junction`) are used instead of symlinks for directories, because NTFS symlinks require elevated privileges.
+- Machine-local setup (first-time junction creation) is documented in `setup.sh` and must be re-run after a fresh clone.
+
+---
+
+## References
+
+- Engineering journal: `sessions/meta/2026-04-13-post-tool-use-hook-and-settings-into-dev-env.md`
+- `dev-env/setup.sh` — bootstrap script for symlinks/junctions
+- `claude/CLAUDE.md` § Dev-Env — symlink table and ownership rules

--- a/docs/adr/004-pr-review-reads-from-remote.md
+++ b/docs/adr/004-pr-review-reads-from-remote.md
@@ -1,0 +1,41 @@
+# ADR 004 — PR Review Reads from Remote, Not Local Worktree
+
+**Date:** 2026-04-17  
+**Status:** Accepted
+
+---
+
+## Context
+
+**Incident (lifting-logbook#86, commit `50f7ac6`):** A follow-up review session reported three findings as still open after a PR author had already committed fixes. The fixes existed on the remote PR branch, but the review step read files from the local working tree, which was checked out to a different branch. The report was wrong — all blockers had been addressed — but the incorrect report delayed the merge.
+
+Root cause: in a multi-worktree environment, the local working tree's branch at review time is not guaranteed to be the PR branch. Even without worktrees, a developer may have checked out another branch between the time the PR was pushed and the time the review runs.
+
+---
+
+## Decision
+
+When checking whether a PR has addressed review findings, or when reading PR branch file state for any reason:
+
+1. Run `git fetch origin <headRefName>` first.
+2. Read files via `git show origin/<branch>:<path>` — never from the local working tree.
+
+This rule applies to: review skill follow-up checks, merge-readiness assessments, and any step that compares "what the PR contains" against a checklist.
+
+---
+
+## Consequences
+
+- Every PR review follow-up begins with a `git fetch` — adds a small network round-trip but eliminates false "still open" results.
+- Local working tree state is irrelevant to PR review; the remote branch is authoritative.
+- The rule is codified in `claude/CLAUDE.md` § Git Workflow to ensure it is applied outside the review skill as well.
+- Multi-worktree setups are the highest-risk environment for this failure mode; the `multi-worktree-alert.py` hook (ADR 006 context) surfaces active worktrees on every prompt as a related safeguard.
+
+---
+
+## References
+
+- Engineering journal: `sessions/dev-env/2026-04-19-hook-infrastructure.md` (incident analysis)
+- `dev-env` commit `28f728e` — `fix: read PR branch state from remote, not local worktree`
+- `claude/CLAUDE.md` § Git Workflow — "PR branch state must come from the remote"
+- `claude/skills/review/SKILL.md` — review follow-up procedure

--- a/docs/adr/005-global-core-hooks-path.md
+++ b/docs/adr/005-global-core-hooks-path.md
@@ -1,0 +1,41 @@
+# ADR 005 — Global `core.hooksPath` for Cross-Repo Invariants
+
+**Date:** 2026-04-19  
+**Status:** Accepted
+
+---
+
+## Context
+
+Certain pre-push safety checks — specifically the squash-merge divergence guard — are needed in every repo, not just one. Git's per-repo `.git/hooks/pre-push` is not version-controlled and must be manually reinstalled after every clone. Committing hooks to individual repos couples global workflow rules to project-specific codebases.
+
+The alternative (a `post-clone` script or repo template) requires tooling outside the existing Claude Code setup and adds installation friction.
+
+---
+
+## Decision
+
+Set `git config --global core.hooksPath ~/.claude/hooks/` so all repos on the machine run hooks from a single version-controlled location.
+
+The global pre-push hook (`claude/hooks/pre-push`) chains to any per-repo `.git/hooks/pre-push` at the end of its execution, preserving compatibility with Husky, Lefthook, or corporate hook tooling already installed in individual repos.
+
+**Pre-existing `core.hooksPath` check:** Before setting, verify no system-level or tool-managed value already exists (`git config --system core.hooksPath`, `git config --global core.hooksPath`). If another tool owns the global value, coordinate rather than overwrite — two tools cannot share `core.hooksPath`.
+
+---
+
+## Consequences
+
+- All new cross-repo invariant checks go in `claude/hooks/`; they take effect in every repo without per-repo installation.
+- Per-repo hooks (`.git/hooks/`) continue to work — the global hook chains to them.
+- `setup.sh` sets `core.hooksPath` as part of the bootstrap sequence.
+- Hook scripts in `claude/hooks/` are version-controlled in dev-env and covered by ADR 003.
+- Hook commands in `settings.json` (Claude Code lifecycle hooks) are separate from git hooks and governed by ADR 007.
+
+---
+
+## References
+
+- Engineering journal: `sessions/dev-env/2026-04-19-hook-infrastructure.md`
+- `dev-env/setup.sh` — sets `core.hooksPath` during bootstrap
+- `claude/hooks/pre-push` — squash-merge divergence guard with per-repo chain
+- `claude/CLAUDE.md` § Git Workflow — "Pre-push hook wiring (one-time setup)"

--- a/docs/adr/006-dev-env-sync-on-every-prompt.md
+++ b/docs/adr/006-dev-env-sync-on-every-prompt.md
@@ -1,0 +1,38 @@
+# ADR 006 — UserPromptSubmit Dev-Env Sync on Every Prompt
+
+**Date:** 2026-04-19  
+**Status:** Accepted
+
+---
+
+## Context
+
+Claude Code reads `CLAUDE.md` once at session start and caches it. Changes committed to `dev-env` during a running session (e.g., a new rule added via PR in a parallel session) are invisible to the current session until it is restarted.
+
+In practice, dev-env changes happen frequently — especially during active workflow development — and restarting sessions to pick them up creates significant friction. The risk of running stale config is non-trivial: a hook removed in one session may still fire in another; a new rule documented in CLAUDE.md won't be followed until the session reads it.
+
+---
+
+## Decision
+
+`dev-env-sync.py` runs on every `UserPromptSubmit` hook. It auto-pulls the `dev-env` repo at `C:/Users/brown/Git/dev-env`, which causes `~/.claude/` symlink targets to reflect the latest committed state immediately — within the current session, without restart.
+
+**Failure mode handling:** The hook must fail open. A network failure, merge conflict, or git error must not block the session. `dev-env-sync.py` logs warnings on failure but exits 0 so the prompt is not blocked.
+
+---
+
+## Consequences
+
+- Commits to `dev-env` take effect in the current session on the next prompt — no session restart required.
+- Every prompt incurs a small network round-trip (a `git pull`). On a fast connection this is imperceptible; on a slow connection it adds latency.
+- The hook must not be removed to "improve performance" without understanding this tradeoff — stale config is a silent failure mode, not a visible one.
+- If dev-env has local uncommitted changes when the hook runs, the pull may produce a conflict. `dev-env-sync.py` should stash, pull, pop to handle this gracefully.
+
+---
+
+## References
+
+- Engineering journal: `sessions/dev-env/2026-04-19-hook-infrastructure.md`
+- `dev-env` commit `317639a` — `feat: auto-sync dev-env repo on every prompt to prevent stale CLAUDE.md`
+- `claude/scripts/dev-env-sync.py` — hook implementation
+- `claude/settings.json` — `UserPromptSubmit` hook registration

--- a/docs/adr/006-dev-env-sync-on-every-prompt.md
+++ b/docs/adr/006-dev-env-sync-on-every-prompt.md
@@ -26,7 +26,7 @@ In practice, dev-env changes happen frequently — especially during active work
 - Commits to `dev-env` take effect in the current session on the next prompt — no session restart required.
 - Every prompt incurs a small network round-trip (a `git pull`). On a fast connection this is imperceptible; on a slow connection it adds latency.
 - The hook must not be removed to "improve performance" without understanding this tradeoff — stale config is a silent failure mode, not a visible one.
-- If dev-env has local uncommitted changes when the hook runs, the pull may produce a conflict. `dev-env-sync.py` should stash, pull, pop to handle this gracefully.
+- The script only runs when `main` is checked out and only attempts a `--ff-only` pull. Because CLAUDE.md prohibits direct commits to `main`, local uncommitted changes on `main` are not an expected state; the pull failing due to a dirty tree would be caught by the existing "fast-forward pull failed" warning path.
 
 ---
 

--- a/docs/adr/007-hook-command-invocation.md
+++ b/docs/adr/007-hook-command-invocation.md
@@ -1,6 +1,6 @@
-# ADR 001 — Hook Command Invocation: Direct `python3` vs `bash -c` Wrapper
+# ADR 007 — Hook Command Invocation: Direct `python3` vs `bash -c` Wrapper
 
-**Date:** 2026-04-29  
+**Date:** 2026-04-27  
 **Status:** Accepted
 
 ---
@@ -9,7 +9,7 @@
 
 Claude Code hook commands in `settings.json` are spawned by the Claude Code Desktop process, which runs in a non-interactive Windows context (not a Git Bash shell). This creates a PATH ambiguity for `python3`:
 
-- **Git Bash PATH** — resolves `python3` to the real Python binary managed by the user's shell profile.  
+- **Git Bash PATH** — resolves `python3` to the real Python binary managed by the user's shell profile.
 - **Windows system PATH** — resolves `python3` to the Windows App Execution Alias stub (`C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\python3.exe`), which redirects to the Microsoft Store and cannot run scripts.
 
 Separately, `bash.exe` (Git Bash) is on the *Git Bash PATH* but **not** on the *Windows system PATH*.
@@ -50,6 +50,6 @@ If `python3` resolves to the Windows App Execution Alias stub in a future Claude
 
 ## References
 
-- Engineering journal: `sessions/dev-env/2026-04-27-workflow-discipline-sprint.md` (root cause diagnosis)  
-- Engineering journal: `sessions/dev-env/2026-04-28-hook-fix-and-workflow-rules.md` (PR #81 review and merge)  
+- Engineering journal: `sessions/dev-env/2026-04-27-workflow-discipline-sprint.md` (root cause diagnosis)
+- Engineering journal: `sessions/dev-env/2026-04-28-hook-fix-and-workflow-rules.md` (PR #81 review and merge)
 - PR #81: `fix: remove bash -c wrapper from hook commands`

--- a/docs/adr/007-hook-command-invocation.md
+++ b/docs/adr/007-hook-command-invocation.md
@@ -1,7 +1,8 @@
 # ADR 007 — Hook Command Invocation: Direct `python3` vs `bash -c` Wrapper
 
 **Date:** 2026-04-27  
-**Status:** Accepted
+**Status:** Accepted  
+**Formerly:** ADR 001 (renumbered 2026-04-29 to maintain chronological order)
 
 ---
 

--- a/docs/adr/008-plan-then-optimize-forcing-function.md
+++ b/docs/adr/008-plan-then-optimize-forcing-function.md
@@ -1,0 +1,39 @@
+# ADR 008 — Plan-Then-Optimize as an Embedded Skill Step
+
+**Date:** 2026-04-27  
+**Status:** Accepted
+
+---
+
+## Context
+
+The plan-then-optimize protocol — state a numbered plan, apply a token-efficiency revision pass, apply an outcome-correctness revision pass, then act — was documented in `claude/CLAUDE.md` as a required pre-execution step for any multi-step task.
+
+**Incident (dev-env#51):** A `/journal-compose` run spawned parallel agents that duplicated significant work. The plan-then-optimize protocol would have caught the redundancy in the efficiency pass, but it was skipped. Post-mortem finding: rules in documentation files rely on recall at execution time. Under time pressure or context load, recall fails.
+
+---
+
+## Decision
+
+**Step 0.5** (the plan-then-optimize protocol) was added directly to the `/journal-compose` skill execution path as an explicit, mandatory step that fires before any tool calls. The skill cannot proceed to Step 1 without completing Step 0.5.
+
+**Generalised pattern:** When a practice documented in CLAUDE.md is repeatedly missed in execution, the correct fix is to embed enforcement as an explicit step in the relevant skill or tool — not to restate or emphasise the rule in documentation. Documentation is for humans reading the file; forcing functions are for execution paths.
+
+---
+
+## Consequences
+
+- Any multi-step skill should include a mandatory planning step (named Step 0.5 by convention) near the top of its execution path.
+- Two copies of Step 0.5 exist in `journal-compose/SKILL.md` (main flow + subagent template). Differences between them are intentional and annotated with a sync comment — do not mechanically de-duplicate them.
+- The plan-then-optimize rule in `claude/CLAUDE.md` remains as human-readable documentation of the protocol's intent; the skill step is the enforcement mechanism.
+- New skills that involve Agent spawning or multi-file reads should include Step 0.5 at authoring time, not after a missed-protocol incident.
+
+---
+
+## References
+
+- Engineering journal: `sessions/meta/2026-04-27-validator-and-workflow-hardening.md`
+- `dev-env` commit `88f2650` — `feat: add Step 0.5 plan-then-optimize to journal-compose skill`
+- `dev-env` commit `d687709` — `feat: require plan-then-optimize pass before multi-step tasks` (original CLAUDE.md rule)
+- `claude/skills/journal-compose/SKILL.md` — Step 0.5 implementation
+- `claude/CLAUDE.md` § Context & Token Efficiency — plan-then-optimize protocol

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,0 +1,15 @@
+# Architectural Decision Records
+
+Design decisions behind the rules in `claude/CLAUDE.md`, hooks, skills, and configuration.
+Consult the relevant ADR before overriding any rule, hook, skill, or config.
+
+| # | Title | Date | Status |
+|---|-------|------|--------|
+| [001](001-per-session-stub-files.md) | Per-Session Stub Files for Journal Composition | 2026-03-27 | Accepted |
+| [002](002-journal-compose-session-isolation.md) | Journal-Compose Session Isolation | 2026-04-04 | Accepted |
+| [003](003-config-in-version-control.md) | Config Artifacts in Version Control via Symlinks | 2026-04-13 | Accepted |
+| [004](004-pr-review-reads-from-remote.md) | PR Review Reads from Remote, Not Local Worktree | 2026-04-17 | Accepted |
+| [005](005-global-core-hooks-path.md) | Global `core.hooksPath` for Cross-Repo Invariants | 2026-04-19 | Accepted |
+| [006](006-dev-env-sync-on-every-prompt.md) | UserPromptSubmit Dev-Env Sync on Every Prompt | 2026-04-19 | Accepted |
+| [007](007-hook-command-invocation.md) | Hook Command Invocation: Direct `python3` vs `bash -c` Wrapper | 2026-04-27 | Accepted |
+| [008](008-plan-then-optimize-forcing-function.md) | Plan-Then-Optimize as an Embedded Skill Step | 2026-04-27 | Accepted |


### PR DESCRIPTION
## Summary

- Reverse-engineers 8 architectural decisions from the engineering journal into authoritative ADRs in `docs/adr/`, numbered chronologically by decision date (Mar 27 – Apr 27 2026)
- Renames old `001-hook-command-invocation.md` → `007` to match chronological order
- Adds `docs/adr/INDEX.md` with a one-line summary table for all 8 ADRs
- Adds an ADR pointer callout to `claude/CLAUDE.md` so it's surfaced at every session start

**ADRs included:**
| # | Title | Date |
|---|-------|------|
| 001 | Per-Session Stub Files for Journal Composition | Mar 27 |
| 002 | Journal-Compose Session Isolation | Apr 4 |
| 003 | Config Artifacts in Version Control via Symlinks | Apr 13 |
| 004 | PR Review Reads from Remote, Not Local Worktree | Apr 17 |
| 005 | Global `core.hooksPath` for Cross-Repo Invariants | Apr 19 |
| 006 | UserPromptSubmit Dev-Env Sync on Every Prompt | Apr 19 |
| 007 | Hook Command Invocation: Direct `python3` vs `bash -c` Wrapper | Apr 27 |
| 008 | Plan-Then-Optimize as an Embedded Skill Step | Apr 27 |

## Test plan

- [x] `ls docs/adr/` shows 9 files (INDEX.md + 001–008) ✓
- [x] INDEX.md links resolve to each ADR file (no broken filenames) ✓
- [x] Each ADR references at least one journal file or PR/commit ✓
- [x] `claude/CLAUDE.md` renders the ADR callout correctly ✓
- No automated test suite in dev-env; visual diff review is sufficient

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)