### PR TITLE
feat(hooks): reconcile open-prs.jsonl against GitHub state at session start

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All hooks are advisory — none block tool execution.
 | UserPromptSubmit | `journal-onboard-check.py` | Warns when the active project has no journal home in engineering-journal |
 | UserPromptSubmit | `turn-count-hook.py` | Warns when session context token count exceeds threshold |
 | UserPromptSubmit | `multi-worktree-alert.py` | Lists active worktrees in `repo:branch` format when ≥2 are open |
+| UserPromptSubmit | `reconcile-open-prs.py` | Removes stale entries from `open-prs.jsonl` whose PRs are now merged/closed; emits surviving open PRs as session context |
 | PreToolUse (Bash) | `pre-commit-branch-check.py` | Emits current branch as a checkpoint before `git commit` |
 | PreToolUse (Bash) | `pre-pr-create-check.py` | Emits test-verification checklist before `gh pr create` |
 | PostToolUse (Bash) | `pr-merge-reminder.py` | Reminds to write a journal stub after `gh pr create` or `gh pr merge` |

--- a/claude/scripts/get-project-item.sh
+++ b/claude/scripts/get-project-item.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# get-project-item.sh — resolve a GitHub Project item ID from an issue/PR number
+#
+# Usage: get-project-item.sh <issue-or-pr-number> [project-number] [owner]
+#
+# Outputs the project item node ID to stdout so callers can capture it:
+#   ITEM_ID=$(bash get-project-item.sh 42)
+#
+# Defaults: project 3, owner brownm09 (dev-env project board).
+# Override via arguments or PROJECT_NUMBER / PROJECT_OWNER env vars.
+#
+# Prerequisites: gh CLI authenticated with the 'project' scope.
+#   Add once if needed: gh auth refresh -s project
+
+set -euo pipefail
+
+ISSUE_NUMBER="${1:-}"
+if [[ -z "$ISSUE_NUMBER" ]]; then
+  echo "Usage: get-project-item.sh <issue-or-pr-number> [project-number] [owner]" >&2
+  exit 1
+fi
+
+PROJECT_NUMBER="${2:-${PROJECT_NUMBER:-3}}"
+OWNER="${3:-${PROJECT_OWNER:-brownm09}}"
+
+SCRATCH="${HOME}/.claude/scratch"
+TMPFILE="${SCRATCH}/tmp_project_item_$$.json"
+
+gh project item-list "$PROJECT_NUMBER" \
+  --owner "$OWNER" \
+  --format json \
+  --limit 1000 > "$TMPFILE"
+
+ITEM_ID=$(node -e "
+  const d = JSON.parse(require('fs').readFileSync('$TMPFILE', 'utf8'));
+  const item = d.items.find(i => i.content && i.content.number === $ISSUE_NUMBER);
+  if (!item) { process.stderr.write('get-project-item: no item found for #$ISSUE_NUMBER\n'); process.exit(1); }
+  console.log(item.id);
+")
+EXIT_CODE=$?
+rm -f "$TMPFILE"
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+  exit 1
+fi
+
+echo "$ITEM_ID"

--- a/claude/scripts/reconcile-open-prs.py
+++ b/claude/scripts/reconcile-open-prs.py
@@ -120,7 +120,7 @@ def reconcile_file(path: Path) -> tuple[list[dict], list[tuple[dict, str]]]:
         repo = repo_from_url(url)
 
         if not repo or not pr_number:
-            surviving.append(entry)
+            removed.append((entry, "malformed"))
             continue
 
         state = check_pr_state(pr_number, repo)
@@ -147,7 +147,7 @@ def main() -> None:
         except json.JSONDecodeError:
             pass
 
-    session_id = data.get("session_id", "unknown")
+    session_id = data.get("session_id") or f"unknown-{int(time.time())}"
 
     if already_ran(session_id):
         return
@@ -166,7 +166,10 @@ def main() -> None:
         for entry in surviving:
             all_surviving.append(f"{project}#{entry.get('pr')} ({entry.get('url', '')})")
         for entry, state in removed:
-            all_removed.append(f"{project}#{entry.get('pr')} — {state.lower()}")
+            if state == "malformed":
+                all_removed.append(f"{project}: malformed entry (missing pr/url)")
+            else:
+                all_removed.append(f"{project}#{entry.get('pr')} — {state.lower()}")
 
     mark_done(session_id)
 
@@ -180,7 +183,7 @@ def main() -> None:
     if all_surviving:
         parts.append("Open PRs: " + ", ".join(all_surviving))
     elif not all_removed:
-        # nothing to report — no files exist
+        # nothing to report — no files found or all are empty
         return
 
     msg = " ".join(parts) if parts else ""

--- a/claude/scripts/reconcile-open-prs.py
+++ b/claude/scripts/reconcile-open-prs.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: reconcile open-prs.jsonl against live GitHub PR state.
+
+Runs once per session (per-session sentinel in scratch/). For every
+sessions/*/open-prs.jsonl in the engineering-journal repo:
+  - Calls `gh pr view` for each entry to check current state.
+  - Removes entries whose PRs are MERGED or CLOSED (in-place rewrite).
+  - Deletes the file when the last entry is removed.
+
+Modified files are left dirty for Claude to pick up in the next stub commit.
+Always exits 0 — never blocks.
+
+Stdout: one JSON line with a systemMessage listing surviving open PRs (and any
+removals), so Claude has correct context from turn 1 without reading the file.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+SCRATCH = Path.home() / ".claude" / "scratch"
+JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
+SENTINEL_PREFIX = "open-prs-reconciled-"
+MAX_AGE_DAYS = 30
+
+
+def cleanup_stale_sentinels() -> None:
+    cutoff = time.time() - MAX_AGE_DAYS * 86400
+    try:
+        for f in SCRATCH.glob(f"{SENTINEL_PREFIX}*.flag"):
+            if f.stat().st_mtime < cutoff:
+                f.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def sentinel_path(session_id: str) -> Path:
+    return SCRATCH / f"{SENTINEL_PREFIX}{session_id}.flag"
+
+
+def already_ran(session_id: str) -> bool:
+    return sentinel_path(session_id).exists()
+
+
+def mark_done(session_id: str) -> None:
+    try:
+        sentinel_path(session_id).write_text("")
+    except Exception:
+        pass
+
+
+def repo_from_url(url: str) -> str | None:
+    """Extract 'owner/repo' from a GitHub PR URL."""
+    try:
+        parts = urlparse(url).path.strip("/").split("/")
+        # expected: ['owner', 'repo', 'pull', 'N']
+        if len(parts) >= 2:
+            return f"{parts[0]}/{parts[1]}"
+    except Exception:
+        pass
+    return None
+
+
+def check_pr_state(pr_number: int, repo: str) -> str | None:
+    """Return 'OPEN', 'MERGED', or 'CLOSED'; None on any failure."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", "state"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        return data.get("state")
+    except Exception:
+        return None
+
+
+def load_entries(path: Path) -> list[dict]:
+    entries = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            pass
+    return entries
+
+
+def write_entries(path: Path, entries: list[dict]) -> None:
+    if not entries:
+        path.unlink(missing_ok=True)
+    else:
+        path.write_text(
+            "\n".join(json.dumps(e) for e in entries) + "\n",
+            encoding="utf-8",
+        )
+
+
+def reconcile_file(path: Path) -> tuple[list[dict], list[tuple[dict, str]]]:
+    """Return (surviving_entries, [(removed_entry, state), ...])."""
+    entries = load_entries(path)
+    if not entries:
+        return [], []
+
+    surviving = []
+    removed: list[tuple[dict, str]] = []
+    for entry in entries:
+        url = entry.get("url", "")
+        pr_number = entry.get("pr")
+        repo = repo_from_url(url)
+
+        if not repo or not pr_number:
+            surviving.append(entry)
+            continue
+
+        state = check_pr_state(pr_number, repo)
+        if state in ("MERGED", "CLOSED"):
+            removed.append((entry, state))
+        else:
+            # OPEN, unknown (gh failed), or None — keep the entry
+            surviving.append(entry)
+
+    if removed:
+        write_entries(path, surviving)
+
+    return surviving, removed
+
+
+def main() -> None:
+    cleanup_stale_sentinels()
+
+    raw = sys.stdin.read().strip()
+    data: dict = {}
+    if raw:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+
+    session_id = data.get("session_id", "unknown")
+
+    if already_ran(session_id):
+        return
+
+    all_surviving: list[str] = []
+    all_removed: list[str] = []
+
+    jsonl_files = sorted(JOURNAL_REPO.glob("sessions/*/open-prs.jsonl"))
+    for path in jsonl_files:
+        project = path.parent.name
+        try:
+            surviving, removed = reconcile_file(path)
+        except Exception:
+            continue
+
+        for entry in surviving:
+            all_surviving.append(f"{project}#{entry.get('pr')} ({entry.get('url', '')})")
+        for entry, state in removed:
+            all_removed.append(f"{project}#{entry.get('pr')} — {state.lower()}")
+
+    mark_done(session_id)
+
+    parts: list[str] = []
+    if all_removed:
+        parts.append(
+            "Reconciled open-prs.jsonl — removed stale entries: "
+            + ", ".join(all_removed)
+            + ". Files updated; include open-prs.jsonl in your next stub commit."
+        )
+    if all_surviving:
+        parts.append("Open PRs: " + ", ".join(all_surviving))
+    elif not all_removed:
+        # nothing to report — no files exist
+        return
+
+    msg = " ".join(parts) if parts else ""
+    if msg:
+        print(json.dumps({"systemMessage": msg}))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -66,6 +66,10 @@
           {
             "type": "command",
             "command": "python3 C:/Users/brown/.claude/scripts/worktree-npm-install.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/reconcile-open-prs.py"
           }
         ]
       }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -134,6 +134,7 @@ Fires on every user prompt, before Claude processes it.
 | `journal-onboard-check.py` | Checks whether the active git repo has a `sessions/<repo-name>/` directory in engineering-journal. Emits a one-line advisory and `/journal-onboard` hint if not. Fires once per session. |
 | `turn-count-hook.py` | Warns when session context accumulates past a threshold. Primary signal: token count; secondary: turn count. Configurable via `"turn_threshold"` in `.claude/hook-config.json` (default: 50). |
 | `multi-worktree-alert.py` | When ≥2 git worktrees are active, emits a list in `repo:branch` format, starring the current one. Fires on every prompt. Suppressed in Claude-managed worktree sessions (`.claude/worktrees/` in cwd). |
