### PR TITLE
fix: extend journal-compose today-guard to all paths; allow same-day draft push

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -422,8 +422,10 @@ Schema — one JSON line per open PR:
 - `/journal-compose` preserves this file unchanged in the merge-to-main commit so it carries forward to the next day.
 
 **End of day (last session):**
-1. Run `/journal-compose` — it discovers all stubs via manifest (or glob fallback), merges them,
-   produces the canonical 11-section document, and auto-merges the PR
+1. Run `/journal-compose --force` — it discovers all stubs via manifest (or glob fallback), merges
+   them, produces the canonical 11-section document, and auto-merges the PR. `--force` is required
+   when composing today's branch; past-date composition (`/journal-compose YYYY-MM-DD` for a prior
+   day) does not need the flag
 
 ---
 

--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -24,8 +24,12 @@ while read local_ref local_sha remote_ref remote_sha; do
   # Block pushes to already-merged draft/YYYY-MM-DD branches in engineering-journal.
   # Pushing to a merged branch resurrects it, causing the stale-branch hook to fire
   # on every subsequent prompt until orphaned commits are reconciled.
+  # Exception: same-day branches are allowed — recovery pushes after an accidental
+  # mid-day compose are legitimate. Prior-day branches are still blocked (stale-branch noise).
   remote_branch="${remote_ref#refs/heads/}"
   if echo "$remote_branch" | grep -qE '^draft/[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    branch_date=$(echo "$remote_branch" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
+    [ "$branch_date" = "$(date +%Y-%m-%d)" ] && continue
     remote_url=$(git remote get-url origin 2>/dev/null || echo "")
     if echo "$remote_url" | grep -q "engineering-journal"; then
       if command -v gh >/dev/null 2>&1; then

--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -26,12 +26,13 @@ while read local_ref local_sha remote_ref remote_sha; do
   # on every subsequent prompt until orphaned commits are reconciled.
   # Exception: same-day branches are allowed — recovery pushes after an accidental
   # mid-day compose are legitimate. Prior-day branches are still blocked (stale-branch noise).
+  # Both the exception and the block are scoped to engineering-journal only.
   remote_branch="${remote_ref#refs/heads/}"
   if echo "$remote_branch" | grep -qE '^draft/[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
