### PR TITLE
feat: detect and reconcile accidentally-resurrected merged draft branches

### DIFF
--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -37,7 +37,7 @@ while read local_ref local_sha remote_ref remote_sha; do
           echo "Check your current branch — did you mean a different draft branch?" >&2
           echo "To reconcile orphaned commits after an accidental push:" >&2
           echo "  python3 ~/.claude/scripts/reconcile-late-stubs.py $remote_branch" >&2
-          exit 1
+          exit 1  # intentionally skips per-repo hook chain — push is fully blocked
         fi
       fi
     fi

--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -20,6 +20,28 @@ while read local_ref local_sha remote_ref remote_sha; do
     echo "If this repo uses squash merges, the PR may target the wrong base." >&2
     echo "Consider cherry-picking onto a fresh branch from origin/main." >&2
   fi
+
+  # Block pushes to already-merged draft/YYYY-MM-DD branches in engineering-journal.
+  # Pushing to a merged branch resurrects it, causing the stale-branch hook to fire
+  # on every subsequent prompt until orphaned commits are reconciled.
+  remote_branch="${remote_ref#refs/heads/}"
+  if echo "$remote_branch" | grep -qE '^draft/[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+    if echo "$remote_url" | grep -q "engineering-journal"; then
+      if command -v gh >/dev/null 2>&1; then
+        merged=$(gh pr list --repo brownm09/engineering-journal \
+          --state merged --head "$remote_branch" --json number 2>/dev/null || echo "[]")
+        if [ "$merged" != "[]" ] && [ -n "$merged" ]; then
+          echo "ERROR: $remote_branch already has a merged PR." >&2
+          echo "Pushing to this branch would resurrect it and cause stale-branch hook noise." >&2
+          echo "Check your current branch — did you mean a different draft branch?" >&2
+          echo "To reconcile orphaned commits after an accidental push:" >&2
+          echo "  python3 ~/.claude/scripts/reconcile-late-stubs.py $remote_branch" >&2
+          exit 1
+        fi
+      fi
+    fi
+  fi
 done
 
 # Chain to per-repo hook if one exists (preserves Husky, git-secrets, corporate hooks, etc.)

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -175,6 +175,44 @@ def unmerged_draft_branches() -> list[str]:
         return []
 
 
