### PR TITLE
feat: PostCompact hook auto-invokes /review when open PRs exist

### DIFF
--- a/claude/scripts/post-compact.py
+++ b/claude/scripts/post-compact.py
@@ -2,17 +2,36 @@
 """PostCompact hook — emit a status line and, for manual compactions with open PRs,
 inject a systemMessage so Claude auto-invokes /review without user input."""
 import json
+import subprocess
 import sys
 from pathlib import Path
 
-OPEN_PRS_PATH = Path("C:/Users/brown/Git/engineering-journal/sessions/dev-env/open-prs.jsonl")
+JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
+
+
+def get_journal_project() -> str | None:
+    """Infer journal project name from the current git repo (worktree-safe)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip()).resolve().parent.name
+    except Exception:
+        pass
+    return None
 
 
 def load_open_prs() -> list[dict]:
-    if not OPEN_PRS_PATH.exists():
+    project = get_journal_project()
+    if not project:
+        return []
+    path = JOURNAL_REPO / "sessions" / project / "open-prs.jsonl"
+    if not path.exists():
         return []
     entries = []
-    for line in OPEN_PRS_PATH.read_text(encoding="utf-8").splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if line:
             try:

--- a/claude/scripts/post-compact.py
+++ b/claude/scripts/post-compact.py
@@ -1,7 +1,25 @@
 #!/usr/bin/env python3
-"""PostCompact hook — emit a status line so compaction is visible in all environments."""
+"""PostCompact hook — emit a status line and, for manual compactions with open PRs,
+inject a systemMessage so Claude auto-invokes /review without user input."""
 import json
 import sys
+from pathlib import Path
+
+OPEN_PRS_PATH = Path("C:/Users/brown/Git/engineering-journal/sessions/dev-env/open-prs.jsonl")
+
+
+def load_open_prs() -> list[dict]:
+    if not OPEN_PRS_PATH.exists():
+        return []
+    entries = []
+    for line in OPEN_PRS_PATH.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return entries
 
 
 def main():
@@ -27,6 +45,26 @@ def main():
     if summary:
         first_line = summary.splitlines()[0].strip()[:120]
         print(f"  summary: {first_line}", file=sys.stderr)
+
+    if trigger == "manual":
+        prs = load_open_prs()
+        if prs:
+            if len(prs) == 1:
+                pr = prs[0]
+                pr_ref = f"#{pr['pr']} — {pr['url']}" if pr.get("url") else f"#{pr['pr']}"
+                msg = (
+                    f"PostCompact complete. Open PR: {pr_ref}\n"
+                    f"Per CLAUDE.md workflow: invoke /review {pr.get('url', '')} --post-comment now."
+                )
+            else:
+                pr_list = ", ".join(
+                    f"#{p['pr']} {p.get('url', '')}" for p in prs
+                )
+                msg = (
+                    f"PostCompact complete. Open PRs: {pr_list}\n"
+                    "Per CLAUDE.md workflow: invoke /review on the relevant PR --post-comment now."
+                )
+            print(json.dumps({"systemMessage": msg}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `post-compact.py` now reads `open-prs.jsonl` from the engineering-journal repo after a manual `/compact`
- If open PRs exist, emits a `systemMessage` with the PR URL(s) and an explicit instruction to invoke `/review <URL> --post-comment`
- Claude sees this as a `<system-reminder>` in its post-compaction response turn and executes the review automatically
- Auto-compact (`trigger == "auto"`) is unchanged — stderr-only, no systemMessage

## Test plan

- [x] `python3 -m py_compile claude/scripts/post-compact.py` — passes
- [x] Dry-run with `trigger=manual`, no `open-prs.jsonl` → stderr status only, exit 0
- [x] Dry-run with `trigger=auto` → stderr status only, no systemMessage, exit 0
- [x] Dry-run with fake `open-prs.jsonl` (1 PR) → correct JSON systemMessage to stdout + stderr status
- [ ] End-to-end: open a PR, write `open-prs.jsonl` entry, run `/compact`, confirm Claude auto-invokes `/review`

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)