### PR TITLE
docs: ADR 017 — journal-compose today-guard (branch-detection path only)

### DIFF
--- a/docs/adr/017-journal-compose-today-guard.md
+++ b/docs/adr/017-journal-compose-today-guard.md
@@ -1,0 +1,63 @@
+# ADR 017 — Journal-Compose Today-Date Guard (Branch-Detection Path Only)
+
+**Date:** 2026-05-10  
+**Status:** Accepted
+
+---
+
+## Context
+
+`/journal-compose` resolves its target date from two sources: an explicit `$ARGUMENTS` value
+(`/journal-compose YYYY-MM-DD`) or auto-detection from the current branch name (`draft/YYYY-MM-DD`).
+
+When no argument is passed and `draft/<today>` is checked out, the skill silently resolves
+today's date and proceeds to merge the draft PR. Any stub pushed later that day triggers the
+pre-push hook (which blocks pushes to branches with merged PRs) and Claude emits a repeated
+"push hook-blocked" message. The root cause was that the skill had no guard on the resolved date.
+
+Two design options were considered for the guard scope:
+
+1. **Block both paths** — refuse today's date whether from `$ARGUMENTS` or branch detection.
+2. **Block branch-detection path only** — allow an explicit argument to override the guard.
+
+Option 1 was implemented first, then revised after review. Blocking an explicit argument is
+incorrect: a user who passes `/journal-compose 2026-05-10` is making a deliberate choice
+(e.g., they have written all stubs for the day and want to compose now). The guard should
+protect against the *accidental* case (branch auto-detection), not the *intentional* case.
+
+---
+
+## Decision
+
+The today-date guard applies **only when the date was auto-detected from the branch name**.
+If `$ARGUMENTS` is provided and matches today's date, the guard is skipped — the explicit date
+is treated as a deliberate end-of-day composition request.
+
+When the guard fires (branch-detection path, date == today), the skill stops immediately
+before stub discovery, manifest reading, or lock acquisition, and responds:
+
+> "`/journal-compose` targets completed days only. `draft/YYYY-MM-DD` is **today's** branch —
+> stubs may still be written during later sessions today.
+> Run `/journal-compose` at end of day, or pass an explicit past date:
+> `/journal-compose YYYY-MM-DD`."
+
+---
+
+## Consequences
+
+- Accidental mid-day composition via branch auto-detection is blocked cleanly with a clear
+  recovery message.
+- Intentional end-of-day composition (explicit date argument) is unaffected.
+- The pre-push hook's "push hook-blocked" message will no longer recur from this cause.
+- Users who want to compose today's journal early (all stubs written) pass an explicit date
+  argument rather than relying on branch detection.
+
+---
+
+## References
+
+- [dev-env#204](https://github.com/brownm09/dev-env/issues/204) — issue tracking this bug
+- [dev-env#205](https://github.com/brownm09/dev-env/pull/205) — PR implementing the guard
+- `claude/skills/journal-compose/SKILL.md` — Step 1, "Guard" block
+- ADR 002 — Journal-Compose Session Isolation (related: the other hard stop in Step 0)
+- `claude/hooks/pre-push` — the hook that blocks pushes to merged draft branches

--- a/docs/adr/017-journal-compose-today-guard.md
+++ b/docs/adr/017-journal-compose-today-guard.md
@@ -20,10 +20,10 @@ Two design options were considered for the guard scope:
 1. **Block both paths** — refuse today's date whether from `$ARGUMENTS` or branch detection.
 2. **Block branch-detection path only** — allow an explicit argument to override the guard.
 
-Option 1 was implemented first, then revised after review. Blocking an explicit argument is
-incorrect: a user who passes `/journal-compose 2026-05-10` is making a deliberate choice
-(e.g., they have written all stubs for the day and want to compose now). The guard should
-protect against the *accidental* case (branch auto-detection), not the *intentional* case.
+Option 1 was considered and rejected because blocking an explicit argument is incorrect: a
+user who passes `/journal-compose 2026-05-10` is making a deliberate choice (e.g., they have
+written all stubs for the day and want to compose now). The guard should protect against the
+*accidental* case (branch auto-detection), not the *intentional* case.
 
 ---
 
@@ -58,6 +58,6 @@ before stub discovery, manifest reading, or lock acquisition, and responds:
 
 - [dev-env#204](https://github.com/brownm09/dev-env/issues/204) — issue tracking this bug
 - [dev-env#205](https://github.com/brownm09/dev-env/pull/205) — PR implementing the guard
-- `claude/skills/journal-compose/SKILL.md` — Step 1, "Guard" block
-- ADR 002 — Journal-Compose Session Isolation (related: the other hard stop in Step 0)
-- `claude/hooks/pre-push` — the hook that blocks pushes to merged draft branches
+- [SKILL.md](../../claude/skills/journal-compose/SKILL.md) — Step 1, "Guard" block
+- [ADR 002](002-journal-compose-session-isolation.md) — Journal-Compose Session Isolation (related: the other hard stop in Step 0)
+- [pre-push](../../claude/hooks/pre-push) — the hook that blocks pushes to merged draft branches

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -21,3 +21,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [014](014-auto-move-project-item-done-on-merge.md) | Auto-Move GitHub Project Item to Done on PR Merge | 2026-05-07 | Accepted | hooks, github-project, post-tool-use, hook-config, automation |
 | [015](015-suppress-hook-noise-in-claude-worktrees.md) | Suppress Hook Noise in Claude-Managed Worktree Sessions | 2026-05-07 | Accepted | hooks, worktree, UserPromptSubmit, token-efficiency, context-pollution |
 | [016](016-worktree-npm-auto-install.md) | Auto-Install npm Packages in Claude-Managed Worktrees | 2026-05-09 | Accepted | hooks, worktree, UserPromptSubmit, npm, node_modules, automation |
+| [017](017-journal-compose-today-guard.md) | Journal-Compose Today-Date Guard (Branch-Detection Path Only) | 2026-05-10 | Accepted | journal, composition, skill, today-guard, branch-detection |


### PR DESCRIPTION
## Summary

- Adds ADR 017 documenting the design decision in PR #205: the today-date guard in `/journal-compose` applies **only on the branch-detection path**, not when an explicit date is passed via `$ARGUMENTS`
- Updates `docs/adr/INDEX.md`

## Why this ADR

Per the ADR-warrant rule: #205 modified a skill in `claude/skills/`, which always warrants an ADR. Identified at the PR-merge checkpoint; written here as a follow-up.

## Test plan

- [x] `python3 -m py_compile claude/scripts/*.py` — passes (no Python files changed)
- [x] `docs/adr/INDEX.md` entry added at ADR 017

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)