### PR TITLE
fix: replace exit-2 PostToolUse hook with sentinel file approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ All hooks are advisory — none block tool execution.
 | PostToolUse (Bash) | `pr-merge-reminder.py` | Reminds to write a journal stub after `gh pr create` or `gh pr merge` |
 | PostToolUse (Bash) | `post-tool-use.py` | Auto-adds issues/PRs to configured GitHub Project |
 | PostToolUse (Bash) | `post-pr-merge-pull.py` | Fast-forwards local `main` after `gh pr merge` |
-| PostToolUse (Bash) | `stub-push-archive-reminder.py` | Prompts to archive session after a stub is pushed to engineering-journal |
+| PostToolUse (Bash) | `stub-push-archive-reminder.py` | Writes a sentinel flag after a stub is pushed to engineering-journal; Stop hook consumes it to remind Claude to archive |
 | Stop | `token-tracker.py` | Aggregates session token usage to `scratch/token-sessions.jsonl` |
-| Stop | `journal-stop-check.py` | Checks for stale open journal stubs at session end |
+| Stop | `journal-stop-check.py` | Checks sentinel flag and stale open journal stubs at session end; emits closing reminder if stub was pushed this session |
 | PostCompact | `post-compact.py` | Emits compaction status line (trigger type + remaining tokens) |
 | Git pre-push | `hooks/pre-push` | Warns when branch merge base diverges from `origin/main` in squash-merge repos |
 

--- a/claude/scripts/journal-stop-check.py
+++ b/claude/scripts/journal-stop-check.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 """
-Stop hook: remind user of stale journal work at session end.
+Stop hook: remind Claude to archive after a stub push, and remind the user
+of stale journal work at session end.
 
-Two checks (same logic as new-day-journal-check.py):
+Check 1 — stub-push sentinel:
+  If stub-push-archive-reminder.py wrote a sentinel flag (meaning a stub was
+  pushed to engineering-journal this session), consume the flag and emit a
+  closing message reminding the user to call ccd_session_mgmt__archive_session.
+
+Checks 2–3:
 1. Stale *_draft.md / *.stub.md files from before today
 2. Unmerged remote draft/* branches
 
 Also cleans up orphaned draft files: physical files left on disk as untracked
 after git rm. This prevents new-day-journal-check.py false positives on the
 next session (see dev-env#31).
-
-Exit 0 always — never block session close.
-Stdout is shown to user as a closing message.
 """
 
 import glob
@@ -23,7 +26,28 @@ from datetime import date
 from pathlib import Path
 
 JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
+SENTINEL = Path.home() / ".claude" / "scratch" / "stub-pushed.flag"
 TODAY = date.today().strftime("%Y-%m-%d")
+
+
+def consume_stub_pushed_sentinel() -> str | None:
+    """Return a reminder message if the stub-push sentinel exists, else None.
+
+    Deletes the sentinel before returning so the reminder fires only once.
+    Any I/O failure is swallowed — the sentinel check is best-effort.
+    """
+    try:
+        if SENTINEL.exists():
+            SENTINEL.unlink()
+            return (
+                "Stub committed and pushed to engineering-journal. "
+                "Archive this session now: call ccd_session_mgmt__archive_session "
+                "(use list_sessions to look up the current session_id if needed). "
+                "Then stop."
+            )
+    except Exception:
+        pass
+    return None
 
 
 def composed_project_dates_on_main() -> set[tuple[str, str]]:
@@ -93,28 +117,6 @@ def stale_draft_artifacts() -> list[str]:
     return stale
 
 
