### PR TITLE
Note ai-adoption framework Appendix C as downstream artifact

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -126,6 +126,10 @@ If the project has no automated tests, the section must say so explicitly and de
 
 **Reference doc maintenance.** When a change adds, removes, or renames a hook script, skill, routine, or utility script, check whether the project README and any reference documentation need updating in the same PR. This includes command renames, new options, and behavior changes. Each project's CLAUDE.md specifies which reference files apply.
 
+**Downstream artifacts that name specific dev-env skills/hooks/routines** (update in the same PR as a rename or retirement):
+
+- `tech-leadership-reference/ai-adoption/ai-adoption-readiness-framework.md` — Appendix C names `/propose`, `/review`, `/journal-compose`, `/research`, and the `prune-stale-worktrees` and nightly journal compose routines as live-state evidence.
+
 **Repo path:** `C:/Users/brown/Git/dev-env`
 
 ---


### PR DESCRIPTION
## Summary
- Adds a 'Downstream artifacts' subsection to the Reference doc maintenance block in \`claude/CLAUDE.md\`
- Lists \`tech-leadership-reference/ai-adoption/ai-adoption-readiness-framework.md\` Appendix C as a downstream artifact that names specific dev-env skills and routines
- Future skill renames or routine retirements should update Appendix C in the same PR

Closes #206

## Test plan
- [x] \`python3 -m py_compile claude/scripts/*.py\` — passes
- [x] Docs-only change to \`claude/CLAUDE.md\`; no \`date -u\` matches affected