### PR TITLE
config: allow Write to scratch dir without permission prompt

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,5 +1,10 @@
 {
   "model": "claude-sonnet-4-6",
+  "permissions": {
+    "allow": [
+      "Write(C:/Users/brown/.claude/scratch/**)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -2,7 +2,8 @@
   "model": "claude-sonnet-4-6",
   "permissions": {
     "allow": [
-      "Write(C:/Users/brown/.claude/scratch/**)"
+      "Write(C:/Users/brown/.claude/scratch/**)",
+      "Edit(C:/Users/brown/.claude/scratch/**)"
     ]
   },
   "hooks": {

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -118,6 +118,10 @@ All hooks are **advisory** — they emit `systemMessage` reminders via exit 2 bu
 Configuration is in `claude/settings.json` (symlinked to `~/.claude/settings.json`).
 See [ADR-007](adr/007-hook-command-invocation.md) for why hooks call `python3` directly rather than via a `bash -c` wrapper.
 
+#### Machine-local permissions
+
+The `permissions.allow` block in `claude/settings.json` contains paths with a hardcoded Windows username (`C:/Users/brown/...`). These rules are functionally correct on this machine but must be updated manually when bootstrapping dev-env on a new machine or account. If scratch-dir writes or edits start prompting for permission after a re-bootstrap, update the username in every `allow` entry.
+
 ---
 
 ### UserPromptSubmit


### PR DESCRIPTION
## Summary
- Adds `permissions.allow` rule for `Write(C:/Users/brown/.claude/scratch/**)` to `claude/settings.json`
- Eliminates permission prompts when I write temp files to the scratch directory during plan execution
- One-time global fix — no per-repo boilerplate needed

## Test plan
- [ ] Verify `python3 -m py_compile claude/scripts/*.py` passes (docs/config-only change, no scripts modified)
- [ ] Start a new session with bypass permissions active; confirm scratch dir writes (e.g. `gh` JSON output, temp parsing files) proceed without a prompt

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)