### PR TITLE
cover-letter skill: JD preservation + two-pass draft retention

### DIFF
--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -1,24 +1,13 @@
 ---
 name: cover-letter
-description: Draft a cover letter for a job application following the full cover letter workflow. Invokes Haiku subagents for fit screening and (on the Opus path) style self-check. Invoke as /cover-letter [JD text, file path, PDF path, or URL].
+description: Draft a cover letter for a job application following the full cover letter workflow. Two-pass workflow: Opus completeness draft, then Sonnet density revision. Invokes Haiku subagents for fit screening and style self-check. Invoke as /cover-letter [JD text, file path, PDF path, or URL].
 argument-hint: "[JD text, file path, PDF path, or URL to job posting]"
 allowed-tools: Read Edit Write Bash Glob Grep Agent WebFetch AskUserQuestion
 ---
 
-You are drafting a cover letter for Mike Brown's job search, following the canonical workflow defined in `CLAUDE.md`.
+You are drafting a cover letter for Mike Brown's job search, following the canonical workflow defined in `CLAUDE.md` (job-search project).
 
-Follow every step in order. Do not skip steps.
-
-## Step -1 — Model selection
-
-Use AskUserQuestion with:
-- Question: "Which model should draft this cover letter?"
-- Header: "Draft model"
-- Options:
-  - "Sonnet (Recommended)" — faster and cheaper; sufficient for most applications; drafts inline (no subagent spawn)
-  - "Opus" — better prose quality; higher cost (~5–10× Sonnet); use for high-stakes applications
-
-Store the answer as DRAFT_MODEL: `"sonnet"` if Sonnet was selected, `"opus"` if Opus.
+Follow every step in order. Do not skip steps. The workflow is two-pass: an Opus completeness draft is followed by a Sonnet density revision; both files are committed in the application PR so the cut is reviewable, and the draft is deleted before the PR is merged.
 
 ## Step 0 — Load the job description
 
@@ -31,11 +20,35 @@ The job description is provided in `$ARGUMENTS`. Determine input type and load a
 
 Store the extracted JD text. If the JD text is under 50 words after extraction, tell the user the source may not have loaded correctly and ask them to paste the JD directly.
 
+Also collect the JD source string (the URL, file path, or `pasted text` literal) and today's date in `YYYYMMDD` format. These are used in Step 0b.
+
+## Step 0b — Save the JD to disk
+
+Confirm the company name and role title with the user if not clearly recoverable from the JD. Slugify both for the filename: keep alphanumerics, replace spaces with single underscores, no other punctuation. Use the same `Company` and `Role` slugs in every artifact for this application.
+
+Construct the JD path:
+
+```
+C:/Users/brown/Git/job-search/applications/cover_letters/MikeBrown_YYYYMMDD__Company__Role__JD.md
+```
+
+Use today's local calendar date for `YYYYMMDD`.
+
+If a file at that path already exists, skip silently — the JD is already preserved. Otherwise, write the file with this structure:
+
+```
+<!-- source: <URL or file path or "pasted text">; fetched: YYYY-MM-DD -->
+
+<JD text verbatim>
+```
+
+The save happens before fit screening so the JD artifact is preserved even if Step 2 returns SKIP.
+
 ## Step 1 — Company log check
 
 Read `C:/Users/brown/Git/job-search/context/company_log.md`. Keep this content in context — Step 11 will reuse it without re-reading the file.
 Check the "Roles Completed" and "Roles Skipped" tables for this company and role.
