### PR TITLE
fix(post-compact): tell user to reply to trigger /review after compact

### DIFF
--- a/claude/scripts/post-compact.py
+++ b/claude/scripts/post-compact.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """PostCompact hook — emit a status line and, for manual compactions with open PRs,
-inject a systemMessage so Claude auto-invokes /review without user input."""
+inject a systemMessage so Claude invokes /review on the next user reply."""
 import json
 import subprocess
 import sys
@@ -75,6 +75,7 @@ def main():
                     f"PostCompact complete. Open PR: {pr_ref}\n"
                     f"Per CLAUDE.md workflow: invoke /review {pr.get('url', '')} --post-comment now."
                 )
+                print(f"  open PR #{pr['pr']} — reply to this message to trigger /review", file=sys.stderr)
             else:
                 pr_list = ", ".join(
                     f"#{p['pr']} {p.get('url', '')}" for p in prs
@@ -83,6 +84,7 @@ def main():
                     f"PostCompact complete. Open PRs: {pr_list}\n"
                     "Per CLAUDE.md workflow: invoke /review on the relevant PR --post-comment now."
                 )
+                print(f"  {len(prs)} open PRs — reply to this message to trigger /review", file=sys.stderr)
             print(json.dumps({"systemMessage": msg}))
 
 


### PR DESCRIPTION
## Summary

- `systemMessage` from a PostCompact hook is context injection, not an auto-trigger — Claude only acts on the **next user-initiated turn**, so after `/compact` it waits silently
- Add a stderr status line (`open PR #N — reply to this message to trigger /review`) so users know to type something
- The existing `systemMessage` already contains the right instruction; users just needed a visible cue

## Test plan

- [ ] Run `/compact` in a session with an open PR in `open-prs.jsonl`
- [ ] Confirm new stderr line appears alongside the output block
- [ ] Type any message — Claude should immediately invoke `/review <url> --post-comment`
- [ ] `python3 -m py_compile claude/scripts/post-compact.py` passes (verified)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)