### PR TITLE
[feat] Generalize prune-merged-worktrees.py for multi-repo use

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Autonomous scheduled agents in `claude/routines/`. No user interaction.
 | Schedule | Routine | Purpose |
 |---|---|---|
 | Daily midnight UTC | `daily-journal-compose` | Assembles stub files into canonical journal entries and opens PRs |
-| Sunday midnight UTC | `prune-stale-worktrees` | Removes merged `claude/*` worktrees |
+| Sunday midnight UTC | `prune-stale-worktrees` | Removes merged `claude/*` worktrees and stale `main` checkouts (dev-env) |
+| Sunday 1 AM local | `prune-stale-worktrees-ll` | Removes merged `claude/*` worktrees and stale `main` checkouts (lifting-logbook) |
 | Nightly 8:00 UTC (3 AM CDT) | `nightly-research` | Researches pending topics from the queue and writes structured markdown notes to `research-notes/` |
 
 ## Adding new configs

--- a/claude/routines/prune-stale-worktrees-ll/SKILL.md
+++ b/claude/routines/prune-stale-worktrees-ll/SKILL.md
@@ -9,6 +9,9 @@ Prune stale Claude session worktrees in the lifting-logbook repo. Run fully auto
 **Objective:** Remove all `claude/*` worktrees in lifting-logbook whose branches are fully merged into `origin/main` and have no uncommitted changes. Also remove any non-primary worktrees accidentally checked out on `main`. Report the pruned/skipped summary.
 
 **Steps:**
