### PR TITLE
Extract sync-to-main into reusable routine skill (closes #188)

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -117,6 +117,8 @@ If the project has no automated tests, the section must say so explicitly and de
 
 **Routines note:** `dev-env/claude/routines/` is a directory junction pointing at `~/.claude/scheduled-tasks/`, so the scheduler tool writes directly to the version-controlled path. After creating a new routine, commit it to dev-env under `claude/routines/`.
 
+**Routine authoring — sync-to-main preamble.** Any routine that reads repo-resident files (a skill, a context file, a queue file) at run time must invoke the `sync-routine-worktree` skill as Step 0, before reading any of those files. Scheduled tasks fire into Claude-managed worktrees whose branches were cut from whatever `main` was at worktree creation; without an explicit sync the routine reads stale files or aborts because a recently-merged file is missing on the worktree branch. The sync skill handles fetch, branch-class-aware sync (Claude-managed worktree / `main` / other), file existence verification, and abort-with-push-notification on conflict — routines pass `REPO`, `VERIFY_FILE`, and `PREFIX` and treat the return as a guard. See `claude/skills/sync-routine-worktree/SKILL.md` and `claude/routines/nightly-cover-letters/SKILL.md` for the canonical pattern. Rationale: `docs/adr/013-sync-routine-worktree-skill.md`.
+
 **Reference doc maintenance.** When a change adds, removes, or renames a hook script, skill, routine, or utility script, check whether the project README and any reference documentation need updating in the same PR. This includes command renames, new options, and behavior changes. Each project's CLAUDE.md specifies which reference files apply.
 
 **Repo path:** `C:/Users/brown/Git/dev-env`

--- a/claude/routines/nightly-cover-letters/SKILL.md
+++ b/claude/routines/nightly-cover-letters/SKILL.md
@@ -12,10 +12,11 @@ Never call AskUserQuestion. Run fully autonomously.
 
 ## Step 0 — Sync the working tree
 
-Invoke the `sync-routine-worktree` skill to bring the career-playbook working tree current
-with `origin/main` and verify the batch skill file is present. The sync skill handles repo
-existence, fetch failure, branch-class-aware sync (Claude-managed worktree branch / `main` /
-other), and abort-on-conflict with push notification.
+Read `~/.claude/skills/sync-routine-worktree/SKILL.md` and execute its **Behavior** section
+end-to-end with the parameters below. The skill brings the career-playbook working tree current
+with `origin/main` and verifies the batch skill file is present. It handles repo existence,
+fetch failure, branch-class-aware sync (Claude-managed worktree branch / `main` / other), and
+abort-on-rebase-failure with push notification.
 
 Parameters:
 - `REPO` = `C:/Users/brown/Git/career-playbook`

--- a/claude/routines/nightly-cover-letters/SKILL.md
+++ b/claude/routines/nightly-cover-letters/SKILL.md
@@ -10,40 +10,20 @@ Run the batch cover-letter pipeline on the career-playbook repo.
 
 Never call AskUserQuestion. Run fully autonomously.
 
-## Step 0 — Verify repo
+## Step 0 — Sync the working tree
 
-```bash
-REPO="C:/Users/brown/Git/career-playbook"
-```
+Invoke the `sync-routine-worktree` skill to bring the career-playbook working tree current
+with `origin/main` and verify the batch skill file is present. The sync skill handles repo
+existence, fetch failure, branch-class-aware sync (Claude-managed worktree branch / `main` /
+other), and abort-on-conflict with push notification.
 
-Verify the repo directory exists:
+Parameters:
+- `REPO` = `C:/Users/brown/Git/career-playbook`
+- `VERIFY_FILE` = `.claude/skills/batch-cover-letters/SKILL.md`
+- `PREFIX` = `nightly-cover-letters`
 
-```bash
-if [ ! -d "$REPO" ]; then
-  # send push notification and exit
-fi
-```
-
-If the directory does not exist: send a push notification —
-"nightly-cover-letters: repo not found at ${REPO} — skipping batch run" — and exit.
-
-Check out `main` and ensure it is up to date:
-
-```bash
-git -C "$REPO" checkout main
-```
-
-If checkout fails (e.g., `main` is checked out in a worktree): send a push notification —
-"nightly-cover-letters: git checkout main failed — is main in a worktree? Check ${REPO}" —
-and exit.
-
-```bash
-git -C "$REPO" pull origin main
-```
-
-If the pull fails (network error, merge conflict): send a push notification —
-"nightly-cover-letters: git pull failed — skipping batch run. Check repo state at ${REPO}" —
-and exit.
+If the sync skill returns **ABORT**, exit immediately. The notification has already been sent;
+do not re-notify or fall back to running against stale state.
 
 ## Step 1 — Run the batch skill
 
@@ -52,7 +32,7 @@ skill with cwd set to `${REPO}`.
 
 The batch skill handles all JD processing, artifact writing, `_review_queue.md` updates,
 branch creation, committing, PR creation, and push notification. This routine's job is only
-to ensure the repo is on a clean `main` before the skill runs.
+to ensure the working tree is current with `origin/main` before the skill runs.
 
 ## Constraints
 

--- a/claude/skills/sync-routine-worktree/SKILL.md
+++ b/claude/skills/sync-routine-worktree/SKILL.md
@@ -21,46 +21,52 @@ If `VERIFY_FILE` is omitted, skip the post-sync existence check.
 
 ---
 
+## Push notifications
+
+Every abort path below sends a push notification using the `PushNotification` tool: `title` = `${PREFIX}`, `body` = the message string shown in the step. The notification is the user's only signal that an autonomous run aborted, so it must fire on every ABORT path before the skill returns.
+
+---
+
 ## Behavior
 
-1. **Verify `$REPO` exists as a directory.** If not, push-notify `${PREFIX}: repo not found at ${REPO} — skipping run` and return **ABORT**.
+1. **Verify `${REPO}` exists as a directory.** If not, push-notify `${PREFIX}: repo not found at ${REPO} — skipping run` and return **ABORT**.
 
 2. **Fetch `origin/main`:**
    ```bash
-   git -C "$REPO" fetch origin main
+   git -C "${REPO}" fetch origin main
    ```
    On failure (network error, auth issue), push-notify `${PREFIX}: git fetch failed — check ${REPO}` and return **ABORT**.
 
 3. **Determine the current branch:**
    ```bash
-   BRANCH=$(git -C "$REPO" branch --show-current)
+   BRANCH=$(git -C "${REPO}" branch --show-current)
    ```
 
 4. **Choose a sync strategy based on `BRANCH`:**
 
    - **Claude-managed worktree branch (`claude/*`):** these branches exist only to host an autonomous run; `--hard` reset is authorized.
      ```bash
-     git -C "$REPO" reset --hard origin/main
+     git -C "${REPO}" reset --hard origin/main
      ```
 
-   - **`main`:** fast-forward only, never merge.
+   - **`main`:** fast-forward only, never merge. Step 2 already fetched, so merge directly against the fetched ref rather than re-fetching via `pull`.
      ```bash
-     git -C "$REPO" pull --ff-only origin main
+     git -C "${REPO}" merge --ff-only origin/main
      ```
 
-   - **Anything else** (a feature branch, a draft branch, etc.): rebase onto `origin/main`. If conflicts arise, abort the rebase and exit cleanly.
+   - **Anything else** (a feature branch, a draft branch, etc.): rebase onto `origin/main`. If the rebase fails for any reason — merge conflict, dirty working tree, or anything else — abort cleanly and exit.
      ```bash
-     git -C "$REPO" rebase origin/main
+     git -C "${REPO}" rebase origin/main
      ```
      If `git rebase` exits non-zero:
      ```bash
-     git -C "$REPO" rebase --abort
+     git -C "${REPO}" rebase --abort
      ```
-     Then push-notify `${PREFIX}: sync conflict on ${BRANCH} — manual intervention required` and return **ABORT**.
+     Then push-notify `${PREFIX}: rebase failed on ${BRANCH} — manual intervention required` and return **ABORT**. The message is intentionally broad: rebase can fail for conflicts, uncommitted changes, or other reasons; the user investigates from the worktree state.
 
 5. **Verify the file the routine plans to read** (only if `VERIFY_FILE` is set):
    ```bash
-   if [ ! -f "$REPO/$VERIFY_FILE" ]; then
+   if [ ! -f "${REPO}/${VERIFY_FILE}" ]; then
      # push-notify and abort
    fi
    ```

--- a/claude/skills/sync-routine-worktree/SKILL.md
+++ b/claude/skills/sync-routine-worktree/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: sync-routine-worktree
+description: Sync the working tree of a target repo to origin/main before a scheduled-task routine reads repo-resident files. Routines invoke this as Step 0 to ensure they don't run against stale skills, contexts, or queue files when launched into a worktree branch cut from an older main.
+---
+
+Sync a target repo's working tree to current `origin/main`. Use this from a scheduled-task routine before reading any file that lives in the target repo (a skill, a context file, a queue file).
+
+This skill is invoked **by other routines**, not directly by users. It is a building block, not an end-user command.
+
+---
+
+## Parameters (the invoking routine supplies these)
+
+| Name | Required | Description | Example |
+|---|---|---|---|
+| `REPO` | yes | Absolute path to the target repo whose working tree must be synced. | `C:/Users/brown/Git/career-playbook` |
+| `VERIFY_FILE` | no | Repo-relative path that must exist after sync. Used as a sanity check that the file the routine intends to read is present on `origin/main`. | `.claude/skills/batch-cover-letters/SKILL.md` |
+| `PREFIX` | yes | Short string used to namespace push notifications so the user can tell which routine emitted the abort signal. | `nightly-cover-letters` |
+
+If `VERIFY_FILE` is omitted, skip the post-sync existence check.
+
+---
+
+## Behavior
+
+1. **Verify `$REPO` exists as a directory.** If not, push-notify `${PREFIX}: repo not found at ${REPO} — skipping run` and return **ABORT**.
+
+2. **Fetch `origin/main`:**
+   ```bash
+   git -C "$REPO" fetch origin main
+   ```
+   On failure (network error, auth issue), push-notify `${PREFIX}: git fetch failed — check ${REPO}` and return **ABORT**.
+
+3. **Determine the current branch:**
+   ```bash
+   BRANCH=$(git -C "$REPO" branch --show-current)
+   ```
+
+4. **Choose a sync strategy based on `BRANCH`:**
+
+   - **Claude-managed worktree branch (`claude/*`):** these branches exist only to host an autonomous run; `--hard` reset is authorized.
+     ```bash
+     git -C "$REPO" reset --hard origin/main
+     ```
+
+   - **`main`:** fast-forward only, never merge.
+     ```bash
+     git -C "$REPO" pull --ff-only origin main
+     ```
+
+   - **Anything else** (a feature branch, a draft branch, etc.): rebase onto `origin/main`. If conflicts arise, abort the rebase and exit cleanly.
+     ```bash
+     git -C "$REPO" rebase origin/main
+     ```
+     If `git rebase` exits non-zero:
+     ```bash
+     git -C "$REPO" rebase --abort
+     ```
+     Then push-notify `${PREFIX}: sync conflict on ${BRANCH} — manual intervention required` and return **ABORT**.
+
+5. **Verify the file the routine plans to read** (only if `VERIFY_FILE` is set):
+   ```bash
+   if [ ! -f "$REPO/$VERIFY_FILE" ]; then
+     # push-notify and abort
+   fi
+   ```
+   On missing file, push-notify `${PREFIX}: ${VERIFY_FILE} missing on origin/main after sync` and return **ABORT**.
+
+6. **Return SUCCESS.** The caller proceeds with its own logic.
+
+---
+
+## Return semantics
+
+The routine treats this skill as a guard. Two outcomes:
+
+- **SUCCESS** — `$REPO` is now current with `origin/main`, `$VERIFY_FILE` (if specified) exists, and the routine continues.
+- **ABORT** — the push notification has already been sent. The caller exits cleanly without modifying any inbox, opening any PR, or making any commits. Do not re-notify; do not retry; do not fall back to running against stale state.
+
+---
+
+## Why this exists
+
+Scheduled-task routines that read repo-resident files at runtime can land in a Claude-managed worktree whose branch was cut from an older `main`. Without an explicit sync step:
+
+- The routine reads stale skill or context files and runs against outdated logic, OR
+- The file the routine wants to read does not exist yet on the worktree's branch and the routine aborts with a "file not found" report — wasting the run.
+
+This skill centralizes the sync discipline so each routine declares only what it needs (`REPO`, `VERIFY_FILE`, `PREFIX`) without re-implementing branch detection, conflict handling, or the abort-with-notification protocol.
+
+See `docs/adr/013-sync-routine-worktree-skill.md` for the full rationale.
+
+---
+
+## Scope boundary
+
+This skill syncs a repo's working tree to `origin/main`. It does **not** handle:
+
+- Draft-branch workflows (e.g., journal-compose's `draft/YYYY-MM-DD` branch). Those are routine-specific and stay in the routine itself; the routine can call this skill first to ensure `origin/main` is current, then perform its own draft-branch logic.
+- Multi-repo coordination. If a routine reads from two repos, it invokes this skill twice with different `REPO` values.
+- Pushing or merging anything. This is a read-only sync of the working tree.

--- a/docs/adr/013-sync-routine-worktree-skill.md
+++ b/docs/adr/013-sync-routine-worktree-skill.md
@@ -10,7 +10,7 @@
 
 Scheduled-task routines (`claude/routines/`) are launched by the Claude Code scheduler into a Claude-managed worktree under `.claude/worktrees/<name>/`. The worktree's branch is cut from whatever `main` was at the moment the worktree was created — which may predate skill changes, context file edits, or queue updates that have since merged to `main`.
 
-This bit on 2026-05-06: the scheduled `batch-cover-letter-test` task (an out-of-tree test routine) fired into a worktree whose branch did not yet contain the `batch-cover-letters` skill in career-playbook (still on a feature branch when the worktree was created). The routine had to abort with a "skill not found" report instead of running the pipeline against the seven-JD inbox. The skill and its filename-handling fix had already merged to career-playbook `main` (career-playbook#102, career-playbook#109) — the routine simply could not see them from inside the stale worktree. Issue: dev-env#188.
+This bit us on 2026-05-06: the scheduled `batch-cover-letter-test` task (an out-of-tree test routine) fired into a worktree whose branch did not yet contain the `batch-cover-letters` skill in career-playbook (still on a feature branch when the worktree was created). The routine had to abort with a "skill not found" report instead of running the pipeline against the seven-JD inbox. The skill and its filename-handling fix had already merged to career-playbook `main` (career-playbook#102, career-playbook#109) — the routine simply could not see them from inside the stale worktree. Issue: dev-env#188.
 
 A survey of existing tracked routines confirmed the pattern is general:
 

--- a/docs/adr/013-sync-routine-worktree-skill.md
+++ b/docs/adr/013-sync-routine-worktree-skill.md
@@ -1,0 +1,98 @@
+# ADR 013 — Sync-to-Main as a Reusable Routine Skill
+
+**Date:** 2026-05-06
+**Status:** Accepted
+**Tags:** routines, skills, git, worktree, scheduled-tasks, sync
+
+---
+
+## Context
+
+Scheduled-task routines (`claude/routines/`) are launched by the Claude Code scheduler into a Claude-managed worktree under `.claude/worktrees/<name>/`. The worktree's branch is cut from whatever `main` was at the moment the worktree was created — which may predate skill changes, context file edits, or queue updates that have since merged to `main`.
+
+This bit on 2026-05-06: the scheduled `batch-cover-letter-test` task (an out-of-tree test routine) fired into a worktree whose branch did not yet contain the `batch-cover-letters` skill in career-playbook (still on a feature branch when the worktree was created). The routine had to abort with a "skill not found" report instead of running the pipeline against the seven-JD inbox. The skill and its filename-handling fix had already merged to career-playbook `main` (career-playbook#102, career-playbook#109) — the routine simply could not see them from inside the stale worktree. Issue: dev-env#188.
+
+A survey of existing tracked routines confirmed the pattern is general:
+
+| Routine | Reads what at runtime | Sync state before this ADR |
+|---|---|---|
+| `nightly-cover-letters` | `${career-playbook}/.claude/skills/batch-cover-letters/SKILL.md` | Inline `git checkout main && git pull origin main` — assumes the routine is operating on the main repo, not a worktree |
+| `daily-journal-compose` | Stub files in `${engineering-journal}/sessions/<project>/` | None |
+| `nightly-research` | `${research-notes}/research-queue.md` | None |
+| `prune-stale-worktrees` | (operates on git state directly) | Not applicable |
+
+`nightly-cover-letters`'s inline sync silently fails when the routine fires from a worktree (its `git checkout main` either hits the "main is checked out elsewhere" error or noisily switches branches in a worktree it doesn't own). `daily-journal-compose` and `nightly-research` have no sync at all and would inherit the same staleness problem if their worktrees fall behind.
+
+## Decision
+
+Extract the sync logic into a parameterized dev-env skill at `claude/skills/sync-routine-worktree/SKILL.md`. Routines that read repo-resident files at runtime invoke this skill as Step 0, passing `REPO`, `VERIFY_FILE`, and `PREFIX`, and treat the result as a guard — proceed on SUCCESS, exit cleanly on ABORT.
+
+The skill encapsulates:
+
+1. Repo existence verification.
+2. `git fetch origin main`.
+3. Branch-class-aware sync:
+   - **Claude-managed worktree branch (`claude/*`)** → `git reset --hard origin/main` (the branch exists only to host the run; reset is authorized).
+   - **`main`** → `git pull --ff-only origin main`.
+   - **Other branch with commits** → `git rebase origin/main`; on conflict, `git rebase --abort` and notify.
+4. Optional post-sync existence check for `VERIFY_FILE`.
+5. Push notification on any abort path, with consistent message format prefixed by the calling routine's name.
+
+Routine authors document the requirement in `claude/CLAUDE.md` so future routines inherit the discipline.
+
+## Consequences
+
+**Positive:**
+
+- One implementation of branch-class detection and conflict handling. A bug fix in the sync skill propagates to all consumers; routine authors stop re-deriving the heuristic.
+- Routines that previously had no sync (`daily-journal-compose`, `nightly-research`) can adopt the pattern incrementally — each conversion is a one-line skill invocation plus parameter values.
+- The skill's scope boundary is narrow ("sync a working tree to `origin/main`"), so it composes cleanly with routine-specific concerns. Journal-compose's `draft/YYYY-MM-DD` branch logic, for example, stays in the journal-compose skill — the sync skill ensures `origin/main` is current first, then journal-compose checks out or creates the draft branch on top of fresh main.
+- Push notification message format is centralized and consistent across all routines.
+
+**Negative:**
+
+- The sync logic is now a level of indirection away from the routine. A reader has to follow the skill reference to see the actual git commands.
+- Routines now have a build-time dependency on the dev-env skill (via the `~/.claude/skills/` junction). If the skill is deleted or renamed, every consuming routine breaks. Mitigation: the skill is in version control under dev-env and referenced by name in `claude/CLAUDE.md`; renames must update both.
+- Future routines authors need to know the skill exists. Mitigation: the routine-authoring pointer in `claude/CLAUDE.md` makes the sync-to-main preamble part of the documented routine pattern.
+
+## Alternatives Considered
+
+### Inline duplication in each routine
+
+Cost: 15–20 lines of sync prose per routine, three known consumers, drift risk.
+Benefit: each routine is self-contained.
+Rejected: with three known consumers and more likely (Mike's scheduled-task usage is growing), the drift risk and the cost of fixing a bug in three places outweighs the readability cost of the indirection.
+
+### A shell script in `claude/scripts/sync-worktree-to-main.sh`
+
+Cost: branch detection in shell is messier; the abort-with-push-notification path can't be done from a shell script (push notification is a Claude tool call, not a shell capability), so the routine would still need inline notification logic on the abort path.
+Benefit: self-contained executable.
+Rejected: the partial-extraction problem leaves duplication on the most error-prone path (conflict handling and notification).
+
+### Embed sync logic in every consuming skill (`batch-cover-letters`, `journal-compose`, etc.) instead of in the routine
+
+Cost: skills get invoked from interactive user sessions too, where syncing to `origin/main` is wrong (the user may be on a feature branch on purpose). Routine-context vs. user-context detection adds complexity to every skill.
+Benefit: no separate sync skill needed.
+Rejected: the sync need is specific to autonomous, runs-in-a-worktree-it-didn't-create routine contexts. Putting it in skills puts it in the wrong layer.
+
+## Scope Boundary
+
+This skill syncs a single repo's working tree to `origin/main`. It does not handle:
+
+- **Draft-branch workflows** (e.g., journal-compose's `draft/YYYY-MM-DD`). Those stay in the consuming skill; the consuming skill calls this sync skill first to ensure `origin/main` is current, then performs its own draft-branch logic on top.
+- **Multi-repo coordination.** A routine that reads from two repos invokes the sync skill twice with different `REPO` values.
+- **Pushing or merging.** This is read-side: it brings the working tree current with what's already on the remote.
+
+## Migration
+
+- `nightly-cover-letters` is migrated in the same PR that introduces this ADR (PR closing dev-env#188).
+- `daily-journal-compose` and `nightly-research` are not migrated in this PR; their conversions are tracked separately and can land any time before their next reported staleness incident.
+- The non-version-controlled `batch-cover-letter-test` test routine continues to use its inline sync until either it is moved into version control under `claude/routines/` or it is converted to invoke the new skill. Either way it is outside the scope of this ADR.
+
+## References
+
+- dev-env#188 — the issue this ADR closes.
+- career-playbook#102, career-playbook#109 — the merged-to-main work that surfaced the staleness incident.
+- `claude/skills/sync-routine-worktree/SKILL.md` — the skill itself.
+- `claude/routines/nightly-cover-letters/SKILL.md` — the canonical first consumer.
+- ADR 008 — Plan-Then-Optimize as an Embedded Skill Step (similar pattern of pulling cross-cutting discipline into a skill that other workflows invoke).

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -17,3 +17,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [010](010-skill-tmpfile-allow-rule.md) | Skill Temp File Writes: `Bash(TMPFILE=*)` Allow Rule | 2026-05-02 | Accepted | skills, permissions, tmpfile, bash, settings |
 | [011](011-adr-warrant-check.md) | ADR-Warrant Check at Plan, PR-Open, and PR-Merge Checkpoints | 2026-05-03 | Accepted | adr, workflow, git, checkpoints, documentation |
 | [012](012-post-merge-checklist-board-done-roadmap-update.md) | Post-Merge Checklist: Board Done + Roadmap Update Rules | 2026-05-06 | Accepted | git, workflow, project-board, roadmap, post-merge |
+| [013](013-sync-routine-worktree-skill.md) | Sync-to-Main as a Reusable Routine Skill | 2026-05-06 | Accepted | routines, skills, git, worktree, scheduled-tasks, sync |


### PR DESCRIPTION
## Summary

- Extracts the sync-to-`origin/main` logic from `nightly-cover-letters` into a parameterized dev-env skill at `claude/skills/sync-routine-worktree/SKILL.md`.
- Refactors `nightly-cover-letters` to invoke the skill, fixing the worktree-blind sync bug in its inline preamble (its `git checkout main` failed when the routine fired from a Claude-managed worktree).
- Adds a routine-authoring pointer to `claude/CLAUDE.md` so future routines inherit the sync-to-main discipline.
- Captures the rationale, alternatives, and scope boundary in ADR 013.

Closes #188.

## Why this PR

On 2026-05-06 a scheduled `batch-cover-letter-test` routine fired into a Claude-managed worktree whose branch did not yet contain the `batch-cover-letters` skill. The routine had to abort with a "skill not found" report instead of running the pipeline against the seven-JD inbox. The skill had already merged to career-playbook `main` (#102, #109) — the routine simply could not see it from inside the stale worktree.

`nightly-cover-letters` had its own inline sync but assumed the routine was operating on the main repo, not a worktree. `daily-journal-compose` and `nightly-research` had no sync at all. With three known consumers in the pipeline, extraction is past rule-of-three.

## What stays out of scope

- `daily-journal-compose` and `nightly-research` are not migrated in this PR. Their conversions can land any time before their next reported staleness incident.
- The non-version-controlled `batch-cover-letter-test` test routine continues to use the inline sync added earlier in the same session (it lives at \`~/.claude/scheduled-tasks/\`, outside dev-env). If formalized as a tracked routine, it picks up the skill on conversion.

## Test plan

- [x] \`python3 -m py_compile claude/scripts/*.py\` passes
- [x] All five files in the diff (skill, refactored routine, CLAUDE.md, ADR, INDEX) reviewed for cross-references
- [x] ADR file numbered correctly (collision with newly-merged ADR 012 forced renumber to 013)
- [ ] Skill exercised end-to-end on next scheduled \`nightly-cover-letters\` run

## ADR-warrant check

Warranted and written: ADR 013 captures the rationale, alternatives considered (inline duplication, shell script, embedding in consuming skills), scope boundary (does not handle draft-branch workflows, multi-repo coordination, or push/merge), and migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)