### PR TITLE
feat(hooks): auto-write journal stub on git push to open PR branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ All hooks are advisory — none block tool execution.
 | UserPromptSubmit | `reconcile-open-prs.py` | Removes stale entries from `open-prs.jsonl` whose PRs are now merged/closed; emits surviving open PRs as session context |
 | PreToolUse (Bash) | `pre-commit-branch-check.py` | Emits current branch as a checkpoint before `git commit` |
 | PreToolUse (Bash) | `pre-pr-create-check.py` | Emits test-verification checklist and documentation-gap warning before `gh pr create` |
-| PostToolUse (Bash) | `pr-merge-reminder.py` | Reminds to write a journal stub after `gh pr create` or `gh pr merge` |
+| PostToolUse (Bash) | `pr-merge-reminder.py` | Reminds to write a journal stub after `gh pr create`, `gh pr merge`, or `git push` (when the pushed branch has an open PR) |
 | PostToolUse (Bash) | `post-tool-use.py` | Auto-adds issues/PRs to configured GitHub Project |
 | PostToolUse (Bash) | `post-pr-merge-pull.py` | Fast-forwards local `main` after `gh pr merge` |
 | PostToolUse (Bash) | `post-pr-merge-project.py` | Auto-moves linked issue to Done on configured GitHub Project after `gh pr merge` |

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -520,9 +520,9 @@ Subsequent stubs begin directly at `<!-- session: <slug> -->`.
   - PR opened — follow the Stub file workflow immediately after `gh pr create`. If no further work is planned (e.g., waiting on CI or human review), stop after writing the stub.
   - PR merged (including auto-merge) — write or update a stub for the merge session (see Git Workflow → Write a stub on PR merge), then stop.
   - PR closed without merging — stub was already written at PR creation; stopping is optional (see Git Workflow → PR closed without merging)
+  - PR updated (push to a branch with an open PR) — when the hook reminder fires after `git push`, write a **new** stub for this push session immediately. The original PR-creation stub remains unchanged; the push stub documents what changed in this session (review findings addressed, approach decisions, what was pushed).
 - The following do **not** auto-create a stub — they are not session boundaries:
   - Review-only sessions (`/review <PR-URL>`)
-  - Pushing commits to an existing PR (e.g., addressing review findings) — stub was written when the PR was first opened
 
 - Add to the current session's stub when a strategic decision is made mid-session
 - Compose and publish the daily document at end of last session of the day

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -520,7 +520,7 @@ Subsequent stubs begin directly at `<!-- session: <slug> -->`.
   - PR opened — follow the Stub file workflow immediately after `gh pr create`. If no further work is planned (e.g., waiting on CI or human review), stop after writing the stub.
   - PR merged (including auto-merge) — write or update a stub for the merge session (see Git Workflow → Write a stub on PR merge), then stop.
   - PR closed without merging — stub was already written at PR creation; stopping is optional (see Git Workflow → PR closed without merging)
-  - PR updated (push to a branch with an open PR) — when the hook reminder fires after `git push`, write a **new** stub for this push session immediately. The original PR-creation stub remains unchanged; the push stub documents what changed in this session (review findings addressed, approach decisions, what was pushed).
+  - PR updated (push to a branch with an open PR) — when the hook reminder fires after `git push`, update the engineering journal immediately: if a stub already exists for the current session, update it in place; otherwise create a new stub. Document what changed in this session (review findings addressed, approach decisions, what was pushed).
 - The following do **not** auto-create a stub — they are not session boundaries:
   - Review-only sessions (`/review <PR-URL>`)
 

--- a/claude/scripts/pr-merge-reminder.py
+++ b/claude/scripts/pr-merge-reminder.py
@@ -202,6 +202,10 @@ def _open_pr_for_cwd(cwd: str) -> dict | None:
     Returns a dict with keys ``number``, ``url``, and ``title``.
     Returns None when *cwd* is the engineering-journal repo (handled by
     stub-push-archive-reminder.py) or when no open PR exists.