+0. Sync the dev-env working tree to `origin/main`:
+   - Invoke `sync-routine-worktree` with `REPO=C:/Users/brown/Git/dev-env`, `VERIFY_FILE=claude/scripts/prune-merged-worktrees.py`, `PREFIX=prune-stale-worktrees-ll`.
+   - If it returns **ABORT**, stop — the push notification has already been sent.
 1. Run the prune script targeting lifting-logbook:
    ```bash
    python C:/Users/brown/Git/dev-env/claude/scripts/prune-merged-worktrees.py \

--- a/claude/routines/prune-stale-worktrees-ll/SKILL.md
+++ b/claude/routines/prune-stale-worktrees-ll/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: prune-stale-worktrees-ll
+description: Remove Claude session worktrees in lifting-logbook whose branches have been merged into main.
+schedule: "0 1 * * 0"
+---
+
+Prune stale Claude session worktrees in the lifting-logbook repo. Run fully autonomously — do not ask the user anything.
+
+**Objective:** Remove all `claude/*` worktrees in lifting-logbook whose branches are fully merged into `origin/main` and have no uncommitted changes. Also remove any non-primary worktrees accidentally checked out on `main`. Report the pruned/skipped summary.
+
+**Steps:**
+1. Run the prune script targeting lifting-logbook:
+   ```bash
+   python C:/Users/brown/Git/dev-env/claude/scripts/prune-merged-worktrees.py \
+     --repo-path C:/Users/brown/Git/lifting-logbook
+   ```
+   The `--repo-path` flag tells the script which repo's worktrees to scan and which GitHub remote to query for squash-merged PRs.
+2. Report the output: how many worktrees were pruned, how many skipped, and the reason for each skip.
+3. If `git worktree list` in lifting-logbook shows any `claude/*` branches that the script skipped due to "not merged" status, list them and send a push notification summarizing the count and branch names so the user can investigate.
+
+**Constraints:**
+- Lifting-logbook repo: `C:/Users/brown/Git/lifting-logbook`
+- Script uses `git branch -d` (not `-D`) and `git worktree remove` (no `--force`) — safe by default
+- Never remove the current session's worktree or the primary worktree
+- Temp files (if needed) go to `C:/Users/brown/.claude/scratch/`

--- a/claude/routines/prune-stale-worktrees/SKILL.md
+++ b/claude/routines/prune-stale-worktrees/SKILL.md
@@ -9,6 +9,9 @@ Prune stale Claude session worktrees in the dev-env repo. Run fully autonomously
 **Objective:** Remove all `claude/*` worktrees whose branches are fully merged into `origin/main` and have no uncommitted changes. Report the pruned/skipped summary.
 
 **Steps:**
+0. Sync the dev-env working tree to `origin/main`:
+   - Invoke `sync-routine-worktree` with `REPO=C:/Users/brown/Git/dev-env`, `VERIFY_FILE=claude/scripts/prune-merged-worktrees.py`, `PREFIX=prune-stale-worktrees`.
+   - If it returns **ABORT**, stop — the push notification has already been sent.
 1. Run the prune script from the dev-env repo root:
    ```bash
    python C:/Users/brown/Git/dev-env/claude/scripts/prune-merged-worktrees.py

--- a/claude/scripts/prune-merged-worktrees.py
+++ b/claude/scripts/prune-merged-worktrees.py
@@ -33,8 +33,10 @@ BRANCH_PREFIX = "claude/"
 
 def _repo_from_args() -> str:
     for i, arg in enumerate(sys.argv[1:], 1):
-        if arg == "--repo-path" and i < len(sys.argv):
-            return str(Path(sys.argv[i + 1]).resolve())
+        if arg == "--repo-path":
+            if i + 1 < len(sys.argv):
+                return str(Path(sys.argv[i + 1]).resolve())
+            sys.exit("--repo-path requires an argument")
     return _DEFAULT_REPO
 
 
@@ -149,10 +151,6 @@ def main() -> None:
 
         if not branch.startswith(BRANCH_PREFIX):
             skipped.append((path, f"branch '{branch}' not in {BRANCH_PREFIX}* prefix"))
-            continue
-
-        if path == cwd:
-            skipped.append((path, "current worktree"))
             continue
 
         if not is_merged(branch, gh_repo):

--- a/claude/scripts/prune-merged-worktrees.py
+++ b/claude/scripts/prune-merged-worktrees.py
@@ -1,24 +1,59 @@
 #!/usr/bin/env python3
 """Remove claude/* worktrees whose branches have been merged into origin/main.
 
-Safe: skips the current worktree, dirty worktrees, and any non-claude/* branch.
+Also removes non-primary worktrees accidentally checked out on main (e.g. after a
+session runs 'git checkout main' as part of post-merge cleanup, locking main for
+other checkouts like VSCode's branch switcher).
+
+Safe: skips the current worktree, dirty worktrees, and any non-claude/* branch
+      (unless that branch is main, which is always safe to remove from a non-primary
+       worktree since main cannot have unmerged work by definition).
 Uses git branch -d (not -D) and git worktree remove (no --force).
 
+Auto-detects the GitHub repo slug from the remote URL, so the script works
+correctly in any repo — not just brownm09/dev-env.
+
 Usage:
-  python claude/scripts/prune-merged-worktrees.py [--dry-run]
+  python claude/scripts/prune-merged-worktrees.py [--dry-run] [--repo-path /path/to/repo]
+
+  --repo-path  Target a different repo's worktrees (defaults to the dev-env repo).
+               Example: --repo-path C:/Users/brown/Git/lifting-logbook
 """
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 
-REPO = str(Path(__file__).resolve().parents[2])
+# Default: the repo that owns this script (dev-env). Override with --repo-path.
+_DEFAULT_REPO = str(Path(__file__).resolve().parents[2])
 BRANCH_PREFIX = "claude/"
+
+
+def _repo_from_args() -> str:
+    for i, arg in enumerate(sys.argv[1:], 1):
+        if arg == "--repo-path" and i < len(sys.argv):
+            return str(Path(sys.argv[i + 1]).resolve())
+    return _DEFAULT_REPO
+
+
+REPO = _repo_from_args()
 
 
 def run(args: list[str], cwd: str = REPO, check: bool = False) -> subprocess.CompletedProcess:
     return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=30, check=check)
+
+
+def detect_gh_repo() -> str:
+    """Return 'owner/repo' derived from the origin remote URL of REPO."""
+    r = run(["git", "remote", "get-url", "origin"])
+    url = r.stdout.strip()
+    # Matches both https://github.com/owner/repo(.git) and git@github.com:owner/repo(.git)
+    m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1)
+    raise RuntimeError(f"Cannot parse GitHub repo from remote URL: {url!r}")
 
 
 def parse_worktrees(output: str) -> list[dict]:
@@ -39,13 +74,13 @@ def parse_worktrees(output: str) -> list[dict]:
     return worktrees
 
 
-def is_merged(branch: str) -> bool:
+def is_merged(branch: str, gh_repo: str) -> bool:
     # Regular merge: commit is an ancestor of origin/main
     r = run(["git", "merge-base", "--is-ancestor", branch, "origin/main"])
     if r.returncode == 0:
         return True
     # Squash merge: commit SHA diverges from main — ask GitHub instead
-    r = run(["gh", "pr", "list", "--repo", "brownm09/dev-env",
+    r = run(["gh", "pr", "list", "--repo", gh_repo,
              "--head", branch, "--state", "merged", "--json", "number", "--limit", "1"])
     if r.returncode == 0 and r.stdout.strip() not in ("", "[]"):
         return True
@@ -59,14 +94,18 @@ def is_dirty(path: str) -> bool:
     return bool(r.stdout.strip())
 
 
-def current_worktree_path() -> str:
-    return str(Path(os.getcwd()).resolve())
+def primary_worktree_path(worktrees: list[dict]) -> str:
+    """The primary worktree is always the first entry from 'git worktree list'."""
+    return str(Path(worktrees[0]["path"]).resolve()) if worktrees else REPO
 
 
 def main() -> None:
     dry_run = "--dry-run" in sys.argv
     if dry_run:
         print("[dry-run] no changes will be made")
+
+    gh_repo = detect_gh_repo()
+    print(f"Repo: {gh_repo}")
 
     # Fetch origin/main so merge checks are accurate
     print("Fetching origin/main…")
@@ -78,7 +117,8 @@ def main() -> None:
         sys.exit(1)
 
     worktrees = parse_worktrees(result.stdout)
-    cwd = current_worktree_path()
+    primary = primary_worktree_path(worktrees)
+    cwd = str(Path(os.getcwd()).resolve())
 
     pruned: list[str] = []
     skipped: list[tuple[str, str]] = []
@@ -86,6 +126,26 @@ def main() -> None:
     for wt in worktrees:
         branch = wt["branch"]
         path = str(Path(wt["path"]).resolve())
+
+        # Always skip the primary worktree and wherever this process is running
+        if path == primary or path == cwd:
+            skipped.append((path, "primary or current worktree"))
+            continue
+
+        # Non-primary worktrees checked out on main: always safe to remove — main
+        # cannot contain unmerged work, and the checkout just locks the branch name.
+        if branch == "main":
+            if dry_run:
+                pruned.append(path)
+                print(f"  [dry-run] would remove stale main checkout: {path}")
+                continue
+            r = run(["git", "worktree", "remove", path])
+            if r.returncode != 0:
+                skipped.append((path, f"worktree remove failed: {r.stderr.strip()}"))
+                continue
+            pruned.append(path)
+            print(f"  pruned (stale main): {path}")
+            continue
 
         if not branch.startswith(BRANCH_PREFIX):
             skipped.append((path, f"branch '{branch}' not in {BRANCH_PREFIX}* prefix"))
@@ -95,7 +155,7 @@ def main() -> None:
             skipped.append((path, "current worktree"))
             continue
 
-        if not is_merged(branch):
+        if not is_merged(branch, gh_repo):
             skipped.append((path, "not merged into origin/main"))
             continue
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "model": "claude-sonnet-4-6",
   "permissions": {
     "allow": [
       "Write(C:/Users/brown/.claude/scratch/**)",
@@ -24,6 +23,7 @@
       "Bash(gh issue view *)"
     ]
   },
+  "model": "claude-sonnet-4-6",
   "hooks": {
     "PreToolUse": [
       {
@@ -125,5 +125,6 @@
         ]
       }
     ]
-  }
+  },
+  "effortLevel": "medium"
 }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -254,7 +254,15 @@ Assembles all `YYYY-MM-DD_*.stub.md` files across all configured projects into t
 
 **Schedule:** `0 0 * * 0` (midnight UTC, every Sunday)
 
-Removes `claude/*` worktrees whose branches are fully merged into `origin/main`. Uses `git branch -d` and `git worktree remove` (no `--force`). Skips the current worktree, dirty worktrees, and any worktree not named `claude/*`. Sends a push notification listing any unmerged branches that were skipped.
+Targets the **dev-env** repo. Removes `claude/*` worktrees whose branches are fully merged into `origin/main`, and removes any non-primary worktree accidentally checked out on `main` (e.g., after a session runs `git checkout main` as part of post-merge cleanup). Uses `git branch -d` and `git worktree remove` (no `--force`). Skips the current worktree, dirty worktrees, and any worktree not named `claude/*` (except `main`). Sends a push notification listing any unmerged branches that were skipped.
+
+---
+
+### prune-stale-worktrees-ll
+
+**Schedule:** `0 1 * * 0` (1 AM local, every Sunday)
+
+Same behavior as `prune-stale-worktrees` but targets the **lifting-logbook** repo at `C:/Users/brown/Git/lifting-logbook`. Runs the shared `prune-merged-worktrees.py` script with `--repo-path C:/Users/brown/Git/lifting-logbook`; the script auto-detects the GitHub repo slug from the lifting-logbook remote URL.
 
 ---
 
@@ -284,7 +292,7 @@ On-demand scripts — not wired to any event. Run manually or from other scripts
 |--------|-----------|-------------|
 | `token-report.py` | `python3 token-report.py [--date YYYY-MM-DD] [--days N] [--project name] [--latest] [--show-subagents]` | Generates markdown and JSON token usage reports from `~/.claude/scratch/token-sessions.jsonl`. |
 | `backfill-tokens.py` | `python3 backfill-tokens.py` | Backfills token data for sessions predating the token-tracker hook. Idempotent — deduplicates on `session_id`. |
-| `prune-merged-worktrees.py` | `python3 prune-merged-worktrees.py` | Manual equivalent of the `prune-stale-worktrees` routine. |
+| `prune-merged-worktrees.py` | `python3 prune-merged-worktrees.py [--dry-run] [--repo-path /path/to/repo]` | Manual equivalent of the prune routines. Auto-detects the GitHub repo slug from the origin remote URL. `--repo-path` targets a different repo's worktrees; defaults to dev-env. Removes merged `claude/*` worktrees and stale `main` checkouts. |
 | `new-branch.sh` | `new-branch <name>` (shell function; source `~/.claude/scripts/new-branch.sh` in `.bashrc`) | Creates a branch always rooted at `origin/main`. Warns when HEAD has diverged from the merge base. |
 | `merge-stale-pr.sh` | `bash merge-stale-pr.sh <PR-URL>` | Remediates stale `engineering-journal` draft PRs: checks out the branch, warns on missing journal file, deletes orphaned drafts, rebases, and squash-merges with auto-conflict resolution. |
 | `get-project-item.sh` | `ITEM_ID=$(bash get-project-item.sh <issue-number> [project-number] [owner])` | Resolves a GitHub Project item node ID from an issue/PR number. Defaults to project 3, owner `brownm09`. Overridable via args or `PROJECT_NUMBER`/`PROJECT_OWNER` env vars. Requires `project` scope: `gh auth refresh -s project`. |


### PR DESCRIPTION
## Summary

- **Auto-detect GitHub repo** from `git remote get-url origin` (regex handles both HTTPS and SSH URLs) instead of hardcoding `brownm09/dev-env` — the squash-merge `gh pr list` check now targets the correct repo in any context
- **`--repo-path` flag** to target a different repo's worktrees without changing cwd
- **Main-worktree pruning**: non-primary worktrees accidentally checked out on `main` are now removed — this is the root cause of VSCode being unable to checkout main after sessions run `git checkout main` as part of post-merge cleanup
- **`prune-stale-worktrees-ll` routine**: new weekly scheduled task (Sundays 1 AM) that runs the script against `lifting-logbook`

## Test plan

- [x] `python prune-merged-worktrees.py --dry-run` from dev-env → shows `Repo: brownm09/dev-env` ✓
- [x] `python prune-merged-worktrees.py --dry-run --repo-path C:/Users/brown/Git/lifting-logbook` → shows `Repo: brownm09/lifting-logbook` ✓
- [x] `python3 -m py_compile claude/scripts/prune-merged-worktrees.py` → syntax OK ✓
- [x] Scheduled task registered and shows next run in 4 days

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)