### PR TITLE
feat: add PostCompact hook to surface compaction output

### DIFF
--- a/claude/scripts/post-compact.py
+++ b/claude/scripts/post-compact.py
@@ -13,14 +13,19 @@ def main():
     summary = data.get("summary", "")
     tokens = data.get("context_tokens", None)
 
-    label = "[compact]" if trigger == "manual" else "[auto-compact]"
+    if trigger == "manual":
+        label = "[compact]"
+    elif trigger == "auto":
+        label = "[auto-compact]"
+    else:
+        label = f"[compact/{trigger}]"
     if tokens is not None:
         print(f"{label} done -- context now {tokens:,} tokens", file=sys.stderr)
     else:
         print(f"{label} done", file=sys.stderr)
 
     if summary:
-        first_line = summary.splitlines()[0][:120]
+        first_line = summary.splitlines()[0].strip()[:120]
         print(f"  summary: {first_line}", file=sys.stderr)
 
 

--- a/claude/scripts/post-compact.py
+++ b/claude/scripts/post-compact.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""PostCompact hook — emit a status line so compaction is visible in all environments."""
+import json
+import sys
+
+
+def main():
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return
+    data = json.loads(raw)
+    trigger = data.get("trigger", "unknown")   # "manual" | "auto"
+    summary = data.get("summary", "")
+    tokens = data.get("context_tokens", None)
+
+    label = "[compact]" if trigger == "manual" else "[auto-compact]"
+    if tokens is not None:
+        print(f"{label} done -- context now {tokens:,} tokens", file=sys.stderr)
+    else:
+        print(f"{label} done", file=sys.stderr)
+
+    if summary:
+        first_line = summary.splitlines()[0][:120]
+        print(f"  summary: {first_line}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -52,6 +52,16 @@
         ]
       }
     ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/post-compact.py"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Problem

Running `/compact` (or auto-compaction) works but produces no visible output in git worktree / Agent SDK environments. Claude Code renders the compaction summary as a VSCode UI card — in terminal-only contexts that card never appears, so the user sees nothing (or a truncated `Compacted ` string with no continuation).

Root cause confirmed: no existing hooks suppress output. The issue is architectural — the compaction signal exists only in the VSCode UI surface.

## Solution

Wire a `PostCompact` lifecycle hook (`post-compact.py`) that writes a one-line status to stderr, visible in every execution context.

**Example output after `/compact`:**
```
[compact] done -- context now 12,500 tokens
  summary: Prior context condensed...
```

## Changes

- `claude/scripts/post-compact.py` — new hook script; advisory only (exits 0 on all paths)
- `claude/settings.json` — adds `PostCompact` entry; both files in same commit (Hook Safety rule)

## Testing

```bash
# Syntax check (project test command)
python3 -m py_compile claude/scripts/post-compact.py
# → syntax OK ✓

# Safe-exit check (empty stdin)
python3 claude/scripts/post-compact.py < /dev/null; echo "exit: $?"
# → exit: 0 ✓

# Smoke test — manual trigger
echo '{"trigger":"manual","context_tokens":12500,"summary":"Prior context condensed."}'   | python3 claude/scripts/post-compact.py
# → [compact] done -- context now 12,500 tokens ✓

# Smoke test — auto trigger
echo '{"trigger":"auto","context_tokens":8200,"summary":"Session summarized."}'   | python3 claude/scripts/post-compact.py
# → [auto-compact] done -- context now 8,200 tokens ✓
```

All tests passed.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)