### PR TITLE
[feat] Make /propose skill repo-portable via per-project config

### DIFF
--- a/claude/skills/propose/SKILL.md
+++ b/claude/skills/propose/SKILL.md
@@ -219,12 +219,17 @@ gh issue create \
 gh issue edit <N> --milestone "<milestone-title>" -R <config.github_repo>
 ```
 
-**Only if** `config.github_project` is non-null:
+**Only if** `config.github_project` is non-null **and** `config.github_project.node_id` is non-empty:
 
 Run the project/epic assignment workflow from the project CLAUDE.md (it contains the exact
 field IDs and option IDs for this repo's project):
 1. Add issue to project and capture item ID
 2. Set the Epic field using the option ID for the chosen epic
+
+If `config.github_project` is non-null but `node_id` or `epic_field_id` is empty, skip
+project assignment and tell the user: "GitHub Project field IDs are not yet configured in
+`.claude/propose.json` — fill in `node_id` and `epic_field_id`, then assign the project
+manually."
 
 After the issue is created, update the `**Issue:**` line in the proposal file with the issue
 number and URL.
@@ -235,8 +240,11 @@ number and URL.
 
 **Skip this step entirely if** `config.roadmap_file` is null.
 
-Read `<config.roadmap_file>`. Find the section for the milestone chosen in Step 4 (or the
-first proposals table if no milestones are configured).
+Read `<config.roadmap_file>`.
+
+- If a milestone was chosen in Step 4, find that milestone's section and insert there.
+- If `config.milestones` is empty, find the first existing proposals table in the file and
+  insert there. If no proposals table exists anywhere in the file, append one at the end.
 
 Add a new row:
 

--- a/claude/skills/propose/SKILL.md
+++ b/claude/skills/propose/SKILL.md
@@ -1,12 +1,105 @@
 ---
 name: propose
-description: One-sentence idea → PRD in docs/proposals/ → linked GitHub issue → ROADMAP.md update. Run from the lifting-logbook repo root on a clean working tree.
+description: One-sentence idea → PRD → linked GitHub issue → ROADMAP entry. Reads per-project config from .claude/propose.json; scaffolds config interactively for unconfigured repos.
 argument-hint: "<one-line idea>"
 allowed-tools: Read Edit Write Bash Glob Grep
 ---
 
 You are implementing the `/propose` workflow: expand a one-line idea into a proposal document,
 create the linked GitHub issue, and update the roadmap. Follow every step in order.
+
+---
+
+## Step 0 — Detect project context
+
+Run:
+```bash
+cat .claude/propose.json 2>/dev/null
+```
+
+### If the file exists
+
+Read it. All subsequent steps use these keys from the config object (referred to below as
+`config`):
+
+| Key | Type | Used in |
+|---|---|---|
+| `proposals_dir` | string | Steps 7, 8, 9, 10 |
+| `roadmap_file` | string \| null | Steps 4, 9 |
+| `prd_file` | string \| null | Step 3 |
+| `github_repo` | string | Steps 8, 11 |
+| `milestones` | string[] | Step 4 |
+| `epics` | {name, id}[] | Step 4 |
+| `github_project` | object \| null | Step 8 |
+
+Proceed to Step 1.
+
+### If the file does not exist
+
+Present the user with three options:
+
+> **No `/propose` config found for this repo.** Choose how to proceed:
+>
+> **A — Scaffold full infrastructure** (proposals directory, ROADMAP.md stub, full config)
+> **B — Minimal setup** (proposals directory + GitHub issues only; no roadmap, no project assignment)
+> **C — Exit** — I'll configure `.claude/propose.json` manually and run `/propose` again.
+
+**Option A — Scaffold full infrastructure:**
+
+1. Ask:
+   - "What is the GitHub repo? (format: owner/repo)"
+   - "Do you have a GitHub Project set up for this repo? If yes, what is its number?"
+2. Create `docs/proposals/` directory and `docs/proposals/README.md`:
+   ```
+   # Proposals
+
+   Feature proposals for this project. Each file is a PRD-lite document linked to a GitHub issue.
+   Files follow the naming convention `YYYY-MM-DD-<slug>.md`.
+   ```
+3. Create a `ROADMAP.md` stub if none exists:
+   ```markdown
+   # Roadmap
+
+   _This file is the editorial view of planned and in-progress work. It is not auto-synced from GitHub._
+
+   ## Proposals
+
+   | Proposal | Description | Issue |
+   |---|---|---|
+   ```
+4. Read `~/.claude/templates/propose-config.json` and populate `github_repo` from the answer
+   above. If the user provided a project number, set `github_project.number` and
+   `github_project.owner` (the owner segment of `github_repo`); otherwise set
+   `github_project` to `null`.
+5. Write the populated object to `.claude/propose.json`.
+6. Tell the user:
+   > "Scaffold complete. Commit `.claude/propose.json` (and `ROADMAP.md` if new) before your
+   > next `/propose` run so the config is version-controlled."
+7. Use the newly written config for the rest of this session. Proceed to Step 1.
+
+**Option B — Minimal setup:**
+
+1. Ask:
+   - "Where should proposals live? (default: `docs/proposals/`)"
+   - "What is the GitHub repo? (format: owner/repo)"
+2. Write `.claude/propose.json`:
+   ```json
+   {
+     "proposals_dir": "<answer or docs/proposals>",
+     "roadmap_file": null,
+     "prd_file": null,
+     "github_repo": "<answer>",
+     "milestones": [],
+     "epics": [],
+     "github_project": null
+   }
+   ```
+3. Tell the user:
+   > "Minimal config written. Steps that require a roadmap or GitHub Project will be skipped.
+   > Commit `.claude/propose.json` before your next `/propose` run."
+4. Proceed to Step 1.
+
+**Option C:** Stop. Return the message above and exit.
 
 ---
 
@@ -26,45 +119,35 @@ from the one-liner. Typical questions:
 - What would "done" look like? (anchor for acceptance criteria)
 - Is anything explicitly out of scope?
 
-Skip any question whose answer is already obvious from the idea or from `docs/PRD.md`.
+Skip any question whose answer is already obvious from the idea.
+If `config.prd_file` is non-null, skip questions answerable from that file (read it in Step 3).
 Skip questions the user has already answered in their opening message.
 
 ---
 
 ## Step 3 — Read supporting files
 
-Read these two files before drafting:
+Read these files before drafting:
 
 1. The master proposal template:
    ```bash
    cat ~/.claude/templates/proposal.md
    ```
 
-2. The project PRD (for persona and milestone context):
+2. The project PRD (for persona and milestone context) — **only if** `config.prd_file` is non-null:
    ```bash
