### PR TITLE
feat(review): add Step 2c documentation coverage check

### DIFF
--- a/claude/skills/review/SKILL.md
+++ b/claude/skills/review/SKILL.md
@@ -98,6 +98,57 @@ If the table exists (dev-env and any repo that adopts the pattern):
    > **Fix:** Per the Documentation Maintenance table in `CLAUDE.md`, update the relevant
    > section(s) of `README.md` and/or `docs/REFERENCE.md` in this PR.
 
+Proceed to Step 2c.
+
+---
+
+## Step 2c — Documentation Coverage Check
+
+Applies to both PR_URL mode and DIFF_MODE.
+
+For every file that was **added, deleted, or renamed** in the diff (structural changes),
+and for every file that was **significantly rewritten** (purpose or functionality changed,
+not a minor fix or content update), apply the following check:
+
+1. Identify the file's directory and all ancestor directories up to depth 3 from the
+   changed file (stop at repo root).
+2. For each ancestor level, check whether a `README.md` exists at that level.
+   - In PR_URL mode: `git show origin/<headRefName>:<dir>/README.md 2>/dev/null`
+   - In DIFF_MODE: infer from the diff whether a README is present at that level.
+3. Use judgment to determine whether this specific change warrants a documentation update
+   at any of those levels. Consider:
+   - **New file in a directory that has a README index** → the index likely needs a new entry.
+   - **Deleted or renamed file in a directory with a README** → the index reference may need removal or updating.
+   - **File rewritten to serve a different purpose** → the README description may be stale.
+   - **Minor bug fix, typo correction, or content-only update to an existing file** → no README change needed.
+   - **Cross-tree impact**: a skill, hook, or workflow change referenced in a parent README or
+     in a related doc outside the immediate directory tree → flag the relevant parent or sibling
+     doc even if it is not in the same directory as the changed file.
+4. For each directory level where a README **exists** and the change **warrants** an update
+   and the README **does not appear in the diff**: record a **blocking Documentation finding**.
+5. For each directory level where no README exists but one **would add navigational value**
+   (e.g., a directory now has several files with no index): record a **non-blocking
+   Documentation finding** suggesting creation.
+
+If no ancestor directories have READMEs and no cross-tree impact is identified, note
+"No README coverage gaps found." and proceed to Step 3.
+
+**Example findings:**
+
+> **[documentation]** `context/sentence_density.md` added without README update
+> `context/README.md` is an index of all files in this directory. Adding a new file here
+> without adding an entry leaves sessions that orient from `context/README.md` unaware of
+> the new file — the career-playbook#168 incident that prompted issue #219.
+> **Fix:** Add a `### \`sentence_density.md\`` entry to `context/README.md` describing
+> its purpose and when to load it.
+
+> **[documentation]** `claude/skills/new-skill/` added; top-level README not updated
+> `README.md` contains a Skills table that lists all available skills. Adding a skill
+> without updating the table leaves the skill undiscoverable to sessions that orient from
+> `README.md`.
+> **Fix:** Add a row for `new-skill` to the Skills table in `README.md` and the Skills
+> section of `docs/REFERENCE.md`.
+
 Proceed to Step 3.
 
 ---
@@ -177,10 +228,12 @@ Assign each finding to one of four buckets:
 - Reliability failures (unhandled errors in critical paths, missing retries where required)
 - Missing test coverage for a behavior change in a tested codebase
 - Documentation gaps from Step 2b (skill/hook/script/routine changed without updating README.md or docs/REFERENCE.md)
+- Documentation gaps from Step 2c (README exists at a relevant directory level and warrants an update, but was not changed in this PR)
 
-**Non-Blocking** (performance | maintainability):
+**Non-Blocking** (performance | maintainability | documentation):
 - Performance concerns that do not affect correctness
 - Code that works but will be hard to extend, test, or debug
+- Step 2c suggestion to create a README where none exists (not required, but advisable)
 
 **Questions for Author:**
 - Ambiguities where intent is genuinely unclear — frame as a question, not a criticism