+
+    Note: uses ``git branch --show-current`` (the checked-out branch), not the
+    push refspec.  Correct for the common case of ``git push`` with no explicit
+    refspec; may miss or mismatch on ``git push origin other:target`` patterns.
     """
     if _EJ_REPO_FRAGMENT in cwd.replace("\\", "/"):
         return None
@@ -218,6 +222,8 @@ def _open_pr_for_cwd(cwd: str) -> dict | None:
              "--json", "number,url,title", "--state", "open", "--limit", "1"],
             capture_output=True, text=True, timeout=10, cwd=cwd,
         )
+        if pr_result.returncode != 0:
+            return None
         prs = json.loads(pr_result.stdout or "[]")
         return prs[0] if prs else None
     except Exception:

--- a/claude/scripts/pr-merge-reminder.py
+++ b/claude/scripts/pr-merge-reminder.py
@@ -288,16 +288,18 @@ def main() -> None:
         if pr:
             messages.append(
                 f"[journal-reminder] git push detected for PR #{pr['number']} — "
-                f"write a journal stub NOW:\n"
+                f"update the engineering journal NOW:\n"
                 f"  PR: {pr['url']} — {pr['title']}\n"
                 f"  cwd: {cwd}\n"
-                "  Write a NEW stub for this push session (the original PR-creation stub\n"
-                "  remains unchanged). Document what changed and why.\n"
+                "  Check whether a stub already exists for this session:\n"
+                "  - If YES: update it in place (append new content to the session block).\n"
+                "  - If NO: create a new stub for this push session.\n"
+                "  Document what changed and why (review findings addressed,\n"
+                "  approach decisions, what was pushed).\n"
                 "  1. Identify the project journal path from cwd.\n"
                 "  2. Check out the draft branch in engineering-journal.\n"
-                "  3. Write a <!-- session: <slug> --> block (review findings addressed,\n"
-                "     approach decisions, what was pushed).\n"
-                "  4. Add token comment and <!-- next-session-context --> paragraph.\n"
+                "  3. Find today's stub for this session, or create one if absent.\n"
+                "  4. Add/update token comment and <!-- next-session-context --> paragraph.\n"
                 '  5. git commit -m "draft: YYYY-MM-DD session N" && git push'
             )
 

--- a/claude/scripts/pr-merge-reminder.py
+++ b/claude/scripts/pr-merge-reminder.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Claude Code PostToolUse hook — detects 'gh pr create' or 'gh pr merge' in
-Bash commands and emits journal-update reminders via stderr (exit code 2) so
-Claude sees them.
+"""Claude Code PostToolUse hook — detects 'gh pr create', 'gh pr merge', or
+'git push' (when the pushed branch has an open PR) in Bash commands and emits
+journal-update reminders via stderr (exit code 2) so Claude sees them.
 
 Matches only actual CLI invocations, not the string appearing inside commit
 messages, heredocs, or other quoted arguments.
@@ -16,17 +16,25 @@ Stdin JSON shape (PostToolUse):
     "cwd": "..."
   }
 
