### PR TITLE
docs: add REFERENCE.md, expand README tables, and add doc-maintenance rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# dev-env — Project Instructions
+
+The global Claude Code configuration lives in [`claude/CLAUDE.md`](claude/CLAUDE.md),
+symlinked to `~/.claude/CLAUDE.md`. All workflow rules, hook invariants, model selection
+guidelines, and journal conventions are defined there and apply to every project.
+
+## Reference Documentation
+
+| Doc | Purpose |
+|---|---|
+| [README.md](README.md) | Quick-reference tables for skills, hooks, and routines |
+| [docs/REFERENCE.md](docs/REFERENCE.md) | Detailed descriptions, invocation syntax, config options, and ADR links |
+| [docs/adr/](docs/adr/) | Design decisions behind rules in `claude/CLAUDE.md` |
+
+## Testing
+
+Run from the repo root to verify all hook scripts are syntax-clean:
+
+```bash
+python3 -m py_compile claude/scripts/*.py
+```
+
+For docs-only changes to `claude/CLAUDE.md`: run `grep -n 'date -u' claude/CLAUDE.md` and
+confirm every match is in an internal operational artifact context (lock files, log timestamps)
+— not in stub filename or branch name descriptions.
+
+## Documentation Maintenance
+
+When a PR modifies any of the paths below, update the listed reference docs **in the same PR**.
+
+| Change | Required updates |
+|---|---|
+| Add / remove / rename a skill in `claude/skills/` | Skills table in `README.md` + `docs/REFERENCE.md` Skills section |
+| Add / remove / rename a script in `claude/scripts/` or `claude/hooks/` | Hooks table in `README.md` + `docs/REFERENCE.md` Hooks section |
+| Add / remove / rename a routine in `claude/routines/` | Routines table in `README.md` + `docs/REFERENCE.md` Routines section |
+| Change `hook-config.json` schema (new field, removed field, type change) | Configuration subsection in `docs/REFERENCE.md` |
+| Change a skill's invocation syntax or options | Skill entry in `docs/REFERENCE.md` |
+| Rename or move any file linked in `README.md` or `docs/REFERENCE.md` | Update the link in both files |

--- a/README.md
+++ b/README.md
@@ -27,41 +27,53 @@ Any edits made through those symlinks update the repo file directly.
 
 ## Skills
 
-Custom skills extend Claude Code with project-aware slash commands. Invoke with `/skill-name`.
+Custom slash commands loaded from `claude/skills/`. Invoke with `/skill-name [args]`.
 
-| Skill | Command | Description |
+| Command | Purpose |
+|---|---|
+| [`/propose <idea>`](claude/skills/propose/SKILL.md) | One-line idea → proposal doc → GitHub issue → ROADMAP entry. Per-project config via `.claude/propose.json`. |
+| [`/journal-compose [YYYY-MM-DD]`](claude/skills/journal-compose/SKILL.md) | Composes the end-of-day engineering journal from stub files. Dedicated-session only. |
+| [`/research [tag:] <decision> [--compare <alt>]`](claude/skills/research/SKILL.md) | Finds 1–3 primary sources. Greps shared source library first; spawns a subagent only on cache miss. |
+| [`/review <PR-URL> [flags]`](claude/skills/review/SKILL.md) | Reviews a PR for correctness, security, reliability, and maintainability. Posts report as PR comment by default. |
+| [`/cover-letter [JD]`](claude/skills/cover-letter/SKILL.md) | Drafts a cover letter for a job application. Runs fit screening and style check as Haiku subagents. |
+| [`/fit-screen [JD]`](claude/skills/fit-screen/SKILL.md) | Fit-screens a job description. Returns PROCEED / FLAG / SKIP. |
+
+## Hooks
+
+Hook scripts run automatically via Claude Code's `hooks` configuration in `claude/settings.json`.
+All hooks are advisory — none block tool execution.
+
+| Event | Script | Purpose |
 |---|---|---|