--- a/claude/skills/review/SKILL.md
+++ b/claude/skills/review/SKILL.md
@@ -107,26 +107,33 @@ Proceed to Step 2c.
 Applies to both PR_URL mode and DIFF_MODE.
 
 For every file that was **added, deleted, or renamed** in the diff (structural changes),
-and for every file that was **significantly rewritten** (purpose or functionality changed,
-not a minor fix or content update), apply the following check:
+and for every file whose change reflects any of the **4 Ds** — a **decision made**, a
+**discovery surfaced**, a **dependency introduced** (or removed), or a **deviation from
+documented process** — apply the following check. (The 4 Ds match the dev-env stub-update
+criteria in `claude/CLAUDE.md`; minor bug fixes, typo corrections, and content-only updates
+to an existing file do not qualify.)
 
 1. Identify the file's directory and all ancestor directories up to depth 3 from the
-   changed file (stop at repo root).
-2. For each ancestor level, check whether a `README.md` exists at that level.
+   changed file (stop at repo root). When multiple files share an ancestor, deduplicate
+   the ancestor set before issuing `git show` calls — query each unique ancestor once.
+2. For each unique ancestor directory, check whether a `README.md` exists there.
    - In PR_URL mode: `git show origin/<headRefName>:<dir>/README.md 2>/dev/null`
-   - In DIFF_MODE: infer from the diff whether a README is present at that level.
+   - In DIFF_MODE: a pasted diff cannot reveal unchanged READMEs. Skip the blocking
+     branch entirely (step 4 below) — only the non-blocking suggestion branch (step 5)
+     applies. Note in the review output: "DIFF_MODE — README-staleness check skipped;
+     paste the relevant README contents or use PR_URL mode for full coverage."
 3. Use judgment to determine whether this specific change warrants a documentation update
    at any of those levels. Consider:
    - **New file in a directory that has a README index** → the index likely needs a new entry.
    - **Deleted or renamed file in a directory with a README** → the index reference may need removal or updating.
    - **File rewritten to serve a different purpose** → the README description may be stale.
-   - **Minor bug fix, typo correction, or content-only update to an existing file** → no README change needed.
    - **Cross-tree impact**: a skill, hook, or workflow change referenced in a parent README or
      in a related doc outside the immediate directory tree → flag the relevant parent or sibling
      doc even if it is not in the same directory as the changed file.
-4. For each directory level where a README **exists** and the change **warrants** an update
-   and the README **does not appear in the diff**: record a **blocking Documentation finding**.
-5. For each directory level where no README exists but one **would add navigational value**
+4. (PR_URL mode only.) For each ancestor where a README **exists** and the change
+   **warrants** an update and the README **does not appear in the diff**: record a
+   **blocking Documentation finding**.
+5. For each ancestor where no README exists but one **would add navigational value**
    (e.g., a directory now has several files with no index): record a **non-blocking
    Documentation finding** suggesting creation.
 
@@ -137,8 +144,8 @@ If no ancestor directories have READMEs and no cross-tree impact is identified, 
 
 > **[documentation]** `context/sentence_density.md` added without README update
 > `context/README.md` is an index of all files in this directory. Adding a new file here