-def composed_dates_on_main() -> set[str]:
-    """Return YYYY-MM-DD dates that have a composed journal file on origin/main."""
-    try:
-        result = subprocess.run(
-            ["git", "ls-tree", "-r", "--name-only", "origin/main", "sessions/"],
-            cwd=JOURNAL_REPO,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        dates = set()
-        for line in result.stdout.splitlines():
-            fname = line.split("/")[-1]
-            if fname.endswith(".stub.md") or not fname.endswith(".md"):
-                continue
-            if len(fname) >= 10 and fname[4] == "-" and fname[7] == "-":
-                dates.add(fname[:10])
-        return dates
-    except Exception:
-        return set()
-
-
 def unmerged_draft_branches() -> list[str]:
     """Return remote draft/* branch names not yet merged into origin/main."""
     try:
@@ -134,7 +136,8 @@ def unmerged_draft_branches() -> list[str]:
         if not remote_dates:
             return []
 
-        merged = composed_dates_on_main()
+        merged_pairs = composed_project_dates_on_main()
+        merged = {d for _, d in merged_pairs}
         unmerged = sorted(
             [d for d in remote_dates if d != TODAY and d not in merged],
             reverse=True,
@@ -171,7 +174,12 @@ def main() -> None:
         raw = ""
     # session_id / transcript_path available if needed in future
 
+    # Sentinel check: stub was pushed this session — remind user to archive.
+    reminder = consume_stub_pushed_sentinel()
+
     messages = []
+    if reminder:
+        messages.append(f"[journal-stop-hook] {reminder}")
 
     stale = stale_draft_artifacts()
 

--- a/claude/scripts/stub-push-archive-reminder.py
+++ b/claude/scripts/stub-push-archive-reminder.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""PostToolUse/Bash hook — remind Claude to archive the session after a stub
-is pushed to engineering-journal.
+"""PostToolUse/Bash hook — set a sentinel flag after a stub is pushed to
+engineering-journal so the Stop hook can remind Claude to archive the session.
 
 Fires on every Bash tool call. Most calls are skipped quickly:
   1. Command must contain "git push"
@@ -8,10 +8,12 @@ Fires on every Bash tool call. Most calls are skipped quickly:
   3. Push must have succeeded (no error output)
   4. Most-recent commit in engineering-journal must touch a .stub.md file
 
-When all four conditions are met, exits 2 with a systemMessage prompting
-Claude to call ccd_session_mgmt__archive_session before stopping.
+When all four conditions are met, writes a sentinel file to the scratch
+directory. The Stop hook (journal-stop-check.py) reads and clears the
+sentinel and issues a closing reminder via stdout — the correct output
+channel for Stop hook messages.
 
-Exit 0 on every non-trigger path and on any exception — never blocks.
+Exit 0 on every code path — never blocks.
 
 Stdin JSON shape (PostToolUse):
   {
@@ -27,6 +29,7 @@ import sys
 from pathlib import Path
 
 JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
+SENTINEL = Path.home() / ".claude" / "scratch" / "stub-pushed.flag"
 
 
 def most_recent_commit_has_stub(repo: Path) -> bool:
@@ -76,14 +79,14 @@ def main() -> None:
     if not most_recent_commit_has_stub(JOURNAL_REPO):
         sys.exit(0)
 
-    msg = (
-        "Stub committed and pushed to engineering-journal. "
-        "Archive this session now: call ccd_session_mgmt__archive_session "
-        "(use list_sessions to look up the current session_id if needed). "
-        "Then stop."
-    )
-    print(json.dumps({"systemMessage": msg}))
-    sys.exit(2)
+    # Write sentinel — the Stop hook will consume it and issue the reminder
+    try:
+        SENTINEL.parent.mkdir(parents=True, exist_ok=True)
+        SENTINEL.write_text("1")
+    except Exception:
+        pass
+
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -153,7 +153,7 @@ Fires after each Bash tool call completes. Matched with `"matcher": "Bash"`.
 | `pr-merge-reminder.py` | Command contains `gh pr create` or `gh pr merge` | Exits 2 with a `systemMessage` reminding Claude to write a journal stub. |
 | `post-tool-use.py` | Command contains `gh issue create` or `gh pr create` | Auto-adds the created item to the configured GitHub Project. Opt-in via `"github_project_id"` in `.claude/hook-config.json`. |
 | `post-pr-merge-pull.py` | Command contains `gh pr merge` | Fast-forwards the local `main` branch via `git fetch origin main:main` so the local clone stays current after a merge. |
-| `stub-push-archive-reminder.py` | `git push` to `engineering-journal` with a stub commit | Exits 2 prompting Claude to call `ccd_session_mgmt__archive_session`. Verifies the most-recent commit in the journal repo touches a `.stub.md` file before firing. |
+| `stub-push-archive-reminder.py` | `git push` to `engineering-journal` with a stub commit | Writes a sentinel file (`~/.claude/scratch/stub-pushed.flag`) and exits 0. Verifies the most-recent commit in the journal repo touches a `.stub.md` file before writing the flag. The Stop hook (`journal-stop-check.py`) consumes the sentinel and issues the archive reminder via exit 2. |
 
 ---
 
@@ -164,7 +164,7 @@ Fires when the Claude Code session ends (user exits or `/stop`).
 | Script | What it does |
 |--------|-------------|
 | `token-tracker.py` | Reads the session JSONL, aggregates token usage, and appends a record to `~/.claude/scratch/token-sessions.jsonl`. Supports Sonnet 4.6, Opus 4.6, and Haiku 4.5 pricing. |
-| `journal-stop-check.py` | Checks for stale open journal stubs at session end. Emits a reminder if any are found. |
+| `journal-stop-check.py` | Checks for the stub-push sentinel flag (emits a closing message reminding the user to archive if found), then checks for stale open journal stubs and unmerged draft branches, emitting a closing message if any are found. Exit 0 always. |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Root cause:** PostToolUse hooks do not support the exit-2 `systemMessage` mechanism — any non-zero exit is treated as a blocking error. The original hook called `sys.exit(2)`, causing a spurious "blocking error" notification after every stub push. The same limitation applies to Stop hooks in this Claude Code environment.
- **Fix:** Two-part sentinel approach where all hooks exit 0 always:
  - `stub-push-archive-reminder.py` (PostToolUse) writes `~/.claude/scratch/stub-pushed.flag` when it detects a stub push, then exits 0.
  - `journal-stop-check.py` (Stop) checks for the sentinel at session end, consumes it (deletes it), and emits the archive reminder as a plain stdout closing message, then exits 0.
- Removed dead `composed_dates_on_main()` and wired `composed_project_dates_on_main()` into `unmerged_draft_branches()` — the project-aware variant is more precise (requires `sessions/<project>/<file>` depth).
- Updated `README.md` and `docs/REFERENCE.md` to reflect the new design.

## How it works

```
git push → engineering-journal stub commit
  └─ PostToolUse fires → writes stub-pushed.flag, exits 0 (no error)

Session ends
  └─ Stop hook fires → finds flag, deletes it, prints closing reminder to stdout, exits 0
     └─ User sees: "[journal-stop-hook] Stub committed and pushed ... Archive this session now."
```

The sentinel is consumed before the message is emitted so the reminder fires exactly once per push.

## Test plan

- [x] `python3 -m py_compile claude/scripts/*.py` — all pass
- [x] `python3 claude/scripts/stub-push-archive-reminder.py < /dev/null` → `exit: 0`
- [x] `python3 claude/scripts/journal-stop-check.py < /dev/null` (no sentinel) → `exit: 0`, no output
- [x] Write sentinel (`echo 1 > ~/.claude/scratch/stub-pushed.flag`), run stop-check → prints `[journal-stop-hook] Stub committed and pushed ...`, `exit: 0`, sentinel deleted

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
