### PR TITLE
config: add git -C read-only allowlist entries to reduce routine permission prompts

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -13,7 +13,8 @@
       "Bash(git -C * status *)",
       "Bash(git -C * merge-base *)",
       "Bash(git -C * diff *)",
-      "Bash(git -C * remote *)",
+      "Bash(git -C * remote -v)",
+      "Bash(git -C * remote get-url *)",
       "Bash(git -C * branch --show-current)",
       "Bash(python3 -m py_compile *)"
     ]

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -5,7 +5,17 @@
       "Write(C:/Users/brown/.claude/scratch/**)",
       "Edit(C:/Users/brown/.claude/scratch/**)",
       "Bash(gh pr comment *)",
-      "Bash(TMPFILE=*)"
+      "Bash(TMPFILE=*)",
+      "Bash(git -C * fetch *)",
+      "Bash(git -C * show *)",
+      "Bash(git -C * ls-remote *)",
+      "Bash(git -C * log *)",
+      "Bash(git -C * status *)",
+      "Bash(git -C * merge-base *)",
+      "Bash(git -C * diff *)",
+      "Bash(git -C * remote *)",
+      "Bash(git -C * branch --show-current)",
+      "Bash(python3 -m py_compile *)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Adds 10 allowlist entries to `claude/settings.json` for `git -C <path>` read-only subcommands that Claude Code does not auto-allow (unlike plain `git` equivalents)
- Covers the patterns routines use most: fetch, show, ls-remote, log, status, merge-base, diff, remote, branch --show-current, and python3 -m py_compile
- Skipped broad git -C * branch * (branch -D appears in transcripts), node -e * (arbitrary code execution), gh project * (mutating)

Closes #175

## Test plan
- [x] python3 -m py_compile claude/scripts/*.py passes
- [x] Settings JSON is valid
- [ ] Verify routines run without permission prompts on next scheduled execution

Generated with Claude Code