### PR TITLE
[config] Run prune-stale-worktrees routines daily at 8am

### DIFF
--- a/claude/routines/prune-stale-worktrees-ll/SKILL.md
+++ b/claude/routines/prune-stale-worktrees-ll/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prune-stale-worktrees-ll
 description: Remove Claude session worktrees in lifting-logbook whose branches have been merged into main.
-schedule: "0 1 * * 0"
+schedule: "0 8 * * *"
 ---
 
 Prune stale Claude session worktrees in the lifting-logbook repo. Run fully autonomously — do not ask the user anything.

--- a/claude/routines/prune-stale-worktrees/SKILL.md
+++ b/claude/routines/prune-stale-worktrees/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prune-stale-worktrees
 description: Remove Claude session worktrees whose branches have been merged into main.
-schedule: "0 0 * * 0"
+schedule: "0 8 * * *"
 ---
 
 Prune stale Claude session worktrees in the dev-env repo. Run fully autonomously — do not ask the user anything.


### PR DESCRIPTION
Change both prune-stale-worktrees (dev-env) and prune-stale-worktrees-ll (lifting-logbook) routines from weekly Sunday-only runs (`0 0 * * 0` / `0 1 * * 0`) to daily at 8:00am local time (`0 8 * * *`).

## Testing
Config-only change — no code to run. Verified the SKILL.md frontmatter fields are correct.

Closes #227