### PR TITLE
fix: suppress hook false positive when draft branch cut from previous day's draft

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -320,6 +320,14 @@ operational artifacts (compose lock files, log file timestamps).
 **First session of the day:**
 1. `git -C C:/Users/brown/Git/engineering-journal checkout main && git pull`
 2. `git -C C:/Users/brown/Git/engineering-journal checkout -b draft/YYYY-MM-DD`
+   **Branch validation (required):** Confirm the new branch was cut from `main`, not a previous
+   draft branch. Both commands below must print the same SHA — if they differ, delete the local
+   branch (`git -C C:/Users/brown/Git/engineering-journal branch -D draft/YYYY-MM-DD`) and
+   re-run steps 1–2:
+   ```bash
+   git -C C:/Users/brown/Git/engineering-journal merge-base HEAD origin/main
+   git -C C:/Users/brown/Git/engineering-journal rev-parse origin/main
+   ```
 3. Read `sessions/<project>/open-prs.jsonl` if it exists — include its PR list as session context before starting work.
 4. Create `sessions/<project>/YYYY-MM-DD_HHMMSS.stub.md` (see stub structure below)
 5. Add a `<!-- tokens: input=N output=N cost≈$N -->` comment at the end of the session block

--- a/claude/scripts/journal-stop-check.py
+++ b/claude/scripts/journal-stop-check.py
@@ -26,15 +26,65 @@ JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
 TODAY = date.today().strftime("%Y-%m-%d")
 
 
