### PR TITLE
config: route /review skill to Opus in model selection table and skill

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -216,8 +216,8 @@ Route tasks to the least powerful model that can handle them reliably:
 | Task type | Model |
 |-----------|-------|
 | Mechanical: search, format, summarize, diff, rename | Haiku |
-| Standard dev: code review, feature implementation, debugging | Sonnet |
-| Complex: architectural decisions, novel problems, multi-file reasoning, writing test code | Opus |
+| Standard dev: feature implementation, debugging | Sonnet |
+| Complex: architectural decisions, novel problems, multi-file reasoning, writing test code, `/review` skill | Opus |
 
 Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handles correctly on the first try.
 

--- a/claude/skills/review/SKILL.md
+++ b/claude/skills/review/SKILL.md
@@ -96,7 +96,7 @@ Proceed to Step 6.
 
 ## Step 5 — Parallel subagent analysis (large diffs only)
 
-Spawn two subagents in parallel using the Agent tool. Pass each the full DIFF and PR context.
+Spawn two subagents in parallel using the Agent tool with `model: "opus"`. Pass each the full DIFF and PR context.
 
 **Subagent A — Correctness & Security:**
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -266,7 +266,7 @@ Route tasks to the least powerful model that can handle them reliably:
 | Task type | Model |
 |-----------|-------|
 | Mechanical: search, format, summarize, diff, rename | Haiku |
-| Standard dev: code review, feature implementation, debugging | Sonnet |
-| Complex: architectural decisions, novel problems, multi-file reasoning, writing test code | Opus |
+| Standard dev: feature implementation, debugging | Sonnet |
+| Complex: architectural decisions, novel problems, multi-file reasoning, writing test code, `/review` skill | Opus |
 
 Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handles correctly on the first try.


### PR DESCRIPTION
## Summary

- Removes 'code review' from the Sonnet row in the Model Selection table; adds '/review skill' to the Opus row
- Mirrors the same change in `docs/REFERENCE.md`
- Adds `model: "opus"` to the two parallel subagent spawns in Step 5 of `claude/skills/review/SKILL.md`

## Motivation

`/review` is the heaviest Sonnet consumer; the user is consistently closer to the Sonnet usage limit than any other. Routing the skill's subagents explicitly to Opus and updating the guidance table aligns cost with the right model.

> Note: Step 4 (small diffs, inline analysis) runs in the session context with no Agent spawn to route. The table entry covers that path as advisory guidance.

## Test plan

- [x] `python3 -m py_compile claude/scripts/*.py` — all scripts pass syntax check
- [x] CLAUDE.md and REFERENCE.md model tables are symmetric
- [x] `model: "opus"` appears exactly once in Step 5 of review/SKILL.md

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)