+| `reconcile-open-prs.py` | Runs once per session (per-session sentinel in `scratch/`). Calls `gh pr view` for each entry in every `sessions/*/open-prs.jsonl` in engineering-journal; removes entries whose PRs are MERGED or CLOSED; emits a `systemMessage` listing surviving open PRs and any removals. Does not commit — modified files are picked up by the next stub commit. Fails safe: `gh` errors leave the entry intact. [ADR-018](adr/018-reconcile-open-prs-hook.md) |
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -282,6 +282,7 @@ On-demand scripts — not wired to any event. Run manually or from other scripts
 | `prune-merged-worktrees.py` | `python3 prune-merged-worktrees.py` | Manual equivalent of the `prune-stale-worktrees` routine. |
 | `new-branch.sh` | `new-branch <name>` (shell function; source `~/.claude/scripts/new-branch.sh` in `.bashrc`) | Creates a branch always rooted at `origin/main`. Warns when HEAD has diverged from the merge base. |
 | `merge-stale-pr.sh` | `bash merge-stale-pr.sh <PR-URL>` | Remediates stale `engineering-journal` draft PRs: checks out the branch, warns on missing journal file, deletes orphaned drafts, rebases, and squash-merges with auto-conflict resolution. |
+| `get-project-item.sh` | `ITEM_ID=$(bash get-project-item.sh <issue-number> [project-number] [owner])` | Resolves a GitHub Project item node ID from an issue/PR number. Defaults to project 3, owner `brownm09`. Overridable via args or `PROJECT_NUMBER`/`PROJECT_OWNER` env vars. Requires `project` scope: `gh auth refresh -s project`. |
 
 ---
 

