### PR TITLE
feat: repo context in worktree alert + auto-archive after stub push

### DIFF
--- a/claude/scripts/multi-worktree-alert.py
+++ b/claude/scripts/multi-worktree-alert.py
@@ -22,6 +22,19 @@ import sys
 from pathlib import Path
 
 
+def repo_name_from_path(path: str) -> str:
+    """Extract the repository directory name from a worktree path.
+
+    Linked worktrees live under <repo>/.claude/worktrees/<name> — walk up past
+    those three components.  Main worktrees ARE the repo root.
+    """
+    parts = Path(path).parts
+    for i, part in enumerate(parts):
+        if part == "worktrees" and i >= 2 and parts[i - 1] == ".claude":
+            return parts[i - 2]
+    return Path(path).name
+
+
 def parse_worktree_list(output: str) -> list[dict]:
     """Parse `git worktree list --porcelain` output into a list of dicts.
 
@@ -96,10 +109,15 @@ def main() -> None:
 
     labeled = []
     for wt in worktrees:
-        name = wt["branch"] or "<unknown>"
+        repo = repo_name_from_path(wt["path"])
+        name = f"{repo}:{wt['branch'] or '<unknown>'}"
         labeled.append(f"*{name}*" if wt is current else name)
 
-    location = "current unknown" if current is None else f"on *{current['branch'] or '<unknown>'}*"
+    if current is None:
+        location = "current unknown"
+    else:
+        repo = repo_name_from_path(current["path"])
+        location = f"on *{repo}:{current['branch'] or '<unknown>'}*"
     msg = f"[worktree-alert] {len(worktrees)} active worktrees ({location}): {', '.join(labeled)}"
     print(json.dumps({"systemMessage": msg}))
     sys.exit(0)

--- a/claude/scripts/stub-push-archive-reminder.py
+++ b/claude/scripts/stub-push-archive-reminder.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""PostToolUse/Bash hook — remind Claude to archive the session after a stub
+is pushed to engineering-journal.
+
+Fires on every Bash tool call. Most calls are skipped quickly:
+  1. Command must contain "git push"
+  2. Command must reference the engineering-journal repo
+  3. Push must have succeeded (no error output)
+  4. Most-recent commit in engineering-journal must touch a .stub.md file
+
+When all four conditions are met, exits 2 with a systemMessage prompting
+Claude to call ccd_session_mgmt__archive_session before stopping.
+
+Exit 0 on every non-trigger path and on any exception — never blocks.
+
+Stdin JSON shape (PostToolUse):
+  {
+    "hook_event_name": "PostToolUse",
+    "tool_name": "Bash",
+    "tool_input": {"command": "...", ...},
+    "tool_response": {"output": "...", ...}
+  }
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
+
+
+def most_recent_commit_has_stub(repo: Path) -> bool:
+    """Return True if HEAD commit in the repo touches at least one .stub.md file."""
+    try:
+        result = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "-r", "--name-only", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0 and any(
+            line.endswith(".stub.md") for line in result.stdout.splitlines()
+        )
+    except Exception:
+        return False
+
+
+def main() -> None:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        sys.exit(0)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    command = (data.get("tool_input") or {}).get("command", "")
+    output = str((data.get("tool_response") or {}).get("output", ""))
+
+    # Must be a git push
+    if "git push" not in command:
+        sys.exit(0)
+
+    # Must reference engineering-journal
+    if "engineering-journal" not in command and "engineering_journal" not in command:
+        sys.exit(0)
+
+    # Must not show an obvious error
+    lower_output = output.lower()
+    if "error:" in lower_output or "fatal:" in lower_output:
+        sys.exit(0)
+
+    # Confirm the pushed commit contains a stub file
+    if not most_recent_commit_has_stub(JOURNAL_REPO):
+        sys.exit(0)
+
+    msg = (
+        "Stub committed and pushed to engineering-journal. "
+        "Archive this session now: call ccd_session_mgmt__archive_session "
+        "(use list_sessions to look up the current session_id if needed). "
+        "Then stop."
+    )
+    print(json.dumps({"systemMessage": msg}))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -52,6 +52,16 @@
         ]
       }
     ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/post-compact.py"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",
@@ -67,6 +77,10 @@
           {
             "type": "command",
             "command": "python3 C:/Users/brown/.claude/scripts/post-pr-merge-pull.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/stub-push-archive-reminder.py"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -52,16 +52,6 @@
         ]
       }
     ],
-    "PostCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 C:/Users/brown/.claude/scripts/post-compact.py"
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary

- **Repo context in worktree alert** ([#120](https://github.com/brownm09/dev-env/issues/120)): `multi-worktree-alert.py` now prefixes each entry with `repo:branch` (e.g., `dev-env:claude/adoring-jones-b71b4d`) so you can see at a glance which repo a session belongs to — no more guessing from branch names alone.

- **Auto-archive after stub push** ([#121](https://github.com/brownm09/dev-env/issues/121)): new `stub-push-archive-reminder.py` PostToolUse/Bash hook detects a successful `git push` to `engineering-journal` whose HEAD commit contains a `.stub.md` file, then exits 2 to prompt Claude to call `ccd_session_mgmt__archive_session`. Sessions clean themselves up after the journal stub is written.

## Changes

| File | Change |
|---|---|
| `claude/scripts/multi-worktree-alert.py` | Add `repo_name_from_path()`, update label/location strings |
| `claude/scripts/stub-push-archive-reminder.py` | New PostToolUse hook |
| `claude/settings.json` | Register new hook under `PostToolUse → Bash` |

## Test plan

- [x] `python3 claude/scripts/multi-worktree-alert.py < /dev/null` exits 0
- [x] `python3 claude/scripts/stub-push-archive-reminder.py < /dev/null` exits 0
- [ ] Open a second worktree in dev-env and confirm `[worktree-alert]` shows `dev-env:branch` format
- [ ] After a PR merge + stub push, confirm archive reminder fires before session ends
- [ ] Confirm no false-positive archive reminders on unrelated `git push` calls

Closes #120, Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)