### PR TITLE
config: allow gh project item-list and scratch rm -f without prompts

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -6,6 +6,8 @@
       "Edit(C:/Users/brown/.claude/scratch/**)",
       "Edit(C:/Users/brown/Git/**)",
       "Bash(gh pr comment *)",
+      "Bash(gh project item-list *)",
+      "Bash(rm -f C:/Users/brown/.claude/scratch/*)",
       "Bash(TMPFILE=*)",
       "Bash(git -C * fetch *)",
       "Bash(git -C * show *)",


### PR DESCRIPTION
## Summary
- Adds `Bash(gh project item-list *)` — not in Claude Code's gh auto-allow list; prompts whenever project board workflows run
- Adds `Bash(rm -f C:/Users/brown/.claude/scratch/*)` — scoped to scratch dir only to avoid a broad rm allowlist

Closes #181

## Test plan
- [x] python3 -m py_compile claude/scripts/*.py passes
- [x] Settings JSON is valid

Generated with Claude Code