+def resurrected_draft_branches() -> list[str]:
+    """Return remote draft/* branch names that were already merged but still exist.
+
+    A branch is resurrected when its date has a composed journal file on
+    origin/main (merged PR) but the remote branch was recreated by a later push.
+    These need reconciliation via reconcile-late-stubs.py, not recomposition.
+
+    Note: uses the local origin/main cache — results are only accurate after a
+    recent git fetch. A stale cache may produce false negatives (silent), which
+    is preferable to false-positive noise.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", "refs/heads/draft/*"],
+            cwd=JOURNAL_REPO,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        remote_dates = set()
+        for line in result.stdout.splitlines():
+            if "\t" in line:
+                ref = line.split("\t", 1)[1].strip()
+                remote_dates.add(ref.replace("refs/heads/draft/", ""))
+
+        if not remote_dates:
+            return []
+
+        merged = composed_dates_on_main()
+        resurrected = sorted(
+            [d for d in remote_dates if d != TODAY and d in merged],
+            reverse=True,
+        )
+        return resurrected
+    except Exception:
+        return []
+
+
 def main() -> None:
     raw = ""
     try:
@@ -211,6 +249,15 @@ def main() -> None:
             f"[journal-hook] Unmerged draft branch(es) detected: {dates_str}\n"
             f"These branches have composed journal files but no PR was opened or merged into main.\n"
             f"Remind the user that draft/{unmerged[0]} (and any others listed) still need a PR to main."
+        )
+
+    resurrected = resurrected_draft_branches()
+    if resurrected:
+        dates_str = ", ".join(resurrected)
+        messages.append(
+            f"[journal-hook] Resurrected draft branch(es) detected: {dates_str}\n"
+            f"draft/{resurrected[0]} was already merged but new commits were pushed to it after the merge.\n"
+            f"Run: python3 ~/.claude/scripts/reconcile-late-stubs.py draft/{resurrected[0]}"
         )
 
     if messages:

--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -138,13 +138,8 @@ def composed_dates_on_main() -> set[str]:
         return set()
 
 
-def unmerged_draft_branches() -> list[str]:
-    """Return remote draft/* branch names not yet merged into origin/main.
-
-    Uses composed_dates_on_main() as the merge signal — squash merges don't
-    leave branch commits in main's ancestry, making git branch --merged
-    unreliable. A composed journal file on main is the authoritative indicator.
-    """
+def remote_draft_dates() -> set[str]:
+    """Return YYYY-MM-DD date strings for all remote draft/* branches."""
     try:
         result = subprocess.run(
             ["git", "ls-remote", "--heads", "origin", "refs/heads/draft/*"],
@@ -153,26 +148,34 @@ def unmerged_draft_branches() -> list[str]:
             text=True,
             timeout=15,
         )
-        remote_dates = set()
+        dates: set[str] = set()
         for line in result.stdout.splitlines():
             if "\t" in line:
                 ref = line.split("\t", 1)[1].strip()
-                remote_dates.add(ref.replace("refs/heads/draft/", ""))
-
-        if not remote_dates:
-            return []
-
-        merged = composed_dates_on_main()
-        # TODAY is always excluded from automatic detection — today's active
-        # branch is never stale. Use /journal-compose YYYY-MM-DD explicitly
-        # to compose and merge the current day's journal.
-        unmerged = sorted(
-            [d for d in remote_dates if d != TODAY and d not in merged],
-            reverse=True,
-        )
-        return unmerged
+                dates.add(ref.replace("refs/heads/draft/", ""))
+        return dates
     except Exception:
+        return set()
+
+
+def unmerged_draft_branches() -> list[str]:
+    """Return remote draft/* branch names not yet merged into origin/main.
+
+    Uses composed_dates_on_main() as the merge signal — squash merges don't
+    leave branch commits in main's ancestry, making git branch --merged
+    unreliable. A composed journal file on main is the authoritative indicator.
+    """
+    remote_dates = remote_draft_dates()
+    if not remote_dates:
         return []
+    merged = composed_dates_on_main()
+    # TODAY is always excluded from automatic detection — today's active
+    # branch is never stale. Use /journal-compose YYYY-MM-DD explicitly
+    # to compose and merge the current day's journal.
+    return sorted(
+        [d for d in remote_dates if d != TODAY and d not in merged],
+        reverse=True,
+    )
 
 
 def resurrected_draft_branches() -> list[str]:
@@ -186,31 +189,14 @@ def resurrected_draft_branches() -> list[str]:
     recent git fetch. A stale cache may produce false negatives (silent), which
     is preferable to false-positive noise.
     """
-    try:
-        result = subprocess.run(
-            ["git", "ls-remote", "--heads", "origin", "refs/heads/draft/*"],
-            cwd=JOURNAL_REPO,
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        remote_dates = set()
-        for line in result.stdout.splitlines():
-            if "\t" in line:
-                ref = line.split("\t", 1)[1].strip()
-                remote_dates.add(ref.replace("refs/heads/draft/", ""))
-
-        if not remote_dates:
-            return []
-
-        merged = composed_dates_on_main()
-        resurrected = sorted(
-            [d for d in remote_dates if d != TODAY and d in merged],
-            reverse=True,
-        )
-        return resurrected
-    except Exception:
+    remote_dates = remote_draft_dates()
+    if not remote_dates:
         return []
+    merged = composed_dates_on_main()
+    return sorted(
+        [d for d in remote_dates if d != TODAY and d in merged],
+        reverse=True,
+    )
 
 
 def main() -> None:

--- a/claude/scripts/reconcile-late-stubs.py
+++ b/claude/scripts/reconcile-late-stubs.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 from datetime import date, datetime
 from pathlib import Path
+from typing import Optional
 
 JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
 SCRATCH = Path.home() / ".claude" / "scratch"
@@ -33,7 +34,7 @@ def run(cmd, cwd=None, check=True, capture=True):
     return result
 
 
-def get_merged_pr_info(branch: str) -> dict | None:
+def get_merged_pr_info(branch: str) -> Optional[dict]:
     result = subprocess.run(
         ["gh", "pr", "list", "--repo", "brownm09/engineering-journal",
          "--state", "merged", "--head", branch,
@@ -67,9 +68,9 @@ def get_stub_files_in_commits(commits: list[str]) -> list[str]:
             status, path = parts
             if status.startswith("D"):
                 continue
+            # open-prs.jsonl is excluded — the target branch's copy is authoritative
             if (path.endswith(".stub.md")
-                    or path.endswith(".manifest.jsonl")
-                    or path.endswith("open-prs.jsonl")):
+                    or path.endswith(".manifest.jsonl")):
                 if path not in seen:
                     files.append(path)
                     seen.add(path)
@@ -98,6 +99,8 @@ def find_target_branch(source_date: str) -> str:
         if date_str not in composed:
             return f"draft/{date_str}"
 
+    # Fallback: today's branch. There should essentially always be an active
+    # day branch, and ensure_remote_branch_exists will create it if absent.
     return f"draft/{TODAY}"
 
 

--- a/claude/scripts/reconcile-late-stubs.py
+++ b/claude/scripts/reconcile-late-stubs.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+reconcile-late-stubs.py <draft/YYYY-MM-DD>
+
+Moves stub files pushed to an already-merged draft branch to the earliest
+unmerged draft branch (or today's branch if none exists), then deletes the
+stale source branch.
+
+Usage:
+  python3 reconcile-late-stubs.py draft/2026-05-06
+  python3 reconcile-late-stubs.py 2026-05-06   # draft/ prefix optional
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
+SCRATCH = Path.home() / ".claude" / "scratch"
+TODAY = date.today().strftime("%Y-%m-%d")
+
+
+def run(cmd, cwd=None, check=True, capture=True):
+    result = subprocess.run(
+        cmd, cwd=cwd or JOURNAL_REPO, capture_output=capture, text=True
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(f"Command failed: {' '.join(str(c) for c in cmd)}\n{result.stderr}")
+    return result
+
+
+def get_merged_pr_info(branch: str) -> dict | None:
+    result = subprocess.run(
+        ["gh", "pr", "list", "--repo", "brownm09/engineering-journal",
+         "--state", "merged", "--head", branch,
+         "--json", "number,mergedAt,url"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return None
+    prs = json.loads(result.stdout.strip() or "[]")
+    return prs[0] if prs else None
+
+
+def get_commits_after(branch: str, after_iso: str) -> list[str]:
+    result = run(
+        ["git", "log", f"origin/{branch}", f"--after={after_iso}", "--format=%H"]
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def get_stub_files_in_commits(commits: list[str]) -> list[str]:
+    files: list[str] = []
+    seen: set[str] = set()
+    for commit in commits:
+        result = run(["git", "show", commit, "--name-status", "--format="])
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t", 1)
+            if len(parts) != 2:
+                continue
+            status, path = parts
+            if status.startswith("D"):
+                continue
+            if (path.endswith(".stub.md")
+                    or path.endswith(".manifest.jsonl")
+                    or path.endswith("open-prs.jsonl")):
+                if path not in seen:
+                    files.append(path)
+                    seen.add(path)
+    return files
+
+
+def find_target_branch(source_date: str) -> str:
+    result = run(["git", "ls-remote", "--heads", "origin", "refs/heads/draft/*"])
+    remote_dates: list[str] = []
+    for line in result.stdout.splitlines():
+        if "\t" in line:
+            ref = line.split("\t", 1)[1].strip()
+            date_str = ref.replace("refs/heads/draft/", "")
+            if re.match(r"\d{4}-\d{2}-\d{2}$", date_str) and date_str > source_date:
+                remote_dates.append(date_str)
+
+    main_tree = run(["git", "ls-tree", "-r", "--name-only", "origin/main", "sessions/"])
+    composed: set[str] = set()
+    for line in main_tree.stdout.splitlines():
+        fname = line.split("/")[-1]
+        if not fname.endswith(".stub.md") and fname.endswith(".md"):
+            if len(fname) >= 10 and fname[4] == "-" and fname[7] == "-":
+                composed.add(fname[:10])
+
+    for date_str in sorted(remote_dates):
+        if date_str not in composed:
+            return f"draft/{date_str}"
+
+    return f"draft/{TODAY}"
+
+
+def ensure_remote_branch_exists(branch: str) -> None:
+    result = run(["git", "ls-remote", "--heads", "origin", branch])
+    if not result.stdout.strip():
+        print(f"  Creating remote branch {branch} from origin/main...")
+        run(["git", "push", "origin", f"origin/main:refs/heads/{branch}"])
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: reconcile-late-stubs.py <draft/YYYY-MM-DD>", file=sys.stderr)
+        sys.exit(1)
+
+    arg = sys.argv[1].strip()
+    source_branch = arg if arg.startswith("draft/") else f"draft/{arg}"
+    source_date = source_branch.removeprefix("draft/")
+
+    print(f"Reconciling late stubs from {source_branch}...")
+
+    run(["git", "fetch", "origin", source_branch, "--quiet"])
+
+    pr = get_merged_pr_info(source_branch)
+    if not pr:
+        print(f"Error: No merged PR found for {source_branch}. Aborting.", file=sys.stderr)
+        sys.exit(1)
+
+    merged_at = pr["mergedAt"]
+    print(f"Found merged PR #{pr['number']} ({pr['url']}) merged at {merged_at}")
+
+    commits = get_commits_after(source_branch, merged_at)
+    if not commits:
+        print("No commits found after merge. Deleting stale branch...")
+        run(["git", "push", "origin", "--delete", source_branch])
+        print(f"Deleted {source_branch}. Done.")
+        return
+
+    print(f"Found {len(commits)} commit(s) after merge:")
+    for c in commits:
+        msg = run(["git", "log", "-1", "--format=%s", c]).stdout.strip()
+        print(f"  {c[:8]} {msg}")
+
+    stub_files = get_stub_files_in_commits(commits)
+    if not stub_files:
+        print("No stub/manifest files in new commits. Deleting stale branch...")
+        run(["git", "push", "origin", "--delete", source_branch])
+        print(f"Deleted {source_branch}. Done.")
+        return
+
+    print(f"Found {len(stub_files)} file(s) to move:")
+    for f in stub_files:
+        print(f"  {f}")
+
+    run(["git", "fetch", "origin", "--quiet"])
+    target_branch = find_target_branch(source_date)
+    print(f"Target branch: {target_branch}")
+
+    ensure_remote_branch_exists(target_branch)
+    run(["git", "fetch", "origin", target_branch, "--quiet"])
+
+    temp_dir = SCRATCH / f"reconcile_tmp_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # --detach avoids "branch already checked out" errors from active worktrees
+        run(["git", "worktree", "add", "--detach", str(temp_dir),
+             f"origin/{target_branch}"])
+
+        copied: list[str] = []
+        for rel_path in stub_files:
+            content_result = run(
+                ["git", "show", f"origin/{source_branch}:{rel_path}"],
+                check=False,
+            )
+            if content_result.returncode != 0:
+                print(f"  Skipping {rel_path} (not found on source branch)")
+                continue
+            dest = temp_dir / rel_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content_result.stdout, encoding="utf-8")
+            print(f"  Copied {rel_path}")
+            copied.append(rel_path)
+
+        if not copied:
+            print("No files could be copied. Deleting stale branch...")
+            run(["git", "push", "origin", "--delete", source_branch])
+            return
+
+        run(["git", "add"] + copied, cwd=temp_dir)
+        run(
+            ["git", "commit", "-m",
+             f"reconcile: move late stubs from {source_branch}\n\n"
+             f"PR #{pr['number']} was already merged but {len(commits)} commit(s) were pushed "
+             f"after the merge. Moving {len(copied)} stub file(s) to {target_branch}."],
+            cwd=temp_dir,
+        )
+        run(["git", "push", "origin", f"HEAD:refs/heads/{target_branch}"], cwd=temp_dir)
+        print(f"Pushed {len(copied)} file(s) to {target_branch}")
+
+    finally:
+        run(["git", "worktree", "remove", "--force", str(temp_dir)], check=False)
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    run(["git", "push", "origin", "--delete", source_branch])
+    print(f"Deleted stale branch {source_branch}")
+    print("Reconciliation complete.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- **pre-push hook**: blocks pushes to `draft/YYYY-MM-DD` branches in engineering-journal that already have a merged PR — prevents the resurrection at the source
- **`reconcile-late-stubs.py`**: moves orphaned stub files from a resurrected branch to the earliest unmerged draft branch (or today's), then deletes the stale source branch
- **`new-day-journal-check.py`**: adds `resurrected_draft_branches()` to distinguish "never composed" from "merged but resurrected", emitting the correct actionable message for each case

## Test plan
- [ ] `python3 -m py_compile` passes on all changed scripts
- [ ] `python3 ~/.claude/scripts/reconcile-late-stubs.py draft/2026-05-06` moves late stubs to `draft/2026-05-07` and deletes stale branch
- [ ] Hook no longer fires for `draft/2026-05-06` after reconciliation

## Testing
Run `python3 -m py_compile claude/scripts/*.py` — passes.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)