### PR TITLE
config: allow Edit in Git repos without permission prompt

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -4,6 +4,7 @@
     "allow": [
       "Write(C:/Users/brown/.claude/scratch/**)",
       "Edit(C:/Users/brown/.claude/scratch/**)",
+      "Edit(C:/Users/brown/Git/**)",
       "Bash(gh pr comment *)",
       "Bash(TMPFILE=*)",
       "Bash(git -C * fetch *)",

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -115,6 +115,12 @@ See [ADR-007](adr/007-hook-command-invocation.md) for why hooks call `python3` d
 
 The `permissions.allow` block in `claude/settings.json` contains paths with a hardcoded Windows username (`C:/Users/brown/...`). These rules are functionally correct on this machine but must be updated manually when bootstrapping dev-env on a new machine or account. If scratch-dir writes or edits start prompting for permission after a re-bootstrap, update the username in every `allow` entry.
 
+**Known scope decisions:**
+
+| Entry | Scope | Rationale |
+|---|---|---|
+| `Edit(C:/Users/brown/Git/**)` | All files in all local repos | Covers skill and config edits across career-playbook, lifting-logbook, dev-env, etc. without per-file prompts. Intentionally broad — includes `.env` and credential files — accepted tradeoff on a single-user personal machine. |
+
 ---
 
 ### UserPromptSubmit


### PR DESCRIPTION
## Summary
- Adds `Edit(C:/Users/brown/Git/**)` to the global allowlist
- Covers editing files in any project repo (e.g. career-playbook worktree skill files) without a permission prompt
- The existing scratch-dir entry only covered `~/.claude/scratch/`

Closes #177

## Test plan
- [x] python3 -m py_compile claude/scripts/*.py passes
- [x] Settings JSON is valid

Generated with Claude Code