### PR TITLE
config: allow gh pr comment without permission prompt

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,7 +3,8 @@
   "permissions": {
     "allow": [
       "Write(C:/Users/brown/.claude/scratch/**)",
-      "Edit(C:/Users/brown/.claude/scratch/**)"
+      "Edit(C:/Users/brown/.claude/scratch/**)",
+      "Bash(gh pr comment *)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Adds `Bash(gh pr comment *)` to the global `permissions.allow` array in `claude/settings.json`
- The `/review` skill's `gh pr comment … && gh pr edit … && rm -f …` compound call was triggering a permission prompt in bypass permissions mode because no allow rule matched it
- Prefix-wildcard match covers the full compound command since the string starts with `gh pr comment`

## Test plan
- [ ] Run `/review <PR-URL>` in a session with bypass permissions mode active
- [ ] Confirm no permission prompt appears for the `gh pr comment` step

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)