-| [`propose`](claude/skills/propose/SKILL.md) | `/propose <idea>` | Expands a one-line idea into a proposal doc, creates a GitHub issue, and updates ROADMAP.md. Targets `lifting-logbook`. |
-| [`journal-compose`](claude/skills/journal-compose/SKILL.md) | `/journal-compose [draft-path]` | Composes the end-of-day engineering journal from the day's draft file. Produces the canonical 11-section document, updates READMEs, commits, and opens a PR. |
-| [`research`](claude/skills/research/SKILL.md) | `/research [tag:] <decision> [--compare <alt>]` | Finds 1–3 primary sources for an engineering decision. Greps the shared source library first; spawns a subagent only on a cache miss. |
+| UserPromptSubmit | `dev-env-sync.py` | Fast-forward pulls dev-env to `origin/main` at session start |
+| UserPromptSubmit | `new-day-journal-check.py` | Warns if stale `draft/*` journal branches exist on origin |
+| UserPromptSubmit | `turn-count-hook.py` | Warns when session context token count exceeds threshold |
+| UserPromptSubmit | `multi-worktree-alert.py` | Lists active worktrees in `repo:branch` format when ≥2 are open |
+| PreToolUse (Bash) | `pre-commit-branch-check.py` | Emits current branch as a checkpoint before `git commit` |
+| PreToolUse (Bash) | `pre-pr-create-check.py` | Emits test-verification checklist before `gh pr create` |
+| PostToolUse (Bash) | `pr-merge-reminder.py` | Reminds to write a journal stub after `gh pr create` or `gh pr merge` |
+| PostToolUse (Bash) | `post-tool-use.py` | Auto-adds issues/PRs to configured GitHub Project |
+| PostToolUse (Bash) | `post-pr-merge-pull.py` | Fast-forwards local `main` after `gh pr merge` |
+| PostToolUse (Bash) | `stub-push-archive-reminder.py` | Prompts to archive session after a stub is pushed to engineering-journal |
+| Stop | `token-tracker.py` | Aggregates session token usage to `scratch/token-sessions.jsonl` |
+| Stop | `journal-stop-check.py` | Checks for stale open journal stubs at session end |
+| PostCompact | `post-compact.py` | Emits compaction status line (trigger type + remaining tokens) |
+| Git pre-push | `hooks/pre-push` | Warns when branch merge base diverges from `origin/main` in squash-merge repos |
 
-The source library for `/research` and `/journal-compose` lives at [`claude/skills/sources.md`](claude/skills/sources.md).
+## Routines
 
-## Scripts
+Autonomous scheduled agents in `claude/routines/`. No user interaction.
 
-Hook scripts run automatically via Claude Code's `hooks` configuration in `settings.json`.
-
-| Script | Trigger | Purpose |
+| Schedule | Routine | Purpose |
 |---|---|---|
-| `post-tool-use.py` | After every tool call | Tracks token usage to the session JSONL log |
-| `token-tracker.py` | Session start/stop | Writes and closes session records |
-| `token-report.py` | On demand | Generates markdown and JSON token usage reports by date |
-| `backfill-tokens.py` | On demand | Backfills token data for sessions predating the tracker |
-| `pr-merge-reminder.py` | After tool calls | Reminds to open a PR when changes are pushed without one |
-
-## Templates
-
-Document templates consumed by skills at runtime.
-
-| Template | Used by | Purpose |
-|---|---|---|
-| [`proposal.md`](claude/templates/proposal.md) | `/propose` | PRD template for feature proposals |
-| [`pr-body.md`](claude/templates/pr-body.md) | `/propose`, `/journal-compose` | PR body structure guide |
-| [`contributing.md`](claude/templates/contributing.md) | Manual / `/propose` | CONTRIBUTING.md template for project repos |
+| Daily midnight UTC | `daily-journal-compose` | Assembles stub files into canonical journal entries and opens PRs |
+| Sunday midnight UTC | `prune-stale-worktrees` | Removes merged `claude/*` worktrees |
 
 ## Adding new configs
 
 1. Add the file under a descriptive directory (e.g., `claude/scripts/`, `claude/skills/`)
 2. Add a `ln -sf` or `mklink` line for it in `setup.sh` (if it needs symlinking)