-Exit 0  — neither gh pr create nor gh pr merge; no action
-Exit 2  — gh pr create and/or gh pr merge detected; reminder(s) emitted via stderr
+Exit 0  — no relevant command detected; no action
+Exit 2  — gh pr create, gh pr merge, or git push (open PR) detected;
+          reminder(s) emitted via stderr
 """
 import json
 import re
+import subprocess
 import sys
 from collections.abc import Callable
 
-# Matches the start of a statement token against `gh pr merge` or `gh pr create`.
+# Matches the start of a statement token against `gh pr merge`, `gh pr create`,
+# or `git push`.
 _MERGE_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+merge\b")
 _CREATE_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+create\b")
+_PUSH_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?git\s+push\b")
+
+# Path fragment that identifies the engineering-journal repo — push events
+# there are handled by stub-push-archive-reminder.py, not this script.
+_EJ_REPO_FRAGMENT = "engineering-journal"
 
 
 def _check_merge_stmt(token: str) -> bool:
@@ -35,6 +43,10 @@ def _check_merge_stmt(token: str) -> bool:
 
 def _check_create_stmt(token: str) -> bool:
     return bool(_CREATE_RE.match(token.lstrip()))
+
+
+def _check_push_stmt(token: str) -> bool:
+    return bool(_PUSH_RE.match(token.lstrip()))
 
 
 def _find_heredoc_end(cmd: str, start: int) -> int:
@@ -179,6 +191,39 @@ def is_pr_create_command(command: str) -> bool:
     return _scan_top_level(command, _check_create_stmt)
 
 
+def is_git_push_command(command: str) -> bool:
+    """Return True only when *command* contains a top-level `git push`."""
+    return _scan_top_level(command, _check_push_stmt)
+
+
+def _open_pr_for_cwd(cwd: str) -> dict | None:
+    """Return the first open PR for the current branch in *cwd*, or None.
+
+    Returns a dict with keys ``number``, ``url``, and ``title``.
+    Returns None when *cwd* is the engineering-journal repo (handled by
+    stub-push-archive-reminder.py) or when no open PR exists.
+    """
+    if _EJ_REPO_FRAGMENT in cwd.replace("\\", "/"):
+        return None
+    try:
+        branch_result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True, text=True, timeout=5, cwd=cwd,
+        )
+        branch = branch_result.stdout.strip()
+        if not branch:
+            return None
+        pr_result = subprocess.run(
+            ["gh", "pr", "list", "--head", branch,
+             "--json", "number,url,title", "--state", "open", "--limit", "1"],
+            capture_output=True, text=True, timeout=10, cwd=cwd,
+        )
+        prs = json.loads(pr_result.stdout or "[]")
+        return prs[0] if prs else None
+    except Exception:
+        return None
+
+
 def main() -> None:
     raw = sys.stdin.read().strip()
     if not raw:
@@ -201,8 +246,9 @@ def main() -> None:
 
     is_create = is_pr_create_command(command)
     is_merge = is_pr_merge_command(command)
+    is_push = is_git_push_command(command)
 
-    if not (is_create or is_merge):
+    if not (is_create or is_merge or is_push):
         sys.exit(0)
 
     messages = []
@@ -230,6 +276,27 @@ def main() -> None:
             "  4. Add token comment and <!-- next-session-context --> paragraph.\n"
             '  5. git commit -m "draft: YYYY-MM-DD session N" && git push'
         )
+
+    if is_push and not (is_create or is_merge):
+        pr = _open_pr_for_cwd(cwd)
+        if pr:
+            messages.append(
+                f"[journal-reminder] git push detected for PR #{pr['number']} — "
+                f"write a journal stub NOW:\n"
+                f"  PR: {pr['url']} — {pr['title']}\n"
+                f"  cwd: {cwd}\n"
+                "  Write a NEW stub for this push session (the original PR-creation stub\n"
+                "  remains unchanged). Document what changed and why.\n"
+                "  1. Identify the project journal path from cwd.\n"
+                "  2. Check out the draft branch in engineering-journal.\n"
+                "  3. Write a <!-- session: <slug> --> block (review findings addressed,\n"
+                "     approach decisions, what was pushed).\n"
+                "  4. Add token comment and <!-- next-session-context --> paragraph.\n"
+                '  5. git commit -m "draft: YYYY-MM-DD session N" && git push'
+            )
+
+    if not messages:
+        sys.exit(0)
 
     print("\n\n".join(messages), file=sys.stderr)
     sys.exit(2)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -160,7 +160,7 @@ Fires after each Bash tool call completes. Matched with `"matcher": "Bash"`.
 
 | Script | Trigger condition | What it does |
 |--------|------------------|-------------|
-| `pr-merge-reminder.py` | Command contains `gh pr create` or `gh pr merge` | Exits 2 with a `systemMessage` reminding Claude to write a journal stub. |
+| `pr-merge-reminder.py` | Command contains `gh pr create`, `gh pr merge`, or `git push` (when the pushed branch has an open PR) | Exits 2 with a `systemMessage` reminding Claude to write a journal stub. For `git push`, runs `git branch --show-current` and `gh pr list --head <branch>` as subprocesses to confirm an open PR exists before emitting the reminder. Skips `engineering-journal` pushes (handled by `stub-push-archive-reminder.py`). |
 | `post-tool-use.py` | Command contains `gh issue create` or `gh pr create` | Auto-adds the created item to the configured GitHub Project. Opt-in via `"github_project_id"` in `.claude/hook-config.json`. |
 | `post-pr-merge-pull.py` | Command contains `gh pr merge` | Fast-forwards the local `main` branch via `git fetch origin main:main` so the local clone stays current after a merge. |
 | `post-pr-merge-project.py` | Command contains `gh pr merge` | Auto-moves the linked issue (`Closes/Fixes/Resolves #N` in PR body) to Done on the configured GitHub Project. Opt-in via `status_field_id` and `done_option_id` in `hook-config.json`. [ADR-014](adr/014-auto-move-project-item-done-on-merge.md) |

--- a/docs/adr/021-auto-stub-on-pr-push.md
+++ b/docs/adr/021-auto-stub-on-pr-push.md
@@ -61,6 +61,14 @@ existing PR") is removed.
   add latency to pushes on branches without an open PR. The `except Exception: return None`
   guard ensures the hook fails silently if either call errors (no valid cwd, auth issue, etc.).
 - Branches with no open PR produce no reminder and no latency beyond the two subprocess calls.
+- `_PUSH_RE` matches `git push --delete origin <branch>` (remote branch deletion). If the
+  currently checked-out branch has an open PR, this would emit a spurious reminder. In
+  practice Claude uses `gh pr merge --delete-branch` rather than `git push --delete`, so
+  this case does not arise in the normal workflow. Accepted as a known edge case.
+- `_open_pr_for_cwd` uses `git branch --show-current` (the checked-out branch), not the
+  push refspec. Pushes with an explicit `other:target` refspec would look up the wrong
+  branch. The normal workflow always pushes the currently checked-out branch, so this is
+  not a practical concern.
 
 ---
 

--- a/docs/adr/021-auto-stub-on-pr-push.md
+++ b/docs/adr/021-auto-stub-on-pr-push.md
@@ -1,0 +1,76 @@
+# ADR-021 — Auto-Write Journal Stub on git push to Open PR Branch
+
+**Date:** 2026-05-11
+**Status:** Accepted
+**Tags:** journal, stubs, hooks, post-tool-use, git-push, automation
+
+---
+
+## Context
+
+The engineering journal auto-writes stubs at two session boundaries: PR creation
+(`gh pr create`) and PR merge (`gh pr merge`). The `pr-merge-reminder.py` PostToolUse
+hook detects those commands and emits a reminder so Claude writes the stub without being
+asked by the user.
+
+Push events to an existing PR branch — the most common mid-review activity (addressing
+review findings, follow-up fixes) — were explicitly excluded from auto-stub. The rationale
+at the time was that "the stub was written when the PR was first opened." In practice this
+left a gap: iterative push sessions produced no journal record, making the review cycle
+invisible in the engineering journal unless the user remembered to request one manually.
+
+---
+
+## Decision
+
+Extend `pr-merge-reminder.py` to detect `git push` commands and, when the pushed branch
+has an open PR, emit a journal-update reminder with the PR number, URL, and title.
+
+**Detection approach:**
+
+1. `_PUSH_RE` regex identifies top-level `git push` statements in the command string using
+   the existing `_scan_top_level` shell parser (same mechanism as `_MERGE_RE` / `_CREATE_RE`).
+2. If the command is a push (and not already a `gh pr create` or `gh pr merge`), the hook
+   calls `_open_pr_for_cwd(cwd)`, which:
+   - Returns `None` immediately if `cwd` contains `"engineering-journal"` (those pushes are
+     handled by `stub-push-archive-reminder.py`).
+   - Runs `git branch --show-current` in `cwd` to get the active branch.
+   - Runs `gh pr list --head <branch> --json number,url,title --state open --limit 1`.
+   - Returns the first result, or `None` if no open PR exists.
+3. If a PR is found, the hook emits a reminder (exit 2) with step-by-step stub instructions,
+   instructing Claude to write a **new** stub for the push session.
+
+**CLAUDE.md update:** "PR updated (push to a branch with an open PR)" is added to the
+auto-create-stub trigger list, and the former exclusion bullet ("Pushing commits to an
+existing PR") is removed.
+
+---
+
+## Consequences
+
+**Positive:**
+- Every push to a PR branch now yields a stub, closing the main gap in journal coverage.
+- The push stub captures review findings addressed, approach decisions, and what changed —
+  context that is lost if the session ends before a merge.
+- Consistent with the existing pattern: the hook detects the event; CLAUDE.md governs the
+  automatic behavior; no user prompt required.
+
+**Trade-off:**
+- Every successful `git push` in a non-engineering-journal repo now triggers two subprocess
+  calls (`git branch --show-current` + `gh pr list`). Both are fast (~100 ms combined) but
+  add latency to pushes on branches without an open PR. The `except Exception: return None`
+  guard ensures the hook fails silently if either call errors (no valid cwd, auth issue, etc.).
+- Branches with no open PR produce no reminder and no latency beyond the two subprocess calls.
+
+---
+
+## Alternatives considered
+
+**Reminder only, no subprocess lookup:** Emit the reminder on every `git push` and let
+Claude check for open PRs. Rejected — too noisy on pushes to branches without a PR (e.g.,
+pushing the draft journal branch itself, though that is separately filtered by the
+engineering-journal path check).
+
+**Read `open-prs.jsonl` instead of calling `gh`:** The in-repo tracking file lists open
+PRs. Rejected — `open-prs.jsonl` only covers PRs Claude opened in a tracked session; it
+would miss PRs opened in other sessions or by other tools.

--- a/docs/adr/021-auto-stub-on-pr-push.md
+++ b/docs/adr/021-auto-stub-on-pr-push.md
@@ -38,11 +38,12 @@ has an open PR, emit a journal-update reminder with the PR number, URL, and titl
    - Runs `gh pr list --head <branch> --json number,url,title --state open --limit 1`.
    - Returns the first result, or `None` if no open PR exists.
 3. If a PR is found, the hook emits a reminder (exit 2) with step-by-step stub instructions,
-   instructing Claude to write a **new** stub for the push session.
+   instructing Claude to check whether a stub already exists for the current session —
+   update it in place if yes, create a new stub if no.
 
 **CLAUDE.md update:** "PR updated (push to a branch with an open PR)" is added to the
-auto-create-stub trigger list, and the former exclusion bullet ("Pushing commits to an
-existing PR") is removed.
+Update triggers section with check-first-update-or-create semantics. The former exclusion
+bullet ("Pushing commits to an existing PR") is removed.
 
 ---
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -25,3 +25,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [018](018-reconcile-open-prs-hook.md) | Auto-Reconcile open-prs.jsonl Against GitHub State | 2026-05-10 | Accepted | hooks, open-prs, UserPromptSubmit, github, token-efficiency |
 | [019](019-doc-reconciliation-enforcement.md) | Documentation Reconciliation Enforcement | 2026-05-10 | Accepted | documentation, skills, hooks, workflow, review, checkpoints |
 | [020](020-doc-coverage-in-review.md) | Documentation Coverage Check as LLM-Judged Step in /review | 2026-05-11 | Accepted | documentation, review, skill, semantic, readme, llm-judgment |
+| [021](021-auto-stub-on-pr-push.md) | Auto-Write Journal Stub on git push to Open PR Branch | 2026-05-11 | Accepted | journal, stubs, hooks, post-tool-use, git-push, automation |


### PR DESCRIPTION
## Summary

- Extends `pr-merge-reminder.py` to detect `git push` and, when the pushed branch has an open PR, emit a journal-stub reminder (exit 2) with PR details
- Updates `CLAUDE.md` to add "PR updated (push to open PR branch)" as a first-class auto-stub trigger alongside PR create and PR merge
- Updates `README.md` and `docs/REFERENCE.md` to reflect the new trigger
- Adds ADR-021 documenting the decision and trade-offs

## Motivation

Push sessions — the most common mid-review activity — previously produced no journal record unless the user explicitly requested one. This closes the main gap in journal coverage for the review cycle.

## How it works

After each successful `git push`, the hook runs two subprocess calls in the cwd:
1. `git branch --show-current` → get active branch
2. `gh pr list --head <branch> --state open --limit 1` → look up open PR

If a PR is found, it emits a reminder with the PR number, URL, and title. Engineering-journal pushes are skipped (handled by `stub-push-archive-reminder.py`). Branches without an open PR produce no reminder.

## Testing

- `python3 -m py_compile claude/scripts/*.py` — all scripts syntax-clean ✓
- Smoke test: push to a branch with open PR → hook reminder fires with PR details ✓
- Smoke test: push to a branch with no PR → no reminder ✓
- Smoke test: push to `engineering-journal` → no reminder from this script ✓

Closes #221