### PR TITLE
fix: emit dev-env-sync divergence warning to stderr

### DIFF
--- a/claude/scripts/dev-env-sync.py
+++ b/claude/scripts/dev-env-sync.py
@@ -77,7 +77,8 @@ def main() -> None:
         print(
             "[dev-env-sync] WARNING: local dev-env repo has diverged from origin/main.\n"
             "CLAUDE.md and symlinked tooling may be stale. Run `git -C ~/Git/dev-env "
-            "status` to investigate before proceeding."
+            "status` to investigate before proceeding.",
+            file=sys.stderr,
         )
         sys.exit(0)
 
@@ -99,7 +100,8 @@ def main() -> None:
     else:
         print(
             "[dev-env-sync] WARNING: fast-forward pull failed.\n"
-            + pull.stderr.strip()
+            + pull.stderr.strip(),
+            file=sys.stderr,
         )
 
     sys.exit(0)


### PR DESCRIPTION
## Summary

- Changes two `print()` calls in `dev-env-sync.py` to `print(..., file=sys.stderr)` so diverged-main and failed-pull warnings surface in the terminal instead of being silently swallowed as system messages.

## Context

UserPromptSubmit hook **stdout** is injected into Claude's context as a system message — not shown in the UI. The divergence warning was therefore invisible, which allowed stale symlinked tooling to keep running undetected. This is the root cause of the PostCompact `/review` regression from issue #133: local `main` diverged, the warning fired but was never seen, and the old `post-compact.py` (without the `systemMessage` output) kept running.

## What's not changed

The success-pull notification stays on stdout — it's informational and the system-message channel is fine for it.

## Test plan

- [ ] `python3 -m py_compile claude/scripts/dev-env-sync.py` → syntax OK
- [ ] `python3 claude/scripts/dev-env-sync.py < /dev/null; echo "exit: $?"` → exits 0

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)