### PR TITLE
feat: once-per-session journal hook + Stop hook for session-close reminder

### DIFF
--- a/claude/scripts/journal-stop-check.py
+++ b/claude/scripts/journal-stop-check.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Stop hook: remind user of stale journal work at session end.
+
+Two checks (same logic as new-day-journal-check.py):
+1. Stale *_draft.md / *.stub.md files from before today
+2. Unmerged remote draft/* branches
+
+Also cleans up orphaned draft files: physical files left on disk as untracked
+after git rm. This prevents new-day-journal-check.py false positives on the
+next session (see dev-env#31).
+
+Exit 0 always — never block session close.
+Stdout is shown to user as a closing message.
+"""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
+TODAY = date.today().strftime("%Y-%m-%d")
+
+
+def stale_draft_artifacts() -> list[str]:
+    """Return paths of *_draft.md or *.stub.md files from before today."""
+    artifacts = []
+    for pattern in (
+        str(JOURNAL_REPO / "sessions" / "**" / "*_draft.md"),
+        str(JOURNAL_REPO / "sessions" / "**" / "????-??-??_*.stub.md"),
+    ):
+        artifacts.extend(glob.glob(pattern, recursive=True))
+    stale = [f for f in artifacts if not os.path.basename(f).startswith(TODAY)]
+    stale.sort(key=lambda f: os.path.basename(f), reverse=True)
+    return stale
+
+
+def composed_dates_on_main() -> set[str]:
+    """Return YYYY-MM-DD dates that have a composed journal file on origin/main."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", "origin/main", "sessions/"],
+            cwd=JOURNAL_REPO,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        dates = set()
+        for line in result.stdout.splitlines():
+            fname = line.split("/")[-1]
+            if fname.endswith(".stub.md") or not fname.endswith(".md"):
+                continue
+            if len(fname) >= 10 and fname[4] == "-" and fname[7] == "-":
+                dates.add(fname[:10])
+        return dates
+    except Exception:
+        return set()
+
+
+def unmerged_draft_branches() -> list[str]:
+    """Return remote draft/* branch names not yet merged into origin/main."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", "refs/heads/draft/*"],
+            cwd=JOURNAL_REPO,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        remote_dates = set()
+        for line in result.stdout.splitlines():
+            if "\t" in line:
+                ref = line.split("\t", 1)[1].strip()
+                remote_dates.add(ref.replace("refs/heads/draft/", ""))
+
+        if not remote_dates:
+            return []
+
+        merged = composed_dates_on_main()
+        unmerged = sorted(
+            [d for d in remote_dates if d != TODAY and d not in merged],
+            reverse=True,
+        )
+        return unmerged
+    except Exception:
+        return []
+
+
+def remove_orphaned_drafts(stale: list[str]) -> list[str]:
+    """Delete stale draft files that are untracked (orphaned after git rm)."""
+    removed = []
+    for path_str in stale:
+        try:
+            result = subprocess.run(
+                ["git", "status", "--porcelain", path_str],
+                cwd=JOURNAL_REPO,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.stdout.startswith("??"):
+                os.remove(path_str)
+                removed.append(path_str)
+        except Exception:
+            pass
+    return removed
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read().strip()
+    except Exception:
+        raw = ""
+    # session_id / transcript_path available if needed in future
+    json.loads(raw) if raw else {}
+
+    messages = []
+
+    stale = stale_draft_artifacts()
+
+    removed = remove_orphaned_drafts(stale)
+    for path_str in removed:
+        messages.append(
+            f"[journal-stop-hook] Removed orphaned draft: {Path(path_str).as_posix()}"
+        )
+
+    # After removing orphans, re-evaluate what's still stale
+    still_stale = [f for f in stale if f not in removed]
+
+    if still_stale:
+        artifact_path = Path(still_stale[0]).as_posix()
+        artifact_date = os.path.basename(still_stale[0])[:10]
+        messages.append(
+            f"[journal-stop-hook] Stale draft artifact: {artifact_path}\n"
+            f"The engineering journal draft from {artifact_date} was never composed.\n"
+            f"Run /journal-compose in a new session to close it out."
+        )
+
+    unmerged = unmerged_draft_branches()
+    if unmerged:
+        dates_str = ", ".join(unmerged)
+        messages.append(
+            f"[journal-stop-hook] Unmerged draft branch(es): {dates_str}\n"
+            f"These branches still need a PR merged to main."
+        )
+
+    if messages:
+        print("\n".join(messages))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/journal-stop-check.py
+++ b/claude/scripts/journal-stop-check.py
@@ -116,7 +116,6 @@ def main() -> None:
     except Exception:
         raw = ""
     # session_id / transcript_path available if needed in future
-    json.loads(raw) if raw else {}
 
     messages = []
 

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -13,14 +13,28 @@ Stdout is injected as context Claude sees before processing the user's message.
 """
 
 import glob
+import json
 import os
 import subprocess
 import sys
+import time
 from datetime import date
 from pathlib import Path
 
 JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
+SCRATCH = Path.home() / ".claude" / "scratch"
 TODAY = date.today().strftime("%Y-%m-%d")
+FLAG_MAX_AGE_HOURS = 24
+
+
+def cleanup_stale_flags() -> None:
+    cutoff = time.time() - FLAG_MAX_AGE_HOURS * 3600
+    try:
+        for f in SCRATCH.glob("journal_hook_*.flag"):
+            if f.stat().st_mtime < cutoff:
+                f.unlink(missing_ok=True)
+    except Exception:
+        pass
 
 
 def stale_draft_artifacts() -> list[str]:
@@ -108,11 +122,20 @@ def unmerged_draft_branches() -> list[str]:
 
 
 def main() -> None:
-    # Consume stdin (UserPromptSubmit sends JSON; we don't need the contents).
+    raw = ""
     try:
-        sys.stdin.read()
+        raw = sys.stdin.read().strip()
     except Exception:
         pass
+    hook_data = json.loads(raw) if raw else {}
+    session_id = hook_data.get("session_id", "")
+
+    cleanup_stale_flags()
+
+    if session_id:
+        flag_path = SCRATCH / f"journal_hook_{session_id}.flag"
+        if flag_path.exists():
+            sys.exit(0)
 
     messages = []
 
@@ -138,6 +161,11 @@ def main() -> None:
 
     if messages:
         print("\n".join(messages))
+        if session_id:
+            try:
+                (SCRATCH / f"journal_hook_{session_id}.flag").touch()
+            except Exception:
+                pass
 
     sys.exit(0)
 

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -171,4 +171,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -44,6 +44,10 @@
           {
             "type": "command",
             "command": "python3 C:/Users/brown/.claude/scripts/token-tracker.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/journal-stop-check.py"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `new-day-journal-check.py` now fires at most once per session by writing a `~/.claude/scratch/journal_hook_<session_id>.flag` on first emission; flag files older than 24 h are pruned at startup
- New `journal-stop-check.py` Stop hook re-runs the same stale-draft and unmerged-branch checks at session end, plus removes orphaned draft files left as untracked after `git rm` (prevents false positives per #31)
- `settings.json` updated to register the new Stop hook alongside `token-tracker.py`

## Test plan

- [ ] `python3 claude/scripts/new-day-journal-check.py < /dev/null; echo "exit: $?"` → exit: 0
- [ ] `python3 claude/scripts/journal-stop-check.py < /dev/null; echo "exit: $?"` → exit: 0
- [ ] Start a fresh session with a stale draft present: first prompt shows `[journal-hook]` message; second prompt in same session is silent
- [ ] End a session with a stale draft present: closing `[journal-stop-hook]` message appears
- [ ] End a clean session: no output from either hook

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)