### PR TITLE
feat(#190): add sync-routine-worktree Step 0 to daily-journal-compose

### DIFF
--- a/claude/routines/daily-journal-compose/SKILL.md
+++ b/claude/routines/daily-journal-compose/SKILL.md
@@ -9,6 +9,14 @@ Compose today's engineering journal entries for all active projects. Run fully a
 **Objective:** For each project directory that contains stubs dated today, run /journal-compose sequentially, then report all PR URLs.
 
 **Steps:**
+0. **Sync the engineering-journal repo to `origin/main`** before reading any stubs. Read `~/.claude/skills/sync-routine-worktree/SKILL.md` and execute its Behavior section with these parameters:
+   - `REPO` = `C:/Users/brown/Git/engineering-journal`
+   - `PREFIX` = `daily-journal-compose`
+   - `VERIFY_FILE` = (omit — no single file is required; the stub glob in Step 2 handles the empty-directory case)
+
+   On **SUCCESS**, continue to Step 1.
+   On **ABORT**, exit cleanly — do not proceed, do not commit, do not open PRs.
+
 1. Determine today's date in Git Bash:
    ```bash
    DATE=$(date -u +%Y-%m-%d)


### PR DESCRIPTION
## Summary
- Adds Step 0 to `claude/routines/daily-journal-compose/SKILL.md` that invokes `sync-routine-worktree` before reading any stubs
- Parameters: `REPO=C:/Users/brown/Git/engineering-journal`, `PREFIX=daily-journal-compose`, `VERIFY_FILE` omitted
- On SUCCESS the routine continues to its existing date/stub logic; on ABORT it exits cleanly

## Test plan
- [x] `python3 -m py_compile claude/scripts/*.py` — passes
- [ ] Verify next nightly run produces a journal PR (no regression in composition behavior)

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)