-> without adding an entry leaves sessions that orient from `context/README.md` unaware of
-> the new file — the career-playbook#168 incident that prompted issue #219.
+> without an entry leaves sessions that orient from `context/README.md` unaware of the
+> new file.
 > **Fix:** Add a `### \`sentence_density.md\`` entry to `context/README.md` describing
 > its purpose and when to load it.
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -73,7 +73,12 @@ Finds 1–3 primary sources for an engineering decision or topic. Emits footnote
 /review <PR-URL | --diff> [--no-style] [--author junior|mid|senior] [--focus security|correctness|perf] [--no-comment]
 ```
 
-Reviews a PR or pasted diff for correctness, security, reliability, and maintainability. Also runs a documentation reconciliation check (Step 2b) — flags as a blocking finding if `claude/skills/**`, `claude/hooks/**`, `claude/scripts/**`, or `claude/routines/**` were changed without updating `README.md` or `docs/REFERENCE.md`. Produces a structured report with blocking findings, non-blocking findings, questions for the author, and optional style notes.
+Reviews a PR or pasted diff for correctness, security, reliability, and maintainability. Runs two documentation checks before the main analysis:
+
+- **Step 2b — Documentation Reconciliation:** flags as a blocking finding if `claude/skills/**`, `claude/hooks/**`, `claude/scripts/**`, or `claude/routines/**` were changed without updating `README.md` or `docs/REFERENCE.md` (applies to repos with a `Documentation Maintenance` table in their `CLAUDE.md`).
+- **Step 2c — Documentation Coverage:** for every file added, deleted, renamed, or significantly rewritten, walks up ancestor directories and uses LLM judgment to determine whether a README at any of those levels should have been updated. Flags as a blocking finding when an existing README was not touched; suggests creation as a non-blocking finding when a directory would benefit from an index it lacks.
+
+Produces a structured report with blocking findings, non-blocking findings, questions for the author, and optional style notes.
 
 **Flags:**
 - `--no-style` — omit style/nit findings

--- a/docs/adr/020-doc-coverage-in-review.md
+++ b/docs/adr/020-doc-coverage-in-review.md
@@ -1,0 +1,122 @@
+# ADR 020 — Documentation Coverage Check as LLM-Judged Step in /review
+
+- **Status:** Accepted
+- **Date:** 2026-05-11
+- **Related:** ADR 019 (Documentation Reconciliation Enforcement), [issue #219](https://github.com/brownm09/dev-env/issues/219)
+
+## Context
+
+`brownm09/career-playbook#168` added `context/sentence_density.md` — a load-bearing file
+referenced by the modular cover-letter workflow — without updating `context/README.md`
+(the directory index). The miss surfaced two weeks later via `brownm09/career-playbook#170`.
+A briefing regeneration in that window would have silently dropped sentence-density guidance.
+
+Issue #219 originally proposed a mechanical validator: "fail when a file under
+`career-playbook/context/` is added, renamed, or removed without a corresponding change
+to `context/README.md` in the same diff." During planning, the scope expanded:
+
+- The same risk applies to **every** directory in **every** repo that uses a README as an
+  index, not only `career-playbook/context/`.
+- "Warrants a README update" is **not** a path-level question. It depends on the semantic
+  significance of the change: a minor bug fix in an existing file does not warrant an index
+  update; a new file or a purpose change does. Cross-tree impacts (a skill change rippling
+  into a top-level README) cannot be detected by directory adjacency alone.
+- A mechanical script that flags every structural change as a missing README update would
+  produce false positives in directories where the README intentionally describes only a
+  subset of files, or where the index is implicit (folder name self-documents content).
+
+ADR 019 already established the three-layer enforcement model for documentation
+reconciliation: the `/review` skill (Opus judgment), an advisory hook at PR-create time, and
+a CLAUDE.md instruction. Step 2b of `/review` mechanically checks the dev-env-specific
+Documentation Maintenance table. The career-playbook gap is one rung more general than that
+table covers.
+
+## Decision
+
+Extend the `/review` skill with **Step 2c — Documentation Coverage Check**, a semantic
+LLM-judged step that runs after Step 2b and before the main correctness/security/reliability
+analysis. Step 2c:
+
+1. Identifies files in the diff that were added, deleted, renamed, or significantly rewritten.
+2. Walks ancestor directories up to depth 3 from each changed file.
+3. For each ancestor level that has a `README.md`, uses LLM judgment to decide whether the
+   change warrants a README update.
+4. Records a **blocking documentation finding** when a relevant README exists but is not
+   in the diff. Records a **non-blocking suggestion** when an ancestor directory has no
+   README and one would add navigational value.
+
+The check is repo-agnostic — no hardcoded paths, no per-repo configuration. It uses the
+same reasoning Mike applies in manual review: "does this change make the README stale?"
+
+No mechanical script (Python or bash) is added.
+
+## Rationale
+
+**Why semantic instead of mechanical:**
+
+The mechanical version would have to choose between two failure modes:
+
+- **Strict (every structural change in a directory with a README requires that README in the
+  diff):** produces false positives for directories where the README is not an exhaustive
+  index. Reviewers learn to ignore the warning, eroding the value of all blocking findings.
+- **Permissive (only flag a narrow set of known directories like `context/`):** requires
+  per-repo configuration, does not generalize to new directories, and offers no help when
+  a new directory is created.
+
+The LLM-judged version sidesteps both by reading the change and the README's purpose, then
+reasoning about staleness. The trade-off — needing Claude to run the check — is acceptable
+because `/review` already runs Claude on every PR.
+
+**Why a separate Step 2c rather than expanding Step 2b:**
+
+Step 2b is a path-matching mechanical check tied to a specific Documentation Maintenance
+table convention. It is fast and produces a deterministic finding. Folding semantic
+reasoning into Step 2b would blur the two modes — readers of `SKILL.md` could no longer
+tell at a glance which findings require LLM reasoning and which are mechanical.
+
+**Why no pre-push hook:**
+
+A pre-push hook cannot make semantic judgments. The mechanical version of the check would
+need to be permissive enough to avoid blocking legitimate pushes, which means it would not
+catch the case that prompted this ADR (a real file addition that needed a README update).
+The `/review` skill — run as part of the PR-open → review → merge sequence specified in
+ADR 019 — is the right enforcement point.
+
+**Why both blocking and non-blocking findings:**
+
+A missing update to an existing README is a regression — the index is wrong after this
+change. A missing README in a directory that does not yet have one is a suggestion — the
+maintainer may have a reason not to add one. The two cases warrant different severities.
+
+## Consequences
+
+- The `/review` skill now produces documentation coverage findings on every PR with
+  structural file changes. Reviewers see them as part of the standard blocking/non-blocking
+  output; no new section or flag is needed.
+- Repos that previously had silent documentation drift (career-playbook `context/`,
+  potentially others) will see findings on the next PR that exercises the pattern.
+- The check uses LLM tokens proportional to the changed-file count. For PRs touching only
+  one or two files, the cost is negligible (≤200 tokens of reasoning). For larger PRs the
+  check is bounded by the changed-file count, not the diff size.
+- Future repos do not need to opt in or add configuration. The check applies uniformly.
+- The career-playbook-specific validator originally proposed in issue #219 is **not built**;
+  this ADR documents the decision to solve the problem at a more general layer.
+
+## Alternatives considered
+
+- **Mechanical Python script in `claude/scripts/` invoked from `validate.sh` and a pre-push
+  hook.** Rejected because it cannot distinguish significant changes from minor edits, and
+  cannot detect cross-tree impacts. Would have produced either false positives (strict) or
+  false negatives (permissive).
+- **Per-repo configuration listing which directories require README updates.** Rejected
+  because it requires maintenance per repo and per new directory, and still cannot handle
+  cross-tree impacts.
+- **Expanding Step 2b to cover the general case.** Rejected because it would conflate
+  mechanical and semantic checks under one heading.
+
+## References
+
+- [Issue #219](https://github.com/brownm09/dev-env/issues/219) — original mechanical-validator proposal
+- [ADR 019](019-doc-reconciliation-enforcement.md) — three-layer documentation enforcement
+- [ADR 011](011-adr-warrant-check.md) — ADR-warrant check rationale
+- [career-playbook#170](https://github.com/brownm09/career-playbook/pull/170) — incident PR that surfaced the gap

--- a/docs/adr/020-doc-coverage-in-review.md
+++ b/docs/adr/020-doc-coverage-in-review.md
@@ -37,8 +37,12 @@ Extend the `/review` skill with **Step 2c — Documentation Coverage Check**, a 
 LLM-judged step that runs after Step 2b and before the main correctness/security/reliability
 analysis. Step 2c:
 
-1. Identifies files in the diff that were added, deleted, renamed, or significantly rewritten.
-2. Walks ancestor directories up to depth 3 from each changed file.
+1. Identifies files in the diff that were added, deleted, or renamed, plus files whose
+   change reflects any of the 4 Ds (decision made, discovery surfaced, dependency
+   introduced/removed, deviation from documented process — the same criteria the
+   stub-update rules in `claude/CLAUDE.md` use to define a substantive session event).
+2. Walks ancestor directories up to depth 3 from each changed file, deduplicating shared
+   ancestors so each unique directory is queried once.
 3. For each ancestor level that has a `README.md`, uses LLM judgment to decide whether the
    change warrants a README update.
 4. Records a **blocking documentation finding** when a relevant README exists but is not
@@ -95,9 +99,13 @@ maintainer may have a reason not to add one. The two cases warrant different sev
   output; no new section or flag is needed.
 - Repos that previously had silent documentation drift (career-playbook `context/`,
   potentially others) will see findings on the next PR that exercises the pattern.
-- The check uses LLM tokens proportional to the changed-file count. For PRs touching only
-  one or two files, the cost is negligible (≤200 tokens of reasoning). For larger PRs the
-  check is bounded by the changed-file count, not the diff size.
+- The check uses LLM tokens proportional to the unique-ancestor count, not the changed-file
+  count. For PRs touching only one or two files, the cost is negligible (≤200 tokens of
+  reasoning). For larger PRs the check is bounded by the number of distinct ancestor
+  directories, not the diff size.
+- DIFF_MODE (pasted diff) cannot reveal unchanged READMEs, so the blocking-finding branch
+  is skipped in that mode; only README-creation suggestions (non-blocking) apply. For full
+  coverage, run `/review` against a PR URL.
 - Future repos do not need to opt in or add configuration. The check applies uniformly.
 - The career-playbook-specific validator originally proposed in issue #219 is **not built**;
   this ADR documents the decision to solve the problem at a more general layer.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -24,3 +24,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [017](017-journal-compose-today-guard.md) | Journal-Compose Today-Date Guard (All Paths; `--force` Opt-Out) | 2026-05-10 | Accepted | journal, composition, skill, today-guard, branch-detection, pre-push |
 | [018](018-reconcile-open-prs-hook.md) | Auto-Reconcile open-prs.jsonl Against GitHub State | 2026-05-10 | Accepted | hooks, open-prs, UserPromptSubmit, github, token-efficiency |
 | [019](019-doc-reconciliation-enforcement.md) | Documentation Reconciliation Enforcement | 2026-05-10 | Accepted | documentation, skills, hooks, workflow, review, checkpoints |
+| [020](020-doc-coverage-in-review.md) | Documentation Coverage Check as LLM-Judged Step in /review | 2026-05-11 | Accepted | documentation, review, skill, semantic, readme, llm-judgment |


### PR DESCRIPTION
## Summary
- Adds **Step 2c — Documentation Coverage Check** to the `/review` skill: LLM-judged check that fires when files are added, deleted, renamed, or significantly rewritten, walks ancestor directories up to depth 3, and flags missing README updates.
- Classifies a missing update to an existing README as **blocking**; a missing README in a directory that would benefit from one as **non-blocking suggestion**.
- Rationale recorded in [ADR 020](docs/adr/020-doc-coverage-in-review.md). Replaces the career-playbook-specific mechanical validator originally proposed in the issue with a repo-agnostic semantic check.

## Why this design (instead of the mechanical script in the issue)
A path-only script must choose between (a) flagging every structural change in a directory with a README (false positives) or (b) hardcoding known index directories per repo (does not generalize, requires maintenance). LLM judgment sidesteps both. Full discussion in ADR 020 § Rationale.

## Files
- `claude/skills/review/SKILL.md` — new Step 2c; Step 6 blocking/non-blocking buckets updated to acknowledge Step 2c findings.
- `docs/REFERENCE.md` — `/review` description rewritten to describe both Step 2b and Step 2c.
- `docs/adr/020-doc-coverage-in-review.md` — new ADR.
- `docs/adr/INDEX.md` — ADR 020 row added.

## Test plan
- [x] `python3 -m py_compile claude/scripts/*.py` — passes (no Python files changed).
- [ ] After merge, run `/review <next-PR>` on a PR that adds a new file to a directory with a README; confirm the review surfaces a blocking documentation finding.
- [ ] Run `/review` on a content-only edit PR; confirm no spurious documentation findings.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)