### PR TITLE
feat: route foundational skill tasks to Opus

### DIFF
--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -9,6 +9,17 @@ You are drafting a cover letter for Mike Brown's job search, following the canon
 
 Follow every step in order. Do not skip steps.
 
+## Step -1 — Model selection
+
+Use AskUserQuestion with:
+- Question: "Which model should draft this cover letter?"
+- Header: "Draft model"
+- Options:
+  - "Opus (Recommended)" — better prose quality, higher cost (~5–10× Sonnet)
+  - "Sonnet" — faster and cheaper, sufficient for routine applications
+
+Store the answer as DRAFT_MODEL: `"opus"` if Opus was selected, `"sonnet"` if Sonnet.
+
 ## Step 0 — Load the job description
 
 The job description is provided in `$ARGUMENTS`. Determine input type and load accordingly:
@@ -78,16 +89,32 @@ Apply the patterns in the synopsis to calibrate opening sentence rhythm, paragra
 
 (The full voice reference files are at `models/voice/` and can be consulted if a specific passage is needed, but the synopsis is sufficient for drafting.)
 
-## Step 6 — Draft the letter (Sonnet — this session)
+## Step 6 — Draft the letter (subagent)
 
-Draft the cover letter body in Markdown. Apply all style rules from Step 3 while drafting:
-- No em-dashes (anywhere, no exceptions)
-- No banned constructions ("The outcomes were concrete" and all variants)
-- Do not claim Mike "led a platform directorate" — use "led platform teams responsible for..." or "led programs within the platform organization"
-- Body word ceiling: 400 words (body paragraphs only)
-- Output is Markdown only
+Spawn an Agent with `model: "<DRAFT_MODEL>"`. Pass all of the following inline — do not
+instruct the subagent to read any files:
 
-Use the model letter from Step 4 as a structural reference. Adapt tone and emphasis to the specific JD. Do not copy model letter text verbatim.
+- All style rules (from Step 3, verbatim)
+- The model letter (from Step 4, verbatim)
+- The accomplishments list (from Step 5, verbatim)
+- The voice synopsis (from Step 5b, verbatim)
+- The full JD text (from Step 0)
+
+Subagent task:
+
+> Draft the cover letter body in Markdown. Apply all style rules provided:
+> - No em-dashes (anywhere, no exceptions)
+> - No banned constructions ("The outcomes were concrete" and all variants)
+> - Do not claim Mike "led a platform directorate" — use "led platform teams responsible for..." or "led programs within the platform organization"
+> - Body word ceiling: 400 words (body paragraphs only)
+> - Output is Markdown only
+>
+> Use the model letter as a structural reference. Adapt tone and emphasis to the specific JD.
+> Do not copy model letter text verbatim.
+>
+> Return only the letter body — no preamble, no commentary.
+
+Collect the subagent's output as DRAFT.
 
 ## Step 7 — Style self-check (Haiku subagent)
 

--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -2,7 +2,7 @@
 name: cover-letter
 description: Draft a cover letter for a job application following the full cover letter workflow. Invokes Haiku subagents for fit screening and style self-check. Invoke as /cover-letter [JD text, file path, PDF path, or URL].
 argument-hint: "[JD text, file path, PDF path, or URL to job posting]"
-allowed-tools: Read Edit Write Bash Glob Grep Agent WebFetch
+allowed-tools: Read Edit Write Bash Glob Grep Agent WebFetch AskUserQuestion
 ---
 
 You are drafting a cover letter for Mike Brown's job search, following the canonical workflow defined in `CLAUDE.md`.

--- a/claude/skills/propose/SKILL.md
+++ b/claude/skills/propose/SKILL.md
@@ -2,7 +2,7 @@
 name: propose
 description: One-sentence idea → PRD → linked GitHub issue → ROADMAP entry. Reads per-project config from .claude/propose.json; scaffolds config interactively for unconfigured repos.
 argument-hint: "<one-line idea>"
-allowed-tools: Read Edit Write Bash Glob Grep
+allowed-tools: Read Edit Write Bash Glob Grep Agent
 ---
 
 You are implementing the `/propose` workflow: expand a one-line idea into a proposal document,
@@ -151,16 +151,28 @@ If both lists are empty (minimal config), skip this step entirely.
 
 ---
 
-## Step 5 — Draft the proposal
+## Step 5 — Draft the proposal (Opus subagent)
 
-Using the template from Step 3 and the answers from Steps 1–4, compose the full proposal.
+Spawn an Agent with `model: "opus"`. Pass all of the following inline — do not instruct
+the subagent to read any files:
 