-   cat docs/PRD.md
+   cat <config.prd_file>
    ```
 
 ---
 
 ## Step 4 — Collect metadata
 
-Ask the user to choose:
+**Only if** `config.milestones` is non-empty, ask the user to choose a milestone from the list.
 
-**Milestone** (pick one):
-- `v0.1 — Foundation`
-- `v0.2 — Core API`
-- `v0.3 — Client Applications`
+**Only if** `config.epics` is non-empty, ask the user to choose an epic from the list.
 
-**Epic** (pick one):
-- Monorepo Scaffolding
-- Package & App Scaffolding
-- Port Interfaces
-- Shared Types
-- CI/CD Foundation
-- Architecture & Documentation
-
-The epic option IDs (needed later for GitHub project assignment) are in `CLAUDE.md`.
+If both lists are empty (minimal config), skip this step entirely.
 
 ---
 
@@ -74,7 +157,7 @@ Using the template from Step 3 and the answers from Steps 1–4, compose the ful
 
 Produce:
 - A **slug**: lowercase, hyphens, 3–5 words (e.g., `bodyweight-exercise-tracking`)
-- A **filename**: `docs/proposals/YYYY-MM-DD-<slug>.md` (use today's date)
+- A **filename**: `<config.proposals_dir>/YYYY-MM-DD-<slug>.md` (use today's date)
 - The **full proposal document**, filled in from the template
 
 Show the draft to the user. Ask: "Does this look right? Any edits before I write the file?"
@@ -104,10 +187,10 @@ git checkout -b docs/propose-<slug>
 ## Step 7 — Write the proposal file
 
 ```bash
-mkdir -p docs/proposals
+mkdir -p <config.proposals_dir>
 ```
 
-Write the confirmed proposal to `docs/proposals/YYYY-MM-DD-<slug>.md`.
+Write the confirmed proposal to `<config.proposals_dir>/YYYY-MM-DD-<slug>.md`.
 
 ---
 
@@ -120,38 +203,48 @@ from the proposal, then append:
 
 ```
 ---
-Proposal: [docs/proposals/YYYY-MM-DD-<slug>.md](docs/proposals/YYYY-MM-DD-<slug>.md)
+Proposal: [<config.proposals_dir>/YYYY-MM-DD-<slug>.md](<config.proposals_dir>/YYYY-MM-DD-<slug>.md)
 ```
 
 Create the issue:
 ```bash
 gh issue create \