--- a/docs/adr/018-reconcile-open-prs-hook.md
+++ b/docs/adr/018-reconcile-open-prs-hook.md
@@ -1,0 +1,99 @@
+# ADR 018 — Auto-Reconcile open-prs.jsonl Against GitHub State
+
+**Date:** 2026-05-10
+**Status:** Accepted
+**Tags:** hooks, open-prs, UserPromptSubmit, github, token-efficiency
+
+---
+
+## Context
+
+`open-prs.jsonl` in `brownm09/engineering-journal` tracks PRs whose full lifecycle (open →
+review → merge) spans multiple sessions. It is updated manually by Claude: append on
+`gh pr create`, remove via a Node.js one-liner on `gh pr merge`.
+
+In practice the file drifts. Two failure modes recur:
+
+1. **Session-end aborts.** A session that merges a PR and then loses context (e.g., via
+   `/compact` before stub writing, or an unexpected stop) may skip the removal step.
+   The merged PR stays in the file indefinitely.
+
+2. **Missing additions.** A session that opens a PR in a complex multi-file context
+   occasionally omits the `open-prs.jsonl` append step.
+
+The consequences compound: `post-compact.py` reads the file to emit review reminders, and
+Claude reads it at session start to establish context. Stale or missing entries cause Claude
+to surface wrong reminders, miss real open PRs, or spend turns reconciling discrepancies —
+each wasted turn costs tokens.
+
+Confirmed instance at ADR authoring time: dev-env #170 (ADR 012) was open but had no entry;
+a session ended without appending it.
+
+---
+
+## Decision
+
+Add a `UserPromptSubmit` hook (`reconcile-open-prs.py`) that self-heals the file at session
+start by querying GitHub directly.
+
+**Behaviour:**
+
+1. Runs once per session via a per-session sentinel file in `scratch/` (same pattern as
+   `turn-count-hook.py`).
+2. Discovers all `sessions/*/open-prs.jsonl` files in the engineering-journal repo.
+3. For each entry, calls `gh pr view <N> --repo <owner>/<repo> --json state`.
+4. Removes entries whose state is `MERGED` or `CLOSED` (rewrites the file in-place; deletes
+   the file when empty).
+5. On `gh` failure (network, auth, timeout), leaves the entry untouched — conservative.
+6. Emits a `systemMessage` to stdout listing surviving open PRs and any removals, so Claude
+   has correct context from turn 1 without a manual file read.
+7. Does **not** commit. Modified files are left dirty and picked up by the next stub commit
+   via the existing `git add ... open-prs.jsonl` step in CLAUDE.md.
+8. Always exits 0 — never blocks.
+
+**Why a hook instead of a manual utility:**
+Staleness is invisible until it causes a problem. A hook that silently self-heals on every
+session start eliminates the failure mode without requiring user or Claude action. A manual
+script would only help after the user notices a problem, which is too late to prevent the
+token waste.
+
+**Why fix silently rather than emit a warning:**
+A warning prompts Claude to act, which costs at least one additional turn. The hook can fix
+the file cheaper than the warning can be processed. The `systemMessage` still surfaces
+removals so there is no silent data loss.
+
+**Why once-per-session rather than every prompt:**
+`gh pr view` makes one API call per tracked PR. Running on every prompt would add latency and
+API load for no additional value — PR state changes slowly, and a single reconciliation at
+session start is sufficient coverage.
+
+---
+
+## Alternatives Considered
+
+**Warning-only (no file modification from hook):**
+Emitting a message and letting Claude fix the file would preserve the "hooks never modify
+state" property, but costs one Claude turn per stale entry. Token waste is the problem being
+solved; adding turns defeats the purpose.
+
+**Detect and add missing PRs (not just remove stale ones):**
+Could scan recent stubs/manifests to find PRs that should be in the file but aren't. Deferred:
+requires parsing stub markdown, is fragile (stubs may not follow the exact format), and the
+missing-addition failure mode is less frequent than the missed-removal mode.
+
+**Run as a daily routine rather than a session hook:**
+Would batch the `gh` calls but introduce a lag window where stale data affects sessions.
+Session-start execution gives the strongest freshness guarantee.
+
+---
+
+## Consequences
+
+- `open-prs.jsonl` is correct from the first turn of every session, eliminating the stale-data
+  class of wasted turns.
+- Sessions with no open PRs see no output (hook exits silently).
+- Sessions with open PRs receive a `systemMessage` that replaces the manual file read Claude
+  would otherwise perform.
+- One `gh pr view` call per tracked PR per session — negligible cost given the typical file
+  has 0–4 entries.
+- Stale sentinel files cleaned up after 30 days (same maintenance window as `turn-count-hook.py`).

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -22,3 +22,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [015](015-suppress-hook-noise-in-claude-worktrees.md) | Suppress Hook Noise in Claude-Managed Worktree Sessions | 2026-05-07 | Accepted | hooks, worktree, UserPromptSubmit, token-efficiency, context-pollution |
 | [016](016-worktree-npm-auto-install.md) | Auto-Install npm Packages in Claude-Managed Worktrees | 2026-05-09 | Accepted | hooks, worktree, UserPromptSubmit, npm, node_modules, automation |
 | [017](017-journal-compose-today-guard.md) | Journal-Compose Today-Date Guard (Branch-Detection Path Only) | 2026-05-10 | Accepted | journal, composition, skill, today-guard, branch-detection |
+| [018](018-reconcile-open-prs-hook.md) | Auto-Reconcile open-prs.jsonl Against GitHub State | 2026-05-10 | Accepted | hooks, open-prs, UserPromptSubmit, github, token-efficiency |


### PR DESCRIPTION
## Summary

- Adds `reconcile-open-prs.py` (`UserPromptSubmit` hook) that calls `gh pr view` for every entry across all `sessions/*/open-prs.jsonl` files in engineering-journal, removes stale entries whose PRs are MERGED or CLOSED, and emits a `systemMessage` with surviving open PRs so Claude has correct context from turn 1 without a manual file read.
- Runs once per session via a per-session sentinel in `scratch/`; always exits 0; fails safe on `gh` errors (leaves entry intact).
- Does **not** commit — modified files are left dirty and picked up by the next stub commit.
- Includes ADR 018 and reference doc updates.

## Test plan

- [x] `python3 -m py_compile claude/scripts/reconcile-open-prs.py` — passes
- [x] Manual run found and removed 6 stale merged entries (dev-env#152, dev-env#205, career-playbook#149, lifting-logbook#214, and 2 others), correctly preserved 3 open PRs
- [x] Second run with same session_id produced no output (idempotent)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)