-Produce:
-- A **slug**: lowercase, hyphens, 3–5 words (e.g., `bodyweight-exercise-tracking`)
-- A **filename**: `<config.proposals_dir>/YYYY-MM-DD-<slug>.md` (use today's date)
-- The **full proposal document**, filled in from the template
+- The proposal template (from Step 3, verbatim)
+- The project PRD (from Step 3, if loaded — otherwise omit)
+- The idea (from Step 1)
+- Answers to clarifying questions (from Step 2)
+- Chosen milestone and epic (from Step 4, if applicable)
+- Today's date
 
-Show the draft to the user. Ask: "Does this look right? Any edits before I write the file?"
+Subagent task:
+
+> Using the template and context provided, produce a complete proposal. Return:
+> 1. A **slug**: lowercase, hyphens, 3–5 words (e.g., `bodyweight-exercise-tracking`)
+> 2. A **filename**: `<proposals_dir>/YYYY-MM-DD-<slug>.md` (use today's date)
+> 3. The **full proposal document**, filled in from the template
+>
+> Return only the slug, filename, and proposal document — no preamble or commentary.
+
+Collect the subagent's output. Show the draft to the user. Ask: "Does this look right? Any edits before I write the file?"
 
 Wait for confirmation. Apply any requested edits, then confirm once more before proceeding.
 

--- a/claude/skills/propose/SKILL.md
+++ b/claude/skills/propose/SKILL.md
@@ -163,7 +163,7 @@ the subagent to read any files:
 - Chosen milestone and epic (from Step 4, if applicable)
 - Today's date
 
-Subagent task:
+Subagent task (substitute `<proposals_dir>` with `config.proposals_dir` before passing):
 
 > Using the template and context provided, produce a complete proposal. Return:
 > 1. A **slug**: lowercase, hyphens, 3–5 words (e.g., `bodyweight-exercise-tracking`)

--- a/claude/skills/research/SKILL.md
+++ b/claude/skills/research/SKILL.md
@@ -80,16 +80,16 @@ to Step 4.
 ## Step 3b — Approval gate for deep DECISION search
 
 If the Haiku quick scan found no confirmed sources, ask the user for approval before
-spending more tokens on a deeper Sonnet search:
+spending more tokens on a deeper Opus search:
 
 Use AskUserQuestion with:
-- Question: "The quick scan found no verified sources. Run a deeper Sonnet search? (This uses roughly 10× more tokens.)"
+- Question: "The quick scan found no verified sources. Run a deeper Opus search? (Higher quality, ~15× more tokens than the quick scan.)"
 - Header: "Deep search"
 - Options:
-  - "Yes, continue" — spawn a Sonnet subagent for a thorough search
+  - "Yes, continue" — spawn an Opus subagent for a thorough search
   - "No, skip" — report no sources found and move on
 
-If the user approves, spawn a **general-purpose** subagent with the following task:
+If the user approves, spawn a **general-purpose** subagent (`model: "opus"`) with the following task:
 
 > First, call ToolSearch with query "select:WebSearch,WebFetch" to load web tools.
 >
@@ -152,13 +152,13 @@ to Step 6.
 Skip this step if ALTERNATIVE is empty, or if Step 5a found confirmed sources.
 
 Use AskUserQuestion with:
-- Question: "The quick scan found no verified sources for the alternative. Run a deeper Sonnet search? (This uses roughly 10× more tokens.)"
+- Question: "The quick scan found no verified sources for the alternative. Run a deeper Opus search? (Higher quality, ~15× more tokens than the quick scan.)"
 - Header: "Deep search"
 - Options:
-  - "Yes, continue" — spawn a Sonnet subagent for a thorough search
+  - "Yes, continue" — spawn an Opus subagent for a thorough search
   - "No, skip" — report no sources found for this side
 
-If approved, spawn a **general-purpose** subagent with the following task:
+If approved, spawn a **general-purpose** subagent (`model: "opus"`) with the following task:
 
 > First, call ToolSearch with query "select:WebSearch,WebFetch" to load web tools.
 >


### PR DESCRIPTION
## Summary

- **research:** deep-search subagents (Steps 3b, 5b) now use `model: "opus"`; gate question updated to name Opus and quote ~15× token cost vs. the Haiku quick scan
- **cover-letter:** new Step -1 asks Opus vs. Sonnet before loading the JD; Step 6 drafts via subagent with the chosen model rather than in-session Sonnet
- **propose:** Step 5 now spawns an Opus subagent for the proposal body; all file I/O and PR work (Steps 6–11) remain in-session

## Rationale

These are the highest-judgment steps in their workflows — evaluating source quality, crafting persuasive prose, scoping proposals. Haiku quick-scans and mechanical style-checks stay on cheaper models. Deep-search and drafting fire rarely enough that the cost delta is acceptable.

## Test plan

- [ ] Run `/research architecture: chose event sourcing over CRUD`, deny Haiku result, confirm gate question mentions Opus and deep-search fires with `model: "opus"`
- [ ] Run `/cover-letter` with Fetch JD (`Fetch_Director of Engineering, Growth.pdf`) — confirm model-selection question appears first; select Opus and confirm Step 6 spawns a subagent; compare output against Sonnet control (`MikeBrown_20260421__Fetch__Director_Engineering__Cover_Letter.md`)
- [ ] Run `/propose` in a configured repo — confirm Step 5 spawns an Opus subagent and returns draft for confirmation before writing files
- [ ] `python3 -m py_compile claude/scripts/*.py` — syntax OK ✓ (run pre-commit)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)