-3. Add a row to the relevant table above
+3. Update the relevant table above **and** the corresponding section in [`docs/REFERENCE.md`](docs/REFERENCE.md)
 4. Update `claude/CLAUDE.md` if the artifact changes session behavior
+
+→ Full reference: **[docs/REFERENCE.md](docs/REFERENCE.md)**

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -112,6 +112,8 @@ If the project has no automated tests, the section must say so explicitly and de
 
 **Routines note:** `dev-env/claude/routines/` is a directory junction pointing at `~/.claude/scheduled-tasks/`, so the scheduler tool writes directly to the version-controlled path. After creating a new routine, commit it to dev-env under `claude/routines/`.
 
+**Reference doc maintenance.** When a change adds, removes, or renames a hook script, skill, routine, or utility script, check whether the project README and any reference documentation need updating in the same PR. This includes command renames, new options, and behavior changes. Each project's CLAUDE.md specifies which reference files apply.
+
 **Repo path:** `C:/Users/brown/Git/dev-env`
 
 ---

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -115,7 +115,7 @@ Runs fit screening only — a lighter-weight version of the first step of `/cove
 All hooks are **advisory** — they emit `systemMessage` reminders via exit 2 but do not block tool execution. No hook exits with a non-zero code that prevents the matched tool from running.
 
 Configuration is in `claude/settings.json` (symlinked to `~/.claude/settings.json`).
-See [ADR-007](adr/007-hook-invocation-direct-python3.md) for why hooks call `python3` directly rather than via a `bash -c` wrapper.
+See [ADR-007](adr/007-hook-command-invocation.md) for why hooks call `python3` directly rather than via a `bash -c` wrapper.
 
 ---
 
@@ -125,7 +125,7 @@ Fires on every user prompt, before Claude processes it.
 
 | Script | What it does |
 |--------|-------------|
-| `dev-env-sync.py` | Fast-forward pulls the dev-env repo to `origin/main` so symlinked tooling stays current. Skips if a feature branch is active in the main worktree. [ADR-006] |
+| `dev-env-sync.py` | Fast-forward pulls the dev-env repo to `origin/main` so symlinked tooling stays current. Skips if a feature branch is active in the main worktree. [ADR-006](adr/006-dev-env-sync-on-every-prompt.md) |
 | `new-day-journal-check.py` | Checks for stale `draft/*` branches on `origin/engineering-journal`. Emits a one-line warning if any are found; continues silently otherwise. |
 | `turn-count-hook.py` | Warns when session context accumulates past a threshold. Primary signal: token count; secondary: turn count. Configurable via `"turn_threshold"` in `.claude/hook-config.json` (default: 50). |
 | `multi-worktree-alert.py` | When ≥2 git worktrees are active, emits a list in `repo:branch` format, starring the current one. Fires on every prompt. |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,0 +1,233 @@
+# dev-env Reference
+
+Full descriptions of every skill, hook, routine, and utility script managed by this repo.
+For a compact overview see the [README](../README.md).
+
+---
+
+## Contents
+
+- [Skills](#skills)
+- [Hooks](#hooks)
+- [Routines](#routines)
+- [Utility Scripts](#utilities)
+
+---
+
+## Skills
+
+Custom slash commands loaded from `claude/skills/`. Invoke with `/skill-name [args]`.
+
+---
+
+### /propose
+
+```
+/propose <one-line idea>
+```
+
+Expands a one-line idea into a full proposal document, creates a linked GitHub issue, and appends an entry to `ROADMAP.md`.
+
+**Config:** reads `.claude/propose.json` in the project root. If the file is missing, the skill scaffolds it interactively. Keys: `proposals_dir`, `roadmap_file`, `prd_file`, `github_repo`, `milestones`, `epics`, `github_project`.
+
+**Produces:** proposal document at `proposals_dir/`, a GitHub issue in `github_repo`, and a ROADMAP entry. If a `github_project` block is configured, the issue is added to the project and its fields are set.
+
+---
+
+### /journal-compose
+
+```
+/journal-compose [YYYY-MM-DD]
+```
+
+Composes the end-of-day engineering journal from the day's stub files. Discovers all `YYYY-MM-DD_*.stub.md` files, sorts and merges them, produces the canonical 11-section document, commits to the `draft/YYYY-MM-DD` branch, and opens a PR.
+
+**Constraint:** must run in a dedicated session with no prior task work. If other tasks were handled before invocation, the skill refuses with an error message.
+
+**Source library:** greps `~/.claude/skills/sources.md` before spawning any research subagent (zero-cost cache hit path).
+
+**Date argument:** defaults to today. Pass `YYYY-MM-DD` to compose a specific day's stubs.
+
+---
+
+### /research
+
+```
+/research [<tag>:] <decision> [--compare <alternative>]
+```
+
+Finds 1–3 primary sources for an engineering decision or topic. Emits footnote-ready markdown.
+
+**How it works:** greps the shared source library at `~/.claude/skills/sources.md` first (zero token cost). Spawns a Haiku subagent only on a cache miss.
+
+**Arguments:**
+- `tag:` — optional topic prefix (e.g., `architecture:`, `security:`) used to filter the source library
+- `--compare <alternative>` — also finds sources for the rejected alternative
+
+---
+
+### /review
+
+```
+/review <PR-URL | --diff> [--no-style] [--author junior|mid|senior] [--focus security|correctness|perf] [--no-comment]
+```
+
+Reviews a PR or pasted diff for correctness, security, reliability, and maintainability. Produces a structured report with blocking findings, non-blocking findings, questions for the author, and optional style notes.
+
+**Flags:**
+- `--no-style` — omit style/nit findings
+- `--author <level>` — calibrate feedback depth (default: `mid`)
+- `--focus <area>` — narrow to one review dimension (default: all)
+- `--no-comment` — skip posting the report as a PR comment (default: posts)
+
+**Default behavior:** posts the report as a GitHub PR comment and applies the `reviewed-by-claude` label.
+
+---
+
+### /cover-letter
+
+```
+/cover-letter [JD text | file path | PDF path | URL]
+```
+
+Drafts a cover letter for Mike Brown's job search. Accepts the job description as inline text, a file path (`.md`, `.txt`, `.docx`, `.pdf`), or a URL.
+
+**Workflow:** loads JD → checks company log for duplicates → runs fit screening (Haiku subagent) → drafts letter → runs style self-check (Haiku subagent) → logs result to `job-search/context/company_log.md`.
+
+**Returns:** PROCEED / FLAG / SKIP from fit screen, then the drafted letter if proceeding.
+
+---
+
+### /fit-screen
+
+```
+/fit-screen [JD text | file path | PDF path | URL]
+```
+
+Runs fit screening only — a lighter-weight version of the first step of `/cover-letter`. Useful for quickly evaluating a role before drafting.
+
+**Returns:** `PROCEED`, `FLAG`, or `SKIP` with structured sections covering auto-skip triggers, soft flags, fit summary, and recommendation.
+
+---
+
+## Hooks
+
+All hooks are **advisory** — they emit `systemMessage` reminders via exit 2 but do not block tool execution. No hook exits with a non-zero code that prevents the matched tool from running.
+
+Configuration is in `claude/settings.json` (symlinked to `~/.claude/settings.json`).
+See [ADR-007](adr/007-hook-invocation-direct-python3.md) for why hooks call `python3` directly rather than via a `bash -c` wrapper.
+
+---
+
+### UserPromptSubmit
+
+Fires on every user prompt, before Claude processes it.
+
+| Script | What it does |
+|--------|-------------|
+| `dev-env-sync.py` | Fast-forward pulls the dev-env repo to `origin/main` so symlinked tooling stays current. Skips if a feature branch is active in the main worktree. [ADR-006] |
+| `new-day-journal-check.py` | Checks for stale `draft/*` branches on `origin/engineering-journal`. Emits a one-line warning if any are found; continues silently otherwise. |
+| `turn-count-hook.py` | Warns when session context accumulates past a threshold. Primary signal: token count; secondary: turn count. Configurable via `"turn_threshold"` in `.claude/hook-config.json` (default: 50). |
+| `multi-worktree-alert.py` | When ≥2 git worktrees are active, emits a list in `repo:branch` format, starring the current one. Fires on every prompt. |
+
+---
+
+### PreToolUse (Bash only)
+
+Fires before each Bash tool call. Matched with `"matcher": "Bash"`.
+
+| Script | Trigger condition | What it does |
+|--------|------------------|-------------|
+| `pre-commit-branch-check.py` | Command contains `git commit` | Emits the current branch name as a confirmation checkpoint before the commit runs. |
+| `pre-pr-create-check.py` | Command contains `gh pr create` | Emits a test-verification checklist. Enforces the "test before PR" rule from CLAUDE.md. |
+
+---
+
+### PostToolUse (Bash only)
+
+Fires after each Bash tool call completes. Matched with `"matcher": "Bash"`.
+
+| Script | Trigger condition | What it does |
+|--------|------------------|-------------|
+| `pr-merge-reminder.py` | Command contains `gh pr create` or `gh pr merge` | Exits 2 with a `systemMessage` reminding Claude to write a journal stub. |
+| `post-tool-use.py` | Command contains `gh issue create` or `gh pr create` | Auto-adds the created item to the configured GitHub Project. Opt-in via `"github_project_id"` in `.claude/hook-config.json`. |
+| `post-pr-merge-pull.py` | Command contains `gh pr merge` | Fast-forwards the local `main` branch via `git fetch origin main:main` so the local clone stays current after a merge. |
+| `stub-push-archive-reminder.py` | `git push` to `engineering-journal` with a stub commit | Exits 2 prompting Claude to call `ccd_session_mgmt__archive_session`. Verifies the most-recent commit in the journal repo touches a `.stub.md` file before firing. |
+
+---
+
+### Stop
+
+Fires when the Claude Code session ends (user exits or `/stop`).
+
+| Script | What it does |
+|--------|-------------|
+| `token-tracker.py` | Reads the session JSONL, aggregates token usage, and appends a record to `~/.claude/scratch/token-sessions.jsonl`. Supports Sonnet 4.6, Opus 4.6, and Haiku 4.5 pricing. |
+| `journal-stop-check.py` | Checks for stale open journal stubs at session end. Emits a reminder if any are found. |
+
+---
+
+### PostCompact
+
+Fires after `/compact` or auto-compact completes.
+
+| Script | What it does |
+|--------|-------------|
+| `post-compact.py` | Emits a `[compact]` or `[auto-compact]` status line with the trigger type and remaining token count. Visible in all environments. |
+
+---
+
+### Git hook: `hooks/pre-push`
+
+A global git pre-push hook installed via `core.hooksPath` (see [ADR-005](adr/005-global-core-hooks-path.md)).
+
+**What it does:** before every `git push`, checks whether the branch's merge base diverges from `origin/main` in squash-merge repos. Warns when it detects a branch that was cut from a squash-merged ancestor (which would cause a rebase to fail). Chains to any existing per-repo `.git/hooks/pre-push` so repo-level hooks are preserved.
+
+---
+
+### Configuration
+
+`hook-config.json` lives at `.claude/hook-config.json` in the project root (not version-controlled).
+
+| Field | Type | Default | Used by |
+|-------|------|---------|---------|
+| `github_project_id` | string | — | `post-tool-use.py` — opt-in; item is added to this project when an issue or PR is created |
+| `turn_threshold` | integer | `50` | `turn-count-hook.py` — warn after N turns; warns again every 25 turns thereafter |
+
+---
+
+## Routines
+
+Autonomous scheduled agents in `claude/routines/`. They run on a cron schedule with no user interaction. Managed via the `scheduled-tasks` MCP tool; stored in `claude/routines/` (directory junction to `~/.claude/scheduled-tasks/`).
+
+---
+
+### daily-journal-compose
+
+**Schedule:** `0 0 * * *` (midnight UTC, daily)
+
+Assembles all `YYYY-MM-DD_*.stub.md` files across all configured projects into the canonical 11-section journal entries and opens PRs against `engineering-journal`.
+
+**Retry wrapper:** `journal-compose-with-retry.sh` — wraps the routine for Windows Task Scheduler use. Retries up to 3 times with 5-minute delays on transient failures. Logs to `~/.claude/scratch/`.
+
+---
+
+### prune-stale-worktrees
+
+**Schedule:** `0 0 * * 0` (midnight UTC, every Sunday)
+
+Removes `claude/*` worktrees whose branches are fully merged into `origin/main`. Uses `git branch -d` and `git worktree remove` (no `--force`). Skips the current worktree, dirty worktrees, and any worktree not named `claude/*`. Sends a push notification listing any unmerged branches that were skipped.
+
+---
+
+## Utilities
+
+On-demand scripts — not wired to any event. Run manually or from other scripts.
+
+| Script | Invocation | What it does |
+|--------|-----------|-------------|
+| `token-report.py` | `python3 token-report.py [--date YYYY-MM-DD] [--days N] [--project name] [--latest] [--show-subagents]` | Generates markdown and JSON token usage reports from `~/.claude/scratch/token-sessions.jsonl`. |
+| `backfill-tokens.py` | `python3 backfill-tokens.py` | Backfills token data for sessions predating the token-tracker hook. Idempotent — deduplicates on `session_id`. |
+| `prune-merged-worktrees.py` | `python3 prune-merged-worktrees.py` | Manual equivalent of the `prune-stale-worktrees` routine. |
+| `new-branch.sh` | `new-branch <name>` (shell function; source `~/.claude/scripts/new-branch.sh` in `.bashrc`) | Creates a branch always rooted at `origin/main`. Warns when HEAD has diverged from the merge base. |
+| `merge-stale-pr.sh` | `bash merge-stale-pr.sh <PR-URL>` | Remediates stale `engineering-journal` draft PRs: checks out the branch, warns on missing journal file, deletes orphaned drafts, rebases, and squash-merges with auto-conflict resolution. |


### PR DESCRIPTION
## Summary

- **`docs/REFERENCE.md`** (new): full reference for all 6 skills, 13 hooks (5 event types), 2 routines, and 5 utility scripts — invocation syntax, options, config fields, ADR links
- **`README.md`**: replaces incomplete Skills/Scripts tables with complete Skills, Hooks, and Routines tables; adds link to REFERENCE.md; removes stale Templates table
- **`CLAUDE.md`** (new, project root): project-level instructions with Testing section and a doc-maintenance checklist mapping each change type to the specific files that need updating
- **`claude/CLAUDE.md`**: adds file-agnostic reference-doc-maintenance rule to the Dev-Env section

Closes #129

## Test plan

- [ ] `python3 -m py_compile claude/scripts/*.py` — no syntax errors (docs-only change, no scripts modified)
- [ ] All 13 hooks in `claude/settings.json` appear in the README hooks table
- [ ] All 6 skills in `claude/skills/` appear in the README skills table and REFERENCE.md
- [ ] Links in README and REFERENCE.md resolve (REFERENCE.md anchors: `#skills`, `#hooks`, `#routines`, `#utilities`)
- [ ] ADR links in REFERENCE.md resolve to existing files under `docs/adr/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)