### PR TITLE
feat: add /journal-onboard skill and detection hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Custom slash commands loaded from `claude/skills/`. Invoke with `/skill-name [ar
 | [`/review <PR-URL> [flags]`](claude/skills/review/SKILL.md) | Reviews a PR for correctness, security, reliability, and maintainability. Posts report as PR comment by default. |
 | [`/cover-letter [JD]`](claude/skills/cover-letter/SKILL.md) | Drafts a cover letter for a job application. Runs fit screening and style check as Haiku subagents. |
 | [`/fit-screen [JD]`](claude/skills/fit-screen/SKILL.md) | Fit-screens a job description. Returns PROCEED / FLAG / SKIP. |
+| [`/journal-onboard [slug]`](claude/skills/journal-onboard/SKILL.md) | Scaffolds `sessions/<project>/` in engineering-journal and optionally creates `.claude/CLAUDE.md` in the project repo. |
 
 ## Hooks
 
@@ -47,6 +48,7 @@ All hooks are advisory — none block tool execution.
 |---|---|---|
 | UserPromptSubmit | `dev-env-sync.py` | Fast-forward pulls dev-env to `origin/main` at session start |
 | UserPromptSubmit | `new-day-journal-check.py` | Warns if stale `draft/*` journal branches exist on origin |
+| UserPromptSubmit | `journal-onboard-check.py` | Warns when the active project has no journal home in engineering-journal |
 | UserPromptSubmit | `turn-count-hook.py` | Warns when session context token count exceeds threshold |
 | UserPromptSubmit | `multi-worktree-alert.py` | Lists active worktrees in `repo:branch` format when ≥2 are open |
 | PreToolUse (Bash) | `pre-commit-branch-check.py` | Emits current branch as a checkpoint before `git commit` |

--- a/claude/scripts/journal-onboard-check.py
+++ b/claude/scripts/journal-onboard-check.py
@@ -56,6 +56,7 @@ def main() -> None:
         if flag_path.exists():
             sys.exit(0)
         try:
+            SCRATCH.mkdir(parents=True, exist_ok=True)
             flag_path.touch()
         except Exception:
             pass

--- a/claude/scripts/journal-onboard-check.py
+++ b/claude/scripts/journal-onboard-check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: detect when the active project has no engineering-journal home.
+
+Fires once per session. If the current git repo has no corresponding sessions/<repo>/
+directory in engineering-journal, emits a one-line advisory pointing to /journal-onboard.
+
+Exit 0 always — never blocks the user's prompt.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+JOURNAL_SESSIONS = Path.home() / "Git" / "engineering-journal" / "sessions"
+SCRATCH = Path.home() / ".claude" / "scratch"
+
+
+def get_repo_name(cwd: str) -> str | None:
+    """Return the git repo name for cwd, handling worktrees correctly."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+        git_common_dir = result.stdout.strip()
+        # --git-common-dir returns a path like /path/to/repo/.git
+        # Parent of that is the repo root; its name is the repo name.
+        git_path = Path(git_common_dir)
+        if not git_path.is_absolute():
+            git_path = Path(cwd) / git_path
+        repo_root = git_path.parent.resolve()
+        return repo_root.name
+    except Exception:
+        return None
+
+
+def main() -> None:
+    raw = ""
+    try:
+        raw = sys.stdin.read().strip()
+    except Exception:
+        pass
+    hook_data = json.loads(raw) if raw else {}
+    session_id = hook_data.get("session_id", "")
+    cwd = hook_data.get("cwd", "")
+
+    # Fire once per session regardless of outcome
+    if session_id:
+        flag_path = SCRATCH / f"journal_onboard_{session_id}.flag"
+        if flag_path.exists():
+            sys.exit(0)
+        try:
+            flag_path.touch()
+        except Exception:
+            pass
+
+    if not cwd:
+        sys.exit(0)
+
+    repo_name = get_repo_name(cwd)
+    if not repo_name:
+        sys.exit(0)
+
+    # Skip engineering-journal itself
+    if repo_name == "engineering-journal":
+        sys.exit(0)
+
+    journal_home = JOURNAL_SESSIONS / repo_name
+    if not journal_home.exists():
+        print(
+            f"[journal-onboard] No journal home found for `{repo_name}`.\n"
+            f"Run `/journal-onboard` to scaffold `sessions/{repo_name}/` in engineering-journal."
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -37,6 +37,10 @@
           },
           {
             "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/journal-onboard-check.py"
+          },
+          {
+            "type": "command",
             "command": "python3 C:/Users/brown/.claude/scripts/turn-count-hook.py"
           },
           {

--- a/claude/skills/journal-onboard/SKILL.md
+++ b/claude/skills/journal-onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: journal-onboard
 description: Scaffold a new project's journal home (sessions/<project>/) in engineering-journal and optionally create a .claude/CLAUDE.md in the project repo.
 argument-hint: "[project-slug]"
-allowed-tools: Read Write Bash Glob
+allowed-tools: Read Write Edit Bash Glob
 ---
 
 You are implementing the `/journal-onboard` workflow: create a journal home for a new project in the engineering-journal repo and optionally scaffold `.claude/CLAUDE.md` in the project repo.
@@ -102,7 +102,7 @@ If no: note that the journal path convention requires `.claude/CLAUDE.md` to con
 Ask the user:
 > "`.claude/CLAUDE.md` exists but has no journal path. Append the `## Journal` section? (yes/no)"
 
-If yes: append to the file:
+If yes: use the Edit tool to append to the file. Add the following block at the end:
 ```markdown
 
 ## Journal

--- a/claude/skills/journal-onboard/SKILL.md
+++ b/claude/skills/journal-onboard/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: journal-onboard
+description: Scaffold a new project's journal home (sessions/<project>/) in engineering-journal and optionally create a .claude/CLAUDE.md in the project repo.
+argument-hint: "[project-slug]"
+allowed-tools: Read Write Bash Glob
+---
+
+You are implementing the `/journal-onboard` workflow: create a journal home for a new project in the engineering-journal repo and optionally scaffold `.claude/CLAUDE.md` in the project repo.
+
+---
+
+## Step 0 — Determine project slug
+
+If `$ARGUMENTS` is provided, use it as the slug.
+
+Otherwise, infer from the current git repo:
+```bash
+git rev-parse --git-common-dir
+```
+Take the parent directory of the output and use its basename as the slug. For example,
+`C:/Users/brown/Git/my-project/.git` → slug = `my-project`.
+
+Confirm with the user:
+> "Onboarding project `<slug>` — is this the right journal slug?"
+
+Wait for confirmation before proceeding.
+
+---
+
+## Step 1 — Safety check
+
+Check whether the journal home already exists:
+```bash
+ls ~/Git/engineering-journal/sessions/<slug>/
+```
+
+If the directory exists: report "Journal home for `<slug>` already exists at `sessions/<slug>/`. Nothing to do." and stop.
+
+---
+
+## Step 2 — Prepare engineering-journal
+
+```bash
+git -C ~/Git/engineering-journal checkout main
+git -C ~/Git/engineering-journal pull
+```
+
+---
+
+## Step 3 — Scaffold journal home
+
+Create the directory and `README.md`:
+
+```bash
+mkdir -p ~/Git/engineering-journal/sessions/<slug>
+```
+
+Write `~/Git/engineering-journal/sessions/<slug>/README.md`:
+
+```markdown
+# <slug>
+
+<!-- one-line description of the project -->
+
+## Progress Summary
+
+_No sessions yet._
+
+## Where to Start Next Session
+
+_First session — no prior context._
+
+## Sessions
+
+| Date | Session | Topics |
+|---|---|---|
+```
+
+---
+
+## Step 4 — Check project CLAUDE.md
+
+Check whether `.claude/CLAUDE.md` exists in the current project repo:
+```bash
+cat .claude/CLAUDE.md 2>/dev/null
+```
+
+**If the file does not exist:**
+
+Ask the user:
+> "No `.claude/CLAUDE.md` found. Create one from the standard template? (yes/no)"
+
+If yes: read `~/.claude/templates/project-claude.md`, replace `<REPO_NAME>` with the repo
+basename and `<PROJECT_SLUG>` with the slug, then write it to `.claude/CLAUDE.md`. Remind
+the user to commit it in the project repo.
+
+If no: note that the journal path convention requires `.claude/CLAUDE.md` to contain a
+`## Journal` section with the path `sessions/<slug>/`, and that the user should add it manually.
+
+**If the file exists but contains no `sessions/` path reference:**
+
+Ask the user:
+> "`.claude/CLAUDE.md` exists but has no journal path. Append the `## Journal` section? (yes/no)"
+
+If yes: append to the file:
+```markdown
+
+## Journal
+
+Project journal path: `sessions/<slug>/`
+```
+
+Remind the user to commit the updated file.
+
+**If the file exists and already references `sessions/<slug>/`:** no action needed.
+
+---
+
+## Step 5 — Commit and push engineering-journal
+
+```bash
+git -C ~/Git/engineering-journal add sessions/<slug>/
+git -C ~/Git/engineering-journal commit -m "feat: add journal home for <slug>"
+git -C ~/Git/engineering-journal push origin main
+```
+
+---
+
+## Step 6 — Report completion
+
+Tell the user:
+
+- Journal home created at `sessions/<slug>/` and pushed to `engineering-journal` main.
+- First stub for this project must include the `<!-- opening-brief -->` block. Set it to:
+  `"First session — no prior context."`
+- If `.claude/CLAUDE.md` was created or updated, remind the user to commit it in the project repo before the first session stub is written.

--- a/claude/templates/project-claude.md
+++ b/claude/templates/project-claude.md
@@ -1,0 +1,14 @@
+# <REPO_NAME> — Project Instructions
+
+The global Claude Code configuration lives in `~/.claude/CLAUDE.md`.
+All workflow rules, hook invariants, model selection guidelines, and journal conventions are
+defined there and apply to every project.
+
+## Journal
+
+Project journal path: `sessions/<PROJECT_SLUG>/`
+
+## Testing
+
+[Describe the test command here, or state that there are no automated tests and describe
+manual verification steps instead.]

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -113,6 +113,24 @@ Runs fit screening only — a lighter-weight version of the first step of `/cove
 
 ---
 
+### /journal-onboard
+
+```
+/journal-onboard [project-slug]
+```
+
+Scaffolds a new project's journal home (`sessions/<slug>/`) in engineering-journal and optionally creates `.claude/CLAUDE.md` in the project repo.
+
+**Slug inference:** defaults to the active git repo's name. Pass an explicit slug to override (useful when the repo name and journal slug differ).
+
+**Produces:** `sessions/<slug>/README.md` in engineering-journal (committed and pushed directly to `main`), and optionally `.claude/CLAUDE.md` in the current project repo.
+
+**Template:** reads `~/.claude/templates/project-claude.md` when scaffolding a new CLAUDE.md, substituting `<REPO_NAME>` and `<PROJECT_SLUG>`.
+
+**Detection:** the `journal-onboard-check.py` hook emits an advisory on the first prompt of any session in a repo that lacks a journal home.
+
+---
+
 ## Hooks
 
 All hooks are **advisory** — they emit `systemMessage` reminders via exit 2 but do not block tool execution. No hook exits with a non-zero code that prevents the matched tool from running.
@@ -134,6 +152,7 @@ Fires on every user prompt, before Claude processes it.
 |--------|-------------|
 | `dev-env-sync.py` | Fast-forward pulls the dev-env repo to `origin/main` so symlinked tooling stays current. Skips if a feature branch is active in the main worktree. [ADR-006](adr/006-dev-env-sync-on-every-prompt.md) |
 | `new-day-journal-check.py` | Checks for stale `draft/*` branches on `origin/engineering-journal`. Emits a one-line warning if any are found; continues silently otherwise. |
+| `journal-onboard-check.py` | Checks whether the active git repo has a `sessions/<repo-name>/` directory in engineering-journal. Emits a one-line advisory and `/journal-onboard` hint if not. Fires once per session. |
 | `turn-count-hook.py` | Warns when session context accumulates past a threshold. Primary signal: token count; secondary: turn count. Configurable via `"turn_threshold"` in `.claude/hook-config.json` (default: 50). |
 | `multi-worktree-alert.py` | When ≥2 git worktrees are active, emits a list in `repo:branch` format, starring the current one. Fires on every prompt. |
 


### PR DESCRIPTION
## Summary

- Adds `claude/scripts/journal-onboard-check.py`: a `UserPromptSubmit` hook that fires once per session and emits an advisory when the active repo has no `sessions/<repo>/` directory in engineering-journal
- Adds `claude/skills/journal-onboard/SKILL.md`: a `/journal-onboard` skill that scaffolds the journal home directory, creates `sessions/<slug>/README.md`, and optionally creates/updates `.claude/CLAUDE.md` in the project repo
- Adds `claude/templates/project-claude.md`: minimal CLAUDE.md template used by the skill
- Updates `claude/settings.json` to wire the hook into `UserPromptSubmit`
- Updates `README.md` and `docs/REFERENCE.md` with new skill and hook entries

## Test plan

- [x] `python3 -m py_compile claude/scripts/*.py` — all scripts compile cleanly

Manual smoke test: open a Claude Code session in a repo that has no journal home — the hook emits the advisory on the first prompt and is silent on subsequent prompts in the same session.

Closes #163