-If already present, stop and tell the user: "This role is already logged as [completed/skipped]."
+If already present, stop and tell the user: "This role is already logged as [completed/skipped]." (The JD has already been saved by Step 0b; that's acceptable — the JD artifact has standalone reference value.)
 
 ## Step 2 — Fit Screening (Haiku subagent)
 
@@ -77,7 +90,7 @@ Otherwise: Read `C:/Users/brown/Git/job-search/context/style_rules.md` in full. 
 
 Otherwise: Read `C:/Users/brown/Git/job-search/context/prose_style.md` in full.
 
-The `## Universal Self-Check` section from this file will be used in Step 6 (Sonnet inline check) or Step 7 (Haiku subagent) to verify the draft against universal prose rules that are not duplicated in the cover-letter-specific check.
+The `## Universal Self-Check` section from this file will be used in Step 8 (Haiku subagent) to verify the final letter against universal prose rules that are not duplicated in the cover-letter-specific check.
 
 ## Step 4 — Select model letter
 
@@ -104,44 +117,18 @@ Apply the patterns in the synopsis to calibrate opening sentence rhythm, paragra
 
 (The full voice reference files are at `models/voice/` and can be consulted if a specific passage is needed, but the synopsis is sufficient for drafting.)
 
-## Step 5c — Filter accomplishments (Opus path only)
-
-**Skip this step if DRAFT_MODEL is `"sonnet"`.**
+## Step 5c — Filter accomplishments
 
 From the full accomplishments list in context, identify the 4–8 rows most directly relevant to this JD. Criteria: direct match to the JD's stated technical requirements, team size expectations, industry context, or compliance posture. Exclude rows with no plausible relevance to this specific role.
 
 Store the filtered set as RELEVANT_ACCOMPLISHMENTS.
 
-## Step 6 — Draft the letter
+## Step 6 — Completeness draft (Opus subagent)
 
-### Sonnet path (DRAFT_MODEL = "sonnet")
-
-Draft the letter body directly — do not spawn a subagent. All context (style rules, model letter, accomplishments, voice synopsis) is already in context from Steps 3–5b.
-
-Apply all style rules from Step 3. Use the model letter from Step 4 as a structural reference. Adapt tone and emphasis to the specific JD. Draw only from accomplishments in Step 5. Calibrate rhythm using the voice synopsis from Step 5b.
-
-Constraints:
-- No em-dashes (anywhere, no exceptions)
-- No banned constructions ("The outcomes were concrete" and all variants)
-- Do not claim Mike "led a platform directorate" — use "led platform teams responsible for..." or "led programs within the platform organization"
-- Body word ceiling: 475 words (body paragraphs only)
-- Output is Markdown only
-
-After drafting, run a self-check inline — do not spawn a separate subagent. Run both checks in sequence:
-
-1. **Universal Self-Check** — from `prose_style.md` `## Universal Self-Check` (already in context from Step 3b). Applies to all external-facing content: em-dashes, filler phrases, AI-tell patterns, rhythm, passive voice, etc.
-2. **Cover-Letter-Specific Self-Check** — from `style_rules.md` `## Cover-Letter-Specific Self-Check` (already in context from Step 3). Cover-letter extensions only: word count, HQ address, markdown format, closing construction, leadership philosophy presence, etc.
-
-Fix any violations before continuing. Report "PASS" or list each fix made with the offending text.
-
-Collect the final draft as DRAFT. Skip Step 7 and proceed to Step 8.
-
-### Opus path (DRAFT_MODEL = "opus")
-
-Spawn an Agent with `model: "opus"`. Pass all of the following inline — do not
-instruct the subagent to read any files:
+Spawn an Agent with `model: "opus"`. Pass all of the following inline — do not instruct the subagent to read any files:
 
 - All style rules (from Step 3, verbatim)
+- The universal self-check (from `prose_style.md` `## Universal Self-Check`, already in context from Step 3b)
 - The model letter (from Step 4, verbatim)
 - RELEVANT_ACCOMPLISHMENTS (from Step 5c — filtered rows only, not the full list)
 - The voice synopsis (from Step 5b, verbatim)
@@ -149,29 +136,49 @@ instruct the subagent to read any files:
 
 Subagent task:
 
-> Draft the cover letter body in Markdown. Apply all style rules provided:
+> Draft the cover letter body in Markdown. This is the **completeness draft**: prioritize narrative arc, leadership philosophy, signal calibration, and accomplishment density over compactness. No upper word cap; aim for whatever length the argument actually needs. If the draft exceeds roughly 700 words, return early with a flag — over-700 typically signals two role mandates or three threads where there should be two, and the letter plan needs revision before drafting continues.
+>
+> Apply all style rules provided:
 > - No em-dashes (anywhere, no exceptions)
 > - No banned constructions ("The outcomes were concrete" and all variants)
 > - Do not claim Mike "led a platform directorate" — use "led platform teams responsible for..." or "led programs within the platform organization"
-> - Body word ceiling: 475 words (body paragraphs only)
 > - Output is Markdown only
 >
-> Use the model letter as a structural reference. Adapt tone and emphasis to the specific JD.
-> Do not copy model letter text verbatim.
+> Use the model letter as a structural reference; do not copy text verbatim. Adapt tone and emphasis to the specific JD.
 >
 > Return only the letter body — no preamble, no commentary.
 
 Collect the subagent's output as DRAFT.
 
-## Step 7 — Style self-check (Haiku subagent — Opus path only)
+If the subagent flagged over-700, surface to the user and ask whether to proceed (revise the letter plan and re-run) or override and continue with the long draft.
 
-**Skip this step if DRAFT_MODEL is `"sonnet"` (self-check was run inline in Step 6).**
+Save DRAFT to:
+
+```
+C:/Users/brown/Git/job-search/applications/cover_letters/MikeBrown_YYYYMMDD__Company__Role__Cover_Letter_Draft.md
+```
+
+Same `YYYYMMDD`, `Company`, and `Role` slugs as the JD file from Step 0b.
+
+## Step 7 — Density revision (Sonnet, inline)
+
+Apply the precision-then-compactness pass from `prose_style.md` (`## Precision in Word Choice` and `## Compactness Techniques`) aggressively to DRAFT. Target 400 words; 450 is the hard ceiling. The revision should sharpen verbs, remove hedges, collapse redundant clauses, and tighten transitions while preserving the narrative arc, philosophy paragraph, and signal calibration of the completeness draft.
+
+Save the revised letter to:
+
+```
+C:/Users/brown/Git/job-search/applications/cover_letters/MikeBrown_YYYYMMDD__Company__Role__Cover_Letter.md
+```
+
+If this letter is intended as a new canonical model (a new role type not yet in `models/letters/`), also copy the revised version to `C:/Users/brown/Git/job-search/models/letters/` and update `models/INDEX.md`.
+
+## Step 8 — Style self-check (Haiku subagent)
 
 Both style files are already in context. Extract verbatim: (a) the `## Universal Self-Check` section from `prose_style.md` and (b) the `## Cover-Letter-Specific Self-Check` section from `style_rules.md`. Pass both inline — do not instruct the subagent to read any files.
 
 Spawn a **Haiku** subagent with this task:
 
-> You are performing a style self-check on a cover letter draft. Run both checks in sequence. Report each violation with the offending text quoted and the rule it breaks. If no violations in either check, report "PASS".
+> You are performing a style self-check on a cover letter. Run both checks in sequence. Report each violation with the offending text quoted and the rule it breaks. If no violations in either check, report "PASS".
 >
 > **Check 1 — Universal Self-Check (prose_style.md):**
 > <paste the "## Universal Self-Check" section from prose_style.md verbatim>
@@ -180,17 +187,15 @@ Spawn a **Haiku** subagent with this task:
 > <paste the "## Cover-Letter-Specific Self-Check" section from style_rules.md verbatim>
 >
 > **Letter body:**
-> <paste full draft here>
+> <paste the Step 7 density-revised letter here>
 
 Report the subagent's findings to the user.
 
-## Step 8 — Fix violations
+## Step 9 — Fix violations and verify word count
 
-Apply every violation flagged in Step 6 (Sonnet) or Step 7 (Opus). Re-read each fixed passage to confirm it is clean.
+Apply every violation flagged in Step 8 to the `__Cover_Letter.md` file. Re-read each fixed passage to confirm it is clean.
 
-## Step 9 — Word count
-
-Write the letter body to a temp file and count words:
+Write the final letter body to a temp file and count words:
 ```bash
 TMPFILE="C:/Users/brown/.claude/scratch/wc_$$.txt"
 cat > "$TMPFILE" << 'LETTER'
@@ -200,32 +205,19 @@ wc -w < "$TMPFILE"
 rm -f "$TMPFILE"
 ```
 
-The body must be under 475 words (count body paragraphs only — exclude header block, salutation, and sign-off). If over, trim.
+The body must be at most 450 words with a 400-word target (count body paragraphs only — exclude header block, salutation, and sign-off). If over 450, trim further. Report the final word count to the user.
 
-Report the final word count to the user.
-
-## Step 10 — Save the letter
-
-Determine the output path:
-- If this letter is intended as a new canonical model (a new role type not yet in `models/letters/`), save to `C:/Users/brown/Git/job-search/models/letters/` and update `models/INDEX.md`
-- Otherwise, save to `C:/Users/brown/Git/job-search/applications/cover_letters/`
-
-File name format: `MikeBrown_YYYYMMDD__Company__Role__Cover_Letter.md`
-Use today's date. Confirm company name and role title with the user if not clear from the JD.
-
-Write the file.
-
-## Step 11 — Log the application
+## Step 10 — Log the application
 
 The `context/company_log.md` content is already in context from Step 1 — do not re-read the file.
-Add a row to the "Roles Completed" table with: company name, role title, date, and the file path of the saved letter.
+Add a row to the "Roles Completed" table with: company name, role title, date, and the file path of the saved `__Cover_Letter.md` file.
 Write the updated file.
 
-## Step 12 — Report to user
+## Step 11 — Report to user
 
-Before reporting the file path, compute a path relative to the current working directory so the link resolves correctly in the UI (this matters when the session runs in a git worktree).
+Before reporting file paths, compute paths relative to the current working directory so links resolve correctly in the UI (this matters when the session runs in a git worktree).
 
-Replace `<abs>` with the absolute path written in Step 10, then run:
+For each of the three artifacts (`__JD.md`, `__Cover_Letter_Draft.md`, `__Cover_Letter.md`), replace `<abs>` with the absolute path written and run:
 
 ```bash
 ABS="<abs>"
@@ -233,11 +225,14 @@ PYBIN=$(command -v python3 || command -v python)
 "$PYBIN" -c "import os; print(os.path.relpath('$ABS', os.getcwd()).replace('\\', '/'))"
 ```
 
-Use the printed path as the markdown link href — e.g., `[filename](relative/path/filename.md)`.
+Use the printed paths as the markdown link hrefs — e.g., `[filename](relative/path/filename.md)`.
 
 Tell the user:
-- Where the letter was saved (as a clickable markdown link using the relative path computed above)
-- Final word count
-- Draft model used (Sonnet or Opus)
+- Where each of the three artifacts was saved (clickable markdown links using the relative paths computed above)
+- Final word count of `__Cover_Letter.md`
 - Any flags raised during fit screening that are still relevant
 - Any open items (e.g., missing salary range, unclear hiring manager name)
+
+## Step 12 — Pre-merge cleanup note
+
+Remind the user that before the application PR is merged, the `__Cover_Letter_Draft.md` artifact must be deleted from the branch — only `__JD.md` and `__Cover_Letter.md` should land on `main`. The density revision is the canonical artifact; the draft was a process aid that exists in the PR for reviewable contrast only. The skill itself does not delete the draft (the PR has not yet been opened at this point in the workflow); the cleanup is the responsibility of the author or the merge-time session, per `CLAUDE.md` "How to Draft" Step 13.

--- a/claude/skills/cover-letter/SKILL.md
+++ b/claude/skills/cover-letter/SKILL.md
@@ -20,35 +20,14 @@ The job description is provided in `$ARGUMENTS`. Determine input type and load a
 
 Store the extracted JD text. If the JD text is under 50 words after extraction, tell the user the source may not have loaded correctly and ask them to paste the JD directly.
 
-Also collect the JD source string (the URL, file path, or `pasted text` literal) and today's date in `YYYYMMDD` format. These are used in Step 0b.
-
-## Step 0b — Save the JD to disk
-
-Confirm the company name and role title with the user if not clearly recoverable from the JD. Slugify both for the filename: keep alphanumerics, replace spaces with single underscores, no other punctuation. Use the same `Company` and `Role` slugs in every artifact for this application.
-
-Construct the JD path:
-
-```
-C:/Users/brown/Git/job-search/applications/cover_letters/MikeBrown_YYYYMMDD__Company__Role__JD.md
-```
-
-Use today's local calendar date for `YYYYMMDD`.
-
-If a file at that path already exists, skip silently — the JD is already preserved. Otherwise, write the file with this structure:
-
-```
-<!-- source: <URL or file path or "pasted text">; fetched: YYYY-MM-DD -->
-
-<JD text verbatim>
-```
-
-The save happens before fit screening so the JD artifact is preserved even if Step 2 returns SKIP.
+Also collect the JD source string (the URL, file path, or `pasted text` literal) and today's date in `YYYYMMDD` format. These are used in Step 0b after fit screening passes.
 
 ## Step 1 — Company log check
 
-Read `C:/Users/brown/Git/job-search/context/company_log.md`. Keep this content in context — Step 11 will reuse it without re-reading the file.
+Read `C:/Users/brown/Git/job-search/context/company_log.md`. Keep this content in context — Step 10 will reuse it without re-reading the file.
+Identify the company and role from the JD text (no filename slugification needed yet — that happens in Step 0b after fit screening).
 Check the "Roles Completed" and "Roles Skipped" tables for this company and role.
-If already present, stop and tell the user: "This role is already logged as [completed/skipped]." (The JD has already been saved by Step 0b; that's acceptable — the JD artifact has standalone reference value.)
+If already present, stop and tell the user: "This role is already logged as [completed/skipped]."
 
 ## Step 2 — Fit Screening (Haiku subagent)
 
@@ -77,6 +56,28 @@ Spawn a **Haiku** subagent. Pass the extracted sections inline — do not instru
 If the subagent returns SKIP, stop and report the result to the user. Do not proceed.
 If the subagent returns FLAG, surface the flags and ask the user whether to proceed.
 If PROCEED, continue.
+
+## Step 0b — Save the JD to disk
+
+Run this step only after Step 2 returns PROCEED (or FLAG with user override). Auto-skipped JDs are not saved — the skip itself is logged in `Roles Skipped` and the JD source string remains in `$ARGUMENTS` history if needed.
+
+Confirm the company name and role title with the user if not clearly recoverable from the JD. Slugify both for the filename: keep alphanumerics, replace spaces with single underscores, no other punctuation. Use the same `Company` and `Role` slugs in every artifact for this application.
+
+Construct the JD path:
+
+```
+C:/Users/brown/Git/job-search/applications/cover_letters/MikeBrown_YYYYMMDD__Company__Role__JD.md
+```
+
+Use today's local calendar date for `YYYYMMDD`.
+
+If a file at that path already exists, compare its `<!-- source: -->` comment to the current source string (URL or file path). If they match, skip silently — the JD is already preserved. If they differ, surface a one-line note to the user ("existing JD at <path> has source <X>; this run's source is <Y> — keeping existing file") and continue without overwriting. Otherwise, write the file with this structure:
+
+```
+<!-- source: <URL or file path or "pasted text">; fetched: YYYY-MM-DD -->
+
+<JD text verbatim>
+```
 
 ## Step 3 — Read style rules
 

--- a/claude/skills/cover-letter/WORKFLOW.md
+++ b/claude/skills/cover-letter/WORKFLOW.md
@@ -5,8 +5,7 @@ Visual reference for the `/cover-letter` skill execution path. The workflow is t
 ```mermaid
 flowchart TD
     S0["Step 0 — Load JD\nfile / PDF / URL / pasted text"]
-    S0 --> S0B["Step 0b — Save JD to disk\n__JD.md"]
-    S0B --> S1["Step 1 — Company log check"]
+    S0 --> S1["Step 1 — Company log check"]
     S1 -->|"Already logged"| STOP(["Stop"])
     S1 --> S2
 
@@ -14,8 +13,10 @@ flowchart TD
     S2 -->|"SKIP"| STOP
     S2 -->|"FLAG"| FLAG{"Proceed?"}
     FLAG -->|"No"| STOP
-    FLAG -->|"Yes"| CTX_START
-    S2 -->|"PROCEED"| CTX_START
+    FLAG -->|"Yes"| S0B
+    S2 -->|"PROCEED"| S0B
+    S0B["Step 0b — Save JD to disk\n__JD.md\n(only after fit screen passes)"]
+    S0B --> CTX_START
 
     subgraph CTX ["Context loading — session-cached where noted"]
         CTX_START["Step 3 — style_rules.md ♻"]
@@ -48,7 +49,7 @@ flowchart TD
 | Fit screening | Haiku subagent | 650 |
 | Context reads (Steps 3–5b) | Main agent | 1,735 |
 | Completeness draft | Opus subagent | 1,620 |
-| Density revision | Main agent (Sonnet) | inline |
+| Density revision | Main agent (Sonnet) | ~1,400 (no spawn; cost ≈ draft length) |
 | Style self-check | Haiku subagent | 700 |
 
 **Batch savings (letters 2-N, session-cached reads):** ~1,170 tokens eliminated per letter (Steps 3, 3b, 5, 5b skip re-reads).

--- a/claude/skills/cover-letter/WORKFLOW.md
+++ b/claude/skills/cover-letter/WORKFLOW.md
@@ -1,17 +1,12 @@
 # Cover Letter Skill — Execution Flow
 
-Visual reference for the `/cover-letter` skill execution path, including which steps are
-session-cached for batch runs and where the Sonnet and Opus paths diverge.
+Visual reference for the `/cover-letter` skill execution path. The workflow is two-pass: Opus produces a completeness draft, Sonnet produces a density revision, and the Haiku self-check runs against the revised version.
 
 ```mermaid
 flowchart TD
-    S_1["Step -1 — Model selection\nSonnet ✦ recommended\nOpus — high-stakes"]
-    S_1 -->|"Sonnet"| SON(["DRAFT_MODEL = sonnet"])
-    S_1 -->|"Opus"| OPU(["DRAFT_MODEL = opus"])
-    SON & OPU --> S0
-
     S0["Step 0 — Load JD\nfile / PDF / URL / pasted text"]
-    S0 --> S1["Step 1 — Company log check"]
+    S0 --> S0B["Step 0b — Save JD to disk\n__JD.md"]
+    S0B --> S1["Step 1 — Company log check"]
     S1 -->|"Already logged"| STOP(["Stop"])
     S1 --> S2
 
@@ -28,29 +23,23 @@ flowchart TD
         CTX_3B --> CTX_4["Step 4 — Model letter\nalways re-read"]
         CTX_4 --> CTX_5["Step 5 — accomplishments.md ♻"]
         CTX_5 --> CTX_5B["Step 5b — VOICE_SYNOPSIS.md ♻"]
+        CTX_5B --> S5C["Step 5c — Filter accomplishments\n4–8 relevant rows → RELEVANT_ACCOMPLISHMENTS"]
     end
 
-    CTX_5B --> BRANCH{"DRAFT_MODEL?"}
+    S5C --> S6["Step 6 — Completeness draft (Opus subagent)\nNarrative arc, philosophy, signal calibration\nNo word cap; 700-word soft warning\n→ __Cover_Letter_Draft.md"]
+    S6 --> S7["Step 7 — Density revision (Sonnet, inline)\nPrecision-then-compactness pass\nTarget 400 / ceiling 450\n→ __Cover_Letter.md"]
 
-    BRANCH -->|"opus"| S5C["Step 5c — Filter accomplishments\n4–8 relevant rows → RELEVANT_ACCOMPLISHMENTS"]
-    S5C --> OPUS_DRAFT["Step 6 (Opus)\nSpawn Opus subagent\nPasses: style rules, model letter,\nRELEVANT_ACCOMPLISHMENTS,\nvoice synopsis, JD"]
-    OPUS_DRAFT --> S7["Step 7 — Haiku self-check\n① Universal Self-Check\n② Cover-Letter-Specific Self-Check"]
-
-    BRANCH -->|"sonnet"| SONNET_DRAFT["Step 6 (Sonnet)\nDraft inline — all context in window\nApply: style rules, model letter,\naccomplishments, voice synopsis"]
-    SONNET_DRAFT --> S6_CHECK["Inline self-check\n① Universal Self-Check\n② Cover-Letter-Specific Self-Check\n↳ Skip Step 7"]
-
-    S7 --> S8["Step 8 — Fix violations"]
-    S6_CHECK --> S8
-
-    S8 --> S9["Step 9 — Word count ≤ 475"]
-    S9 --> S10["Step 10 — Save letter"]
-    S10 --> S11["Step 11 — Log application\n(company_log.md already in context)"]
-    S11 --> S12["Step 12 — Report\nfile link · word count · model used · flags"]
+    S7 --> S8["Step 8 — Haiku self-check against final\n① Universal Self-Check\n② Cover-Letter-Specific Self-Check"]
+    S8 --> S9["Step 9 — Fix violations + word count ≤ 450"]
+    S9 --> S10["Step 10 — Log application\n(company_log.md already in context)"]
+    S10 --> S11["Step 11 — Report\nthree artifact links · word count · flags"]
+    S11 --> S12["Step 12 — Pre-merge cleanup note\n__Cover_Letter_Draft.md must be deleted before PR merge"]
 ```
 
 **Legend:**
 - ♻ Session-cached: skip re-read if already in context from a prior letter this session
 - Self-check ① then ②: Universal check covers all prose rules; Cover-Letter-Specific covers format, length, structure
+- Three artifacts share the stem `MikeBrown_YYYYMMDD__Company__Role__`: `__JD.md` (Step 0b), `__Cover_Letter_Draft.md` (Step 6), `__Cover_Letter.md` (Step 7)
 
 **Token profile (per letter, first in session):**
 
@@ -58,12 +47,18 @@ flowchart TD
 |---|---|---|
 | Fit screening | Haiku subagent | 650 |
 | Context reads (Steps 3–5b) | Main agent | 1,735 |
-| Draft — Sonnet inline | Main agent | 0 extra |
-| Draft — Opus subagent | Opus subagent | 1,620 |
-| Self-check — Sonnet inline | Main agent | 0 extra |
-| Self-check — Haiku (Opus path) | Haiku subagent | 700 |
+| Completeness draft | Opus subagent | 1,620 |
+| Density revision | Main agent (Sonnet) | inline |
+| Style self-check | Haiku subagent | 700 |
 
-**Batch savings (letters 2-N, session-cached reads):** ~1,170 tokens eliminated per letter
-(Steps 3, 3b, 5, 5b skip re-reads).
+**Batch savings (letters 2-N, session-cached reads):** ~1,170 tokens eliminated per letter (Steps 3, 3b, 5, 5b skip re-reads).
 
-See [ADR 009](../../docs/adr/009-cover-letter-token-efficiency.md) for the full analysis.
+**Lifecycle of the three artifacts:**
+
+| Artifact | Step | In PR? | After merge? |
+|---|---|---|---|
+| `__JD.md` | 0b | yes | kept |
+| `__Cover_Letter_Draft.md` | 6 | yes (cut to final is reviewable) | **deleted** |
+| `__Cover_Letter.md` | 7, post-revision | yes | kept (canonical) |
+
+See [ADR 009](../../docs/adr/009-cover-letter-token-efficiency.md) for the original token-efficiency analysis (predates the two-pass workflow; numbers above reflect current flow).

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -93,11 +93,11 @@ Reviews a PR or pasted diff for correctness, security, reliability, and maintain
 
 Drafts a cover letter for Mike Brown's job search. Accepts the job description as inline text, a file path (`.md`, `.txt`, `.docx`, `.pdf`), or a URL.
 
-**Workflow (two-pass):** loads JD → saves JD to disk (`__JD.md`) → checks company log for duplicates → runs fit screening (Haiku subagent) → completeness draft via Opus subagent (`__Cover_Letter_Draft.md`) → density revision inline on Sonnet (`__Cover_Letter.md`) → runs style self-check on the final (Haiku subagent) → logs result to `job-search/context/company_log.md`.
+**Workflow (two-pass):** loads JD → checks company log for duplicates → runs fit screening (Haiku subagent) → saves JD to disk (`__JD.md`, only on PROCEED/FLAG-override) → completeness draft via Opus subagent (`__Cover_Letter_Draft.md`) → density revision inline on Sonnet (`__Cover_Letter.md`) → runs style self-check on the final (Haiku subagent) → logs result to `job-search/context/company_log.md`.
 
 **Three artifacts share the stem `MikeBrown_YYYYMMDD__Company__Role__`** under `job-search/applications/cover_letters/`: `__JD.md` (kept), `__Cover_Letter_Draft.md` (deleted before PR merge), `__Cover_Letter.md` (canonical, kept).
 
-**Returns:** PROCEED / FLAG / SKIP from fit screen, then both drafts and a pre-merge cleanup reminder if proceeding.
+**Returns:** PROCEED / FLAG / SKIP from fit screen, then all three artifacts (JD, completeness draft, density revision) and a pre-merge cleanup reminder if proceeding.
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -93,9 +93,11 @@ Reviews a PR or pasted diff for correctness, security, reliability, and maintain
 
 Drafts a cover letter for Mike Brown's job search. Accepts the job description as inline text, a file path (`.md`, `.txt`, `.docx`, `.pdf`), or a URL.
 
-**Workflow:** loads JD → checks company log for duplicates → runs fit screening (Haiku subagent) → drafts letter → runs style self-check (Haiku subagent) → logs result to `job-search/context/company_log.md`.
+**Workflow (two-pass):** loads JD → saves JD to disk (`__JD.md`) → checks company log for duplicates → runs fit screening (Haiku subagent) → completeness draft via Opus subagent (`__Cover_Letter_Draft.md`) → density revision inline on Sonnet (`__Cover_Letter.md`) → runs style self-check on the final (Haiku subagent) → logs result to `job-search/context/company_log.md`.
 
-**Returns:** PROCEED / FLAG / SKIP from fit screen, then the drafted letter if proceeding.
+**Three artifacts share the stem `MikeBrown_YYYYMMDD__Company__Role__`** under `job-search/applications/cover_letters/`: `__JD.md` (kept), `__Cover_Letter_Draft.md` (deleted before PR merge), `__Cover_Letter.md` (canonical, kept).
+
+**Returns:** PROCEED / FLAG / SKIP from fit screen, then both drafts and a pre-merge cleanup reminder if proceeding.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Step 0b (new):** save the JD to `applications/cover_letters/MikeBrown_YYYYMMDD__Company__Role__JD.md` after extraction and before fit screening, so the JD artifact persists even on auto-skip. Closes the gap where applications had no recoverable record of what they were responding to.
- **Step 6 → Step 7 split:** the draft step is now two passes — Opus completeness draft (`__Cover_Letter_Draft.md`, no word cap, 700-word soft warning) followed by inline Sonnet density revision (`__Cover_Letter.md`, target 400 / ceiling 450). Both files ride in the application PR so the cut to the final is reviewable; the draft is deleted before merge.
- **Step -1 (model selection) retired:** the workflow is always Opus-then-Sonnet two-pass now; the user-facing model toggle is no longer applicable.
- **Word ceiling 475 → 450** to match the project `CLAUDE.md` and `applications/README.md`.
- `WORKFLOW.md` mermaid and token table rewritten to match.
- `docs/REFERENCE.md` `/cover-letter` entry updated.

Companion job-search PR: brownm09/career-playbook#73

## Test plan

- [x] `python3 -m py_compile claude/scripts/*.py` (per `claude/CLAUDE.md` `## Testing`) — passes (no Python touched in this PR; sanity check only).
- [ ] Smoke run of `/cover-letter` with a real JD URL, in a fresh session, to confirm: JD lands at `__JD.md` before fit screen; `__Cover_Letter_Draft.md` and `__Cover_Letter.md` both land with matching stems; final body is ≤ 450 words. (Deferred to next live application — no synthetic test JD on hand.)
- [x] Manual review of `SKILL.md` step numbering — linear 0, 0b, 1, 2, 3, 3b, 4, 5, 5b, 5c, 6, 7, 8, 9, 10, 11, 12 with no gaps.

Closes #157