### PR TITLE
[feat] Auto-install npm packages in Claude-managed worktrees

### DIFF
--- a/claude/scripts/worktree-npm-install.py
+++ b/claude/scripts/worktree-npm-install.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Claude Code UserPromptSubmit hook — auto-installs npm packages in Claude-managed
+worktrees when node_modules is absent.
+
+Claude-managed worktrees share the git object store but have independent working
+directories. node_modules is never present on first use, causing spurious test
+failures unrelated to the current change. This hook detects that condition and
+runs npm ci (or npm install if no lockfile) before Claude starts working.
+
+The node_modules directory check doubles as the sentinel — once installed, the
+hook exits silently for all subsequent prompts in the same worktree.
+
+Fires on every user prompt; exits silently when not applicable.
+
+Stdin JSON shape (UserPromptSubmit):
+  {
+    "hook_event_name": "UserPromptSubmit",
+    "session_id": "...",
+    "cwd": "..."
+  }
+
+Exit 0 always — advisory only, never blocks.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    raw = sys.stdin.read().strip()
+    cwd = ""
+    if raw:
+        try:
+            cwd = json.loads(raw).get("cwd", "")
+        except json.JSONDecodeError:
+            pass
+
+    if not cwd:
+        sys.exit(0)
+
+    cwd_path = Path(cwd)
+    parts = cwd_path.parts
+
+    # Only run in Claude-managed worktrees (.claude/worktrees/<name> path structure).
+    if ".claude" not in parts or "worktrees" not in parts:
+        sys.exit(0)
+
+    # Verify .claude and worktrees appear as consecutive components.
+    try:
+        claude_idx = parts.index(".claude")
+        if claude_idx + 1 >= len(parts) or parts[claude_idx + 1] != "worktrees":
+            sys.exit(0)
+    except ValueError:
+        sys.exit(0)
+
+    # Only run in npm repos.
+    if not (cwd_path / "package.json").exists():
+        sys.exit(0)
+
+    # node_modules presence is the sentinel — already installed, nothing to do.
+    if (cwd_path / "node_modules").exists():
+        sys.exit(0)
+
+    # Choose npm ci (reproducible) when a lockfile exists, otherwise npm install.
+    has_lockfile = (cwd_path / "package-lock.json").exists()
+    cmd = ["npm", "ci"] if has_lockfile else ["npm", "install"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd_path),
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        sys.exit(0)
+
+    if result.returncode == 0:
+        cmd_str = " ".join(cmd)
+        print(json.dumps({
+            "systemMessage": (
+                f"[worktree-npm-install] Ran `{cmd_str}` — "
+                "packages installed. node_modules is ready."
+            )
+        }))
+    else:
+        stderr_excerpt = result.stderr.strip()[:300] if result.stderr else "(no stderr)"
+        print(json.dumps({
+            "systemMessage": (
+                f"[worktree-npm-install] `{' '.join(cmd)}` failed "
+                f"(exit {result.returncode}). "
+                f"Run it manually before testing.\n{stderr_excerpt}"
+            )
+        }))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/scripts/worktree-npm-install.py
+++ b/claude/scripts/worktree-npm-install.py
@@ -15,7 +15,6 @@ Fires on every user prompt; exits silently when not applicable.
 Stdin JSON shape (UserPromptSubmit):
   {
     "hook_event_name": "UserPromptSubmit",
-    "session_id": "...",
     "cwd": "..."
   }
 
@@ -43,10 +42,7 @@ def main() -> None:
     parts = cwd_path.parts
 
     # Only run in Claude-managed worktrees (.claude/worktrees/<name> path structure).
-    if ".claude" not in parts or "worktrees" not in parts:
-        sys.exit(0)
-
-    # Verify .claude and worktrees appear as consecutive components.
+    # Require .claude and worktrees as consecutive path components.
     try:
         claude_idx = parts.index(".claude")
         if claude_idx + 1 >= len(parts) or parts[claude_idx + 1] != "worktrees":