+def composed_project_dates_on_main() -> set[tuple[str, str]]:
+    """Return (project, YYYY-MM-DD) pairs that have a composed file on origin/main.
+
+    Finer-grained than composed_dates_on_main(): used to suppress false positives
+    when stubs from a composed date are still present on disk because a new-day
+    branch was cut from the previous day's draft branch instead of from main.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", "origin/main", "sessions/"],
+            cwd=JOURNAL_REPO,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        pairs: set[tuple[str, str]] = set()
+        for line in result.stdout.splitlines():
+            parts = line.split("/")
+            if len(parts) < 3:
+                continue
+            project = parts[1]
+            fname = parts[-1]
+            if fname.endswith(".stub.md") or not fname.endswith(".md"):
+                continue
+            if len(fname) >= 10 and fname[4] == "-" and fname[7] == "-":
+                pairs.add((project, fname[:10]))
+        return pairs
+    except Exception:
+        return set()
+
+
 def stale_draft_artifacts() -> list[str]:
-    """Return paths of *_draft.md or *.stub.md files from before today."""
+    """Return stub/draft paths whose (project, date) lacks a composed file on main.
+
+    Stubs whose project+date already have a composed file on main are branch-lineage
+    artifacts (carried forward because the new-day branch was cut from the previous
+    day's draft instead of from main) — not genuine unComposed drafts.
+    """
+    composed = composed_project_dates_on_main()
     artifacts = []
     for pattern in (
         str(JOURNAL_REPO / "sessions" / "**" / "*_draft.md"),
         str(JOURNAL_REPO / "sessions" / "**" / "????-??-??_*.stub.md"),
     ):
         artifacts.extend(glob.glob(pattern, recursive=True))
-    stale = [f for f in artifacts if not os.path.basename(f).startswith(TODAY)]
+    stale = []
+    for f in artifacts:
+        if os.path.basename(f).startswith(TODAY):
+            continue
+        date_prefix = os.path.basename(f)[:10]
+        try:
+            parts = Path(f).parts
+            sessions_idx = next(i for i, p in enumerate(parts) if p == "sessions")
+            project = parts[sessions_idx + 1]
+        except (StopIteration, IndexError):
+            project = None
+        if project and (project, date_prefix) in composed:
+            continue  # Already composed on main — branch-lineage artifact, not stale
+        stale.append(f)
     stale.sort(key=lambda f: os.path.basename(f), reverse=True)
     return stale
 

--- a/claude/scripts/journal-stop-check.py
+++ b/claude/scripts/journal-stop-check.py
@@ -32,6 +32,10 @@ def composed_project_dates_on_main() -> set[tuple[str, str]]:
     Finer-grained than composed_dates_on_main(): used to suppress false positives
     when stubs from a composed date are still present on disk because a new-day
     branch was cut from the previous day's draft branch instead of from main.
+
+    Note: reads the local remote-tracking ref (origin/main) without fetching —
+    results reflect the last fetch. A stale ref could miss composed dates, causing
+    branch-lineage artifacts to appear stale. The next fetch will self-correct.
     """
     try:
         result = subprocess.run(

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -43,6 +43,10 @@ def composed_project_dates_on_main() -> set[tuple[str, str]]:
     Finer-grained than composed_dates_on_main(): used to suppress false positives
     when stubs from a composed date are still present on disk because a new-day
     branch was cut from the previous day's draft branch instead of from main.
+
+    Note: reads the local remote-tracking ref (origin/main) without fetching —
+    results reflect the last fetch. A stale ref could miss composed dates, causing
+    branch-lineage artifacts to appear stale. The next fetch will self-correct.
     """
     try:
         result = subprocess.run(

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -37,8 +37,45 @@ def cleanup_stale_flags() -> None:
         pass
 
 
+def composed_project_dates_on_main() -> set[tuple[str, str]]:
+    """Return (project, YYYY-MM-DD) pairs that have a composed file on origin/main.
+
+    Finer-grained than composed_dates_on_main(): used to suppress false positives
+    when stubs from a composed date are still present on disk because a new-day
+    branch was cut from the previous day's draft branch instead of from main.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", "origin/main", "sessions/"],
+            cwd=JOURNAL_REPO,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        pairs: set[tuple[str, str]] = set()
+        for line in result.stdout.splitlines():
+            parts = line.split("/")
+            if len(parts) < 3:
+                continue
+            project = parts[1]
+            fname = parts[-1]
+            if fname.endswith(".stub.md") or not fname.endswith(".md"):
+                continue
+            if len(fname) >= 10 and fname[4] == "-" and fname[7] == "-":
+                pairs.add((project, fname[:10]))
+        return pairs
+    except Exception:
+        return set()
+
+
 def stale_draft_artifacts() -> list[str]:
-    """Return paths of *_draft.md or *.stub.md files from before today."""
+    """Return stub/draft paths whose (project, date) lacks a composed file on main.
+
+    Stubs whose project+date already have a composed file on main are branch-lineage
+    artifacts (carried forward because the new-day branch was cut from the previous
+    day's draft instead of from main) — not genuine unComposed drafts.
+    """
+    composed = composed_project_dates_on_main()
     artifacts = []
     for pattern in (
         str(JOURNAL_REPO / "sessions" / "**" / "*_draft.md"),
@@ -46,7 +83,20 @@ def stale_draft_artifacts() -> list[str]:
         str(JOURNAL_REPO / "sessions" / "**" / "????-??-??_*.stub.md"),
     ):
         artifacts.extend(glob.glob(pattern, recursive=True))
-    stale = [f for f in artifacts if not os.path.basename(f).startswith(TODAY)]
+    stale = []
+    for f in artifacts:
+        if os.path.basename(f).startswith(TODAY):
+            continue
+        date_prefix = os.path.basename(f)[:10]
+        try:
+            parts = Path(f).parts
+            sessions_idx = next(i for i, p in enumerate(parts) if p == "sessions")
+            project = parts[sessions_idx + 1]
+        except (StopIteration, IndexError):
+            project = None
+        if project and (project, date_prefix) in composed:
+            continue  # Already composed on main — branch-lineage artifact, not stale
+        stale.append(f)
     stale.sort(key=lambda f: os.path.basename(f), reverse=True)
     return stale
 


### PR DESCRIPTION
## Summary

- Adds `composed_project_dates_on_main()` to both journal hook scripts, returning `(project, YYYY-MM-DD)` pairs with a composed file on `origin/main`
- Updates `stale_draft_artifacts()` to skip stubs whose `(project, date)` is already composed — these are branch-lineage artifacts carried forward when a new-day branch is cut from the previous day's draft instead of from main
- Adds a branch validation step to CLAUDE.md first-session instructions: after `git checkout -b draft/YYYY-MM-DD`, require `merge-base HEAD origin/main` == `rev-parse origin/main`

## Root cause

`draft/2026-05-01` was cut from `draft/2026-04-30` at a pre-compose commit. The compose later deleted all 04-30 stubs and produced composed files (squash-merged as PR #34). `draft/2026-05-01` inherited the pre-deletion state; 29 stale stub/manifest files across four projects triggered the hook every session.

## Test plan

- [x] `python3 -m py_compile claude/scripts/new-day-journal-check.py claude/scripts/journal-stop-check.py` — syntax OK
- [x] `python3 claude/scripts/new-day-journal-check.py < /dev/null` — exits 0, no output
- [x] Hook fires correctly on the current session (no false positives after 04-30 artifact removal in engineering-journal)

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)