-    branch_date=$(echo "$remote_branch" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
-    [ "$branch_date" = "$(date +%Y-%m-%d)" ] && continue
     remote_url=$(git remote get-url origin 2>/dev/null || echo "")
     if echo "$remote_url" | grep -q "engineering-journal"; then
+      branch_date="${remote_branch#draft/}"
+      [ "$branch_date" = "$(date +%Y-%m-%d)" ] && continue
       if command -v gh >/dev/null 2>&1; then
         merged=$(gh pr list --repo brownm09/engineering-journal \
           --state merged --head "$remote_branch" --json number 2>/dev/null || echo "[]")

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: journal-compose
-description: Compose the end-of-day engineering journal from today's stub files. Discovers all YYYY-MM-DD_*.stub.md files, sorts and merges them, produces the canonical 11-section document, updates READMEs, commits, and opens the PR. Invoke as /journal-compose [YYYY-MM-DD].
+description: Compose the end-of-day engineering journal from today's stub files. Discovers all YYYY-MM-DD_*.stub.md files, sorts and merges them, produces the canonical 11-section document, updates READMEs, commits, and opens the PR. Invoke as /journal-compose [YYYY-MM-DD] [--force].
 argument-hint: "[YYYY-MM-DD] [--force]"
 allowed-tools: Read Edit Write Bash Glob Grep Agent
 ---

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: journal-compose
 description: Compose the end-of-day engineering journal from today's stub files. Discovers all YYYY-MM-DD_*.stub.md files, sorts and merges them, produces the canonical 11-section document, updates READMEs, commits, and opens the PR. Invoke as /journal-compose [YYYY-MM-DD].
-argument-hint: "[YYYY-MM-DD]"
+argument-hint: "[YYYY-MM-DD] [--force]"
 allowed-tools: Read Edit Write Bash Glob Grep Agent
 ---
 
@@ -52,35 +52,37 @@ node "C:/Users/brown/Git/engineering-journal/scripts/validate-jsonl.js"
 
 ## Step 1 — Locate stubs and acquire compose lock
 
-**Determine the date:**
+**Parse `$ARGUMENTS`:**
 
-If `$ARGUMENTS` is provided and matches `YYYY-MM-DD`, use it as the date. Otherwise, detect
-from the current branch:
-```bash
-git -C C:/Users/brown/Git/engineering-journal branch --show-current
-```
-The branch name is `draft/YYYY-MM-DD`. Extract `YYYY-MM-DD` from it.
+- If `$ARGUMENTS` contains `--force`, set `FORCE=true` and strip it before further parsing.
+  Otherwise set `FORCE=false`.
+- If the remaining `$ARGUMENTS` matches `YYYY-MM-DD`, use it as the date.
+- Otherwise, detect the date from the current branch:
+  ```bash
+  git -C C:/Users/brown/Git/engineering-journal branch --show-current
+  ```
+  The branch name is `draft/YYYY-MM-DD`. Extract `YYYY-MM-DD` from it.
 
-**Guard — refuse to compose today's branch (branch-detection path only):**
+**Guard — refuse to compose today's branch:**
 
-If the date was **auto-detected from the branch name** (i.e., `$ARGUMENTS` was not provided),
-compare it to today's date:
+Compare the resolved date to today's date:
 
 ```bash
 TODAY=$(date +%Y-%m-%d)
 ```
 
-If the detected date equals `$TODAY`, stop immediately and respond:
+If the date equals `$TODAY` **and** `FORCE` is false, stop immediately and respond:
 
 > "`/journal-compose` targets completed days only. `draft/YYYY-MM-DD` is **today's** branch —
 > stubs may still be written during later sessions today.  
-> Run `/journal-compose` at end of day, or pass an explicit past date:
-> `/journal-compose YYYY-MM-DD`."
+> To compose today's journal intentionally (all stubs written, end of day):
+> `/journal-compose --force`"
 
 Do **not** proceed to stub discovery, manifest reading, lock acquisition, or any further step.
 
-If the date came from `$ARGUMENTS`, skip this guard — an explicit date is a deliberate choice
-(e.g., composing after the final stub of the day has been written).
+If the date equals `$TODAY` and `FORCE` is true, proceed — intentional same-day compose.
+
+If the date is not today, proceed normally (regardless of `FORCE`).
 
 **Check for a manifest (fast path):**
 

--- a/docs/adr/017-journal-compose-today-guard.md
+++ b/docs/adr/017-journal-compose-today-guard.md
@@ -1,7 +1,7 @@
-# ADR 017 — Journal-Compose Today-Date Guard (Branch-Detection Path Only)
+# ADR 017 — Journal-Compose Today-Date Guard (All Paths; `--force` Opt-Out)
 
 **Date:** 2026-05-10  
-**Status:** Accepted
+**Status:** Accepted (updated 2026-05-10 — extended guard scope and pre-push hook date exception)
 
 ---
 
@@ -10,54 +10,77 @@
 `/journal-compose` resolves its target date from two sources: an explicit `$ARGUMENTS` value
 (`/journal-compose YYYY-MM-DD`) or auto-detection from the current branch name (`draft/YYYY-MM-DD`).
 
-When no argument is passed and `draft/<today>` is checked out, the skill silently resolves
-today's date and proceeds to merge the draft PR. Any stub pushed later that day triggers the
-pre-push hook (which blocks pushes to branches with merged PRs) and Claude emits a repeated
-"push hook-blocked" message. The root cause was that the skill had no guard on the resolved date.
+**Original problem (PR #205):** When no argument is passed and `draft/<today>` is checked out,
+the skill silently resolves today's date and proceeds to merge the draft PR mid-day. Any stub
+pushed later that day triggers the pre-push hook (which blocks pushes to branches with merged
+PRs) and Claude emits a repeated "push hook-blocked" message. PR #205 added a guard on the
+auto-detection path only.
 
-Two design options were considered for the guard scope:
+**Remaining gap:** An explicit invocation like `/journal-compose 2026-05-10` on May 10 bypassed
+the guard entirely. The original ADR 017 rationale was that an explicit argument is "a deliberate
+choice." In practice, the distinction between "accidental" and "deliberate" cannot be inferred
+from the argument alone — it requires explicit user intent.
 
-1. **Block both paths** — refuse today's date whether from `$ARGUMENTS` or branch detection.
-2. **Block branch-detection path only** — allow an explicit argument to override the guard.
-
-Option 1 was considered and rejected because blocking an explicit argument is incorrect: a
-user who passes `/journal-compose 2026-05-10` is making a deliberate choice (e.g., they have
-written all stubs for the day and want to compose now). The guard should protect against the
-*accidental* case (branch auto-detection), not the *intentional* case.
+**Related problem:** After an accidental mid-day compose squash-merges `draft/YYYY-MM-DD`, the
+pre-push hook blocked all further same-day pushes to that branch — including legitimate recovery
+pushes. The hook made no distinction between same-day branches (still live) and prior-day
+branches (genuinely stale).
 
 ---
 
 ## Decision
 
-The today-date guard applies **only when the date was auto-detected from the branch name**.
-If `$ARGUMENTS` is provided and matches today's date, the guard is skipped — the explicit date
-is treated as a deliberate end-of-day composition request.
+### 1. Journal-compose guard — all date inputs, `--force` opt-out
 
-When the guard fires (branch-detection path, date == today), the skill stops immediately
-before stub discovery, manifest reading, or lock acquisition, and responds:
+The today-date guard now applies to **all** date inputs — both auto-detected and explicitly
+passed via `$ARGUMENTS`. Passing today's date explicitly no longer bypasses the guard.
+
+To compose today's journal deliberately (all stubs written, end of day), the caller must pass
+`--force`:
+
+- `/journal-compose --force` — auto-detects today's branch, proceeds
+- `/journal-compose 2026-05-10 --force` — explicit date with force, proceeds
+- `/journal-compose 2026-05-10` on May 10 — **blocked** (no `--force`)
+- `/journal-compose 2026-05-09` — always proceeds (prior day, no flag needed)
+
+When the guard fires (today's date, no `--force`), the skill stops immediately before stub
+discovery, manifest reading, or lock acquisition, and responds:
 
 > "`/journal-compose` targets completed days only. `draft/YYYY-MM-DD` is **today's** branch —
-> stubs may still be written during later sessions today.
-> Run `/journal-compose` at end of day, or pass an explicit past date:
-> `/journal-compose YYYY-MM-DD`."
+> stubs may still be written during later sessions today.  
+> To compose today's journal intentionally (all stubs written, end of day):
+> `/journal-compose --force`"
+
+The `daily-journal-compose` nightly routine is unaffected: it runs at midnight UTC and always
+passes yesterday's local calendar date — never today's — so the guard never fires for it.
+
+### 2. Pre-push hook — skip merged-PR check for same-day branches
+
+When the branch name is `draft/YYYY-MM-DD` and that date matches today's local date, the
+merged-PR check is skipped and the push is allowed. Prior-day branches still hit the check.
+
+Rationale: a same-day branch may have an accidental merged PR (mid-day compose kerfuffle) but
+recovery pushes to it are still legitimate on the same calendar day. Stale-branch noise only
+becomes a problem when a branch is pushed on a day after it was merged — the session that
+resurrected it is long gone and the orphaned commits are unattended.
 
 ---
 
 ## Consequences
 
-- Accidental mid-day composition via branch auto-detection is blocked cleanly with a clear
-  recovery message.
-- Intentional end-of-day composition (explicit date argument) is unaffected.
-- The pre-push hook's "push hook-blocked" message will no longer recur from this cause.
-- Users who want to compose today's journal early (all stubs written) pass an explicit date
-  argument rather than relying on branch detection.
+- Accidental mid-day composition is blocked on all invocation paths.
+- Intentional end-of-day composition requires `--force` — makes deliberate intent explicit.
+- The nightly routine requires no changes.
+- Same-day recovery pushes after an accidental compose are no longer hook-blocked.
+- CLAUDE.md end-of-day instruction updated: `Run /journal-compose --force`.
 
 ---
 
 ## References
 
-- [dev-env#204](https://github.com/brownm09/dev-env/issues/204) — issue tracking this bug
-- [dev-env#205](https://github.com/brownm09/dev-env/pull/205) — PR implementing the guard
+- [dev-env#204](https://github.com/brownm09/dev-env/issues/204) — original bug
+- [dev-env#205](https://github.com/brownm09/dev-env/pull/205) — initial guard (branch-detection path only)
+- [dev-env#213](https://github.com/brownm09/dev-env/issues/213) — issue tracking this extension
 - [SKILL.md](../../claude/skills/journal-compose/SKILL.md) — Step 1, "Guard" block
+- [pre-push](../../claude/hooks/pre-push) — merged-branch push guard with same-day exception
 - [ADR 002](002-journal-compose-session-isolation.md) — Journal-Compose Session Isolation (related: the other hard stop in Step 0)
-- [pre-push](../../claude/hooks/pre-push) — the hook that blocks pushes to merged draft branches

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -21,4 +21,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [014](014-auto-move-project-item-done-on-merge.md) | Auto-Move GitHub Project Item to Done on PR Merge | 2026-05-07 | Accepted | hooks, github-project, post-tool-use, hook-config, automation |
 | [015](015-suppress-hook-noise-in-claude-worktrees.md) | Suppress Hook Noise in Claude-Managed Worktree Sessions | 2026-05-07 | Accepted | hooks, worktree, UserPromptSubmit, token-efficiency, context-pollution |
 | [016](016-worktree-npm-auto-install.md) | Auto-Install npm Packages in Claude-Managed Worktrees | 2026-05-09 | Accepted | hooks, worktree, UserPromptSubmit, npm, node_modules, automation |
-| [017](017-journal-compose-today-guard.md) | Journal-Compose Today-Date Guard (Branch-Detection Path Only) | 2026-05-10 | Accepted | journal, composition, skill, today-guard, branch-detection |
+| [017](017-journal-compose-today-guard.md) | Journal-Compose Today-Date Guard (All Paths; `--force` Opt-Out) | 2026-05-10 | Accepted | journal, composition, skill, today-guard, branch-detection, pre-push |


### PR DESCRIPTION
## Summary

- **Pre-push hook**: skip merged-PR check when branch date == today — same-day recovery pushes after an accidental mid-day compose are now unblocked (prior-day branches still blocked)
- **journal-compose guard**: extended from branch-detection path only to all date inputs; `--force` flag required for intentional same-day compose (end-of-day manual run); past-date invocations unaffected
- **CLAUDE.md**: end-of-day instruction updated to `/journal-compose --force`
- **ADR 017**: updated to document the extended scope, `--force` mechanism, and pre-push same-day exception

The nightly `daily-journal-compose` routine passes yesterday's UTC date — never today's — so it is unaffected by the guard change and requires no `--force`.

## Test plan

- [x] `python3 -m py_compile claude/scripts/*.py` — passes
- [x] `grep -n 'date -u' claude/CLAUDE.md` — single match in testing instructions paragraph (not a stub filename or branch name context)

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)