-  -R brownm09/lifting-logbook \
+  -R <config.github_repo> \
   --title "[feat] <title>" \
   --body "..."
 ```
 
-Then run the full project/milestone/epic assignment workflow from `CLAUDE.md`:
-1. Set milestone: `gh issue edit <N> --milestone "<milestone-title>"`
-2. Add to project and capture item ID
-3. Set Epic field with the option ID for the chosen epic
+**Only if** a milestone was chosen in Step 4:
+```bash
+gh issue edit <N> --milestone "<milestone-title>" -R <config.github_repo>
+```
 
-After the issue is created and assigned, update the `**Issue:**` line in the proposal file
-with the issue number and URL.
+**Only if** `config.github_project` is non-null:
+
+Run the project/epic assignment workflow from the project CLAUDE.md (it contains the exact
+field IDs and option IDs for this repo's project):
+1. Add issue to project and capture item ID
+2. Set the Epic field using the option ID for the chosen epic
+
+After the issue is created, update the `**Issue:**` line in the proposal file with the issue
+number and URL.
 
 ---
 
-## Step 9 — Update ROADMAP.md
+## Step 9 — Update ROADMAP
 
-Read `ROADMAP.md`. Find the section for the milestone chosen in Step 4.
+**Skip this step entirely if** `config.roadmap_file` is null.
 
-Add a new row to that milestone's proposal table:
+Read `<config.roadmap_file>`. Find the section for the milestone chosen in Step 4 (or the
+first proposals table if no milestones are configured).
+
+Add a new row:
 
 ```
-| [<Title>](docs/proposals/YYYY-MM-DD-<slug>.md) | <one-line description> | [#N](<issue-url>) |
+| [<Title>](<config.proposals_dir>/YYYY-MM-DD-<slug>.md) | <one-line description> | [#N](<issue-url>) |
 ```
 
-If the milestone section has no proposal table yet, add one before adding the row:
+If no proposals table exists yet in the target section, add one before the row:
 
 ```markdown
 | Proposal | Description | Issue |
@@ -162,8 +255,18 @@ If the milestone section has no proposal table yet, add one before adding the ro
 
 ## Step 10 — Commit and push
 
+Stage the proposal file and, if updated, the roadmap:
+
 ```bash
-git add docs/proposals/YYYY-MM-DD-<slug>.md ROADMAP.md
+git add <config.proposals_dir>/YYYY-MM-DD-<slug>.md
+```
+
+If `config.roadmap_file` is non-null:
+```bash
+git add <config.roadmap_file>
+```
+
+```bash
 git commit -m "$(cat <<'EOF'
 [docs] Propose: <title>
 
@@ -185,7 +288,7 @@ This is a docs PR — use the "Docs / proposal PR" pattern.
 
 ```bash
 gh pr create \
-  -R brownm09/lifting-logbook \
+  -R <config.github_repo> \
   --title "[docs] Propose: <title>" \
   --body "..."
 ```

--- a/claude/templates/propose-config.json
+++ b/claude/templates/propose-config.json
@@ -1,0 +1,14 @@
+{
+  "proposals_dir": "docs/proposals",
+  "roadmap_file": "ROADMAP.md",
+  "prd_file": "docs/PRD.md",
+  "github_repo": "OWNER/REPO",
+  "milestones": [],
+  "epics": [],
+  "github_project": {
+    "number": 0,
+    "owner": "OWNER",
+    "node_id": "",
+    "epic_field_id": ""
+  }
+}


### PR DESCRIPTION
## Summary

- Adds Step 0 to `/propose` that reads `.claude/propose.json`; all hardcoded lifting-logbook values (file paths, milestone/epic lists, GitHub repo/project IDs) are replaced with config-derived variables
- When no config exists, the skill offers three paths: scaffold full infrastructure (A), minimal config (B), or exit (C)
- Adds `claude/templates/propose-config.json` as the scaffold template written during Option A
- Steps dependent on nullable config keys (`roadmap_file`, `epics`, `github_project`) are gated and skipped gracefully when those keys are null

## Acceptance Criteria

- [x] `/propose` reads `.claude/propose.json` when present; all hardcoded lifting-logbook values replaced
- [x] When no config exists, skill presents options A / B / C
- [x] Option A scaffold flow documented (creates proposals dir, ROADMAP stub, config from template)
- [x] Option B minimal flow documented (proposals dir + issues only)
- [x] Steps gated on nullable config keys skip cleanly when null
- [x] `claude/templates/propose-config.json` added
- [x] Skill `description` frontmatter no longer references lifting-logbook

## Test plan

- Run `/propose` in lifting-logbook (which will have `.claude/propose.json` added in a companion PR) — behavior should be identical to today
- Run `/propose` in dev-env (no config) — should present A/B/C options; C exits cleanly

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)