@@ -64,7 +60,17 @@ def main() -> None:
 
     # Choose npm ci (reproducible) when a lockfile exists, otherwise npm install.
     has_lockfile = (cwd_path / "package-lock.json").exists()
-    cmd = ["npm", "ci"] if has_lockfile else ["npm", "install"]
+    cmd = "npm ci" if has_lockfile else "npm install"
+
+    # Emit a progress message before starting — install can take 30–120 s on large
+    # monorepos and the first prompt would otherwise appear to hang without feedback.
+    print(json.dumps({
+        "systemMessage": (
+            f"[worktree-npm-install] node_modules absent — running `{cmd}`. "
+            "This may take up to a few minutes on a large repo…"
+        )
+    }))
+    sys.stdout.flush()
 
     try:
         result = subprocess.run(
@@ -73,15 +79,15 @@ def main() -> None:
             capture_output=True,
             text=True,
             timeout=300,
+            shell=True,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+    except (subprocess.TimeoutExpired, OSError):
         sys.exit(0)
 
     if result.returncode == 0:
-        cmd_str = " ".join(cmd)
         print(json.dumps({
             "systemMessage": (
-                f"[worktree-npm-install] Ran `{cmd_str}` — "
+                f"[worktree-npm-install] `{cmd}` succeeded — "
                 "packages installed. node_modules is ready."
             )
         }))
@@ -89,7 +95,7 @@ def main() -> None:
         stderr_excerpt = result.stderr.strip()[:300] if result.stderr else "(no stderr)"
         print(json.dumps({
             "systemMessage": (
-                f"[worktree-npm-install] `{' '.join(cmd)}` failed "
+                f"[worktree-npm-install] `{cmd}` failed "
                 f"(exit {result.returncode}). "
                 f"Run it manually before testing.\n{stderr_excerpt}"
             )

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -62,6 +62,10 @@
           {
             "type": "command",
             "command": "python3 C:/Users/brown/.claude/scripts/multi-worktree-alert.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/worktree-npm-install.py"
           }
         ]
       }

--- a/docs/adr/016-worktree-npm-auto-install.md
+++ b/docs/adr/016-worktree-npm-auto-install.md
@@ -1,0 +1,67 @@
+# ADR-016: Auto-Install npm Packages in Claude-Managed Worktrees
+
+**Date:** 2026-05-09
+**Status:** Accepted
+
+---
+
+## Context
+
+Claude Code worktrees are created at `<repo>/.claude/worktrees/<name>/`. Each worktree is an
+independent working directory — `node_modules` is never inherited from the main repo checkout.
+Because worktrees are created without running any package-install step, the first time Claude
+runs tests or imports a package in a fresh worktree, the session encounters pre-existing
+failures like:
+
+> pre-existing failures due to missing npm packages [...] in this worktree — unrelated to my changes
+
+This is noise that masks real test failures, wastes time diagnosing the environment before
+work begins, and requires a manual `npm install` step that Claude must either remember to run
+or be told to run.
+
+Claude Code does not expose a `WorktreeCreate` or `EnterWorktree` hook event. Sessions also
+often start *already inside* a worktree (the harness places Claude there directly at session
+launch), so a `PostToolUse` hook on the `EnterWorktree` tool call would miss those cases.
+`UserPromptSubmit` fires on the first user message regardless of how the session started —
+the correct event for a one-time setup action that must complete before Claude begins any work.
+
+## Decision
+
+Add a `UserPromptSubmit` hook (`worktree-npm-install.py`) that:
+
+1. Detects a Claude-managed worktree by checking for `.claude` and `worktrees` as consecutive
+   path components in the cwd (`.claude/worktrees` is a stable convention used by the harness
+   and established in ADR-015).
+2. Confirms `package.json` exists in the cwd (repo is an npm project).
+3. Exits silently if `node_modules` already exists — the directory itself is the sentinel.
+4. Runs `npm ci` when `package-lock.json` exists (reproducible, faster) or `npm install`
+   otherwise.
+5. Emits a `systemMessage` confirming success or explaining failure.
+
+The hook is **global** (registered in `claude/settings.json`) so it applies to every npm-based
+repo without per-project configuration. It is a no-op in non-npm repos, non-worktree sessions,
+and worktrees where packages are already installed.
+
+## Consequences
+
+- The first prompt in any fresh Claude-managed worktree of an npm repo triggers a package
+  install automatically. Claude can proceed directly to working without a setup detour.
+- On failure (npm errors, timeout), the hook emits a warning systemMessage and exits 0 —
+  it never blocks Claude from responding.
+- npm install/ci for large monorepos can take 30–120 seconds, adding latency to the first
+  prompt in a fresh worktree. This is a one-time cost per worktree and is preferable to
+  silent test failures.
+- Non-npm repos and already-installed worktrees pay only the cost of three `Path.exists()`
+  checks per prompt until `node_modules` appears — negligible.
+- The `node_modules` check as sentinel means re-running `npm install` (e.g., after adding a
+  package) still requires a manual step or deletion of `node_modules` first. This is
+  acceptable: the hook targets *missing* installs, not *stale* ones.
+
+## References
+
+- [ADR-015](015-suppress-hook-noise-in-claude-worktrees.md) — established the worktree detection
+  pattern (`.claude/worktrees` in path) used here
+- [ADR-006](006-dev-env-sync-on-every-prompt.md) — rationale for `UserPromptSubmit` as the
+  hook event for session-start setup actions
+- [npm ci documentation](https://docs.npmjs.com/cli/v10/commands/npm-ci) — why `npm ci` is
+  preferred over `npm install` in automated contexts

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -20,3 +20,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [013](013-sync-routine-worktree-skill.md) | Sync-to-Main as a Reusable Routine Skill | 2026-05-06 | Accepted | routines, skills, git, worktree, scheduled-tasks, sync |
 | [014](014-auto-move-project-item-done-on-merge.md) | Auto-Move GitHub Project Item to Done on PR Merge | 2026-05-07 | Accepted | hooks, github-project, post-tool-use, hook-config, automation |
 | [015](015-suppress-hook-noise-in-claude-worktrees.md) | Suppress Hook Noise in Claude-Managed Worktree Sessions | 2026-05-07 | Accepted | hooks, worktree, UserPromptSubmit, token-efficiency, context-pollution |
+| [016](016-worktree-npm-auto-install.md) | Auto-Install npm Packages in Claude-Managed Worktrees | 2026-05-09 | Accepted | hooks, worktree, UserPromptSubmit, npm, node_modules, automation |


### PR DESCRIPTION
## Summary

- Adds `worktree-npm-install.py` — a `UserPromptSubmit` hook that detects Claude-managed worktrees and auto-runs `npm ci` (or `npm install`) when `node_modules` is absent
- Registers the hook in `claude/settings.json`
- Documents the decision in ADR-016

## Problem

Fresh Claude-managed worktrees have no `node_modules`. The first test run produces failures like _"pre-existing failures due to missing npm packages — unrelated to my changes"_, requiring a manual `npm install` before real work can begin.

## How it works

On every `UserPromptSubmit`, the hook:
1. Checks that `.claude/worktrees` appears in the cwd path (is a Claude-managed worktree)
2. Checks that `package.json` exists (npm repo)
3. Exits silently if `node_modules` already exists (sentinel — installed, nothing to do)
4. Runs `npm ci` if `package-lock.json` exists, otherwise `npm install`
5. Emits a \`systemMessage\` confirming success or explaining failure; always exits 0

## Scope

Global hook — applies to all npm repos using Claude Code worktrees. No-op in non-npm repos, non-worktree sessions, and already-installed worktrees.

## Test plan

- [ ] Open a new Claude session in a fresh lifting-logbook worktree (no \`node_modules\`): first prompt should trigger install and emit a systemMessage
- [ ] Second prompt in the same worktree: hook is a no-op
- [ ] Session in a non-npm repo: hook exits silently
- [ ] Session in the main repo checkout (not a worktree): hook exits silently
- [ ] \`python3 -m py_compile claude/scripts/worktree-npm-install.py\` — passes ✓

Closes #202