### PR TITLE
feat(hooks): block Write/Edit/NotebookEdit to canonical repo root from worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Custom slash commands loaded from `claude/skills/`. Invoke with `/skill-name [ar
 ## Hooks
 
 Hook scripts run automatically via Claude Code's `hooks` configuration in `claude/settings.json`.
-All hooks are advisory — none block tool execution.
+Most hooks are advisory — they emit reminders but do not block tool execution. The exception is `pre-tool-use-worktree-path-check.py`, which blocks `Write`, `Edit`, and `NotebookEdit` calls that target the canonical repo root instead of the active worktree.
 
 | Event | Script | Purpose |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ All hooks are advisory — none block tool execution.
 | UserPromptSubmit | `reconcile-open-prs.py` | Removes stale entries from `open-prs.jsonl` whose PRs are now merged/closed; emits surviving open PRs as session context |
 | PreToolUse (Bash) | `pre-commit-branch-check.py` | Emits current branch as a checkpoint before `git commit` |
 | PreToolUse (Bash) | `pre-pr-create-check.py` | Emits test-verification checklist and documentation-gap warning before `gh pr create` |
+| PreToolUse (Write/Edit/NotebookEdit) | `pre-tool-use-worktree-path-check.py` | Blocks file writes whose absolute path targets the canonical repo root instead of the active worktree |
 | PostToolUse (Bash) | `pr-merge-reminder.py` | Reminds to write a journal stub after `gh pr create`, `gh pr merge`, or `git push` (when the pushed branch has an open PR) |
 | PostToolUse (Bash) | `post-tool-use.py` | Auto-adds issues/PRs to configured GitHub Project; exits 2 with `required_fields` reminders |
 | PostToolUse (Bash) | `post-pr-merge-pull.py` | Fast-forwards local `main` after `gh pr merge` |

--- a/claude/scripts/pre-tool-use-worktree-path-check.py
+++ b/claude/scripts/pre-tool-use-worktree-path-check.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook — blocks Write/Edit/NotebookEdit calls whose
+file_path targets the canonical repo root when the session is running inside a
+Claude-managed worktree.
+
+Problem: Absolute paths like `C:/Users/brown/Git/dev-env/foo.py` resolve to
+the main working tree, not the active worktree. Files land in the wrong place
+silently. This hook intercepts those calls before the write happens.
+
+Logic:
+  1. If cwd does not contain `/.claude/worktrees/<name>/`, pass immediately.
+  2. Extract canonical_root (repo root) and worktree_root from cwd.
+  3. Read file_path (Write/Edit) or notebook_path (NotebookEdit) from tool input.
+  4. If the path is absolute and starts with canonical_root but NOT with
+     worktree_root → exit 2 with a blocking message naming both paths and the
+     corrected worktree-relative path.
+  5. Otherwise pass (exit 0).
+
+Blocking: exits 2 with JSON {"reason": "..."} — the harness refuses the tool
+call and shows the reason to Claude so it can re-issue with the correct path.
+
+Stdin JSON shape (PreToolUse):
+  {
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Write" | "Edit" | "NotebookEdit",
+    "tool_input": {"file_path": "..." | "notebook_path": "..."},
+    "session_id": "...",
+    "cwd": "..."
+  }
+"""
+import json
+import os
+import re
+import sys
+
+# Matches `.claude/worktrees/<name>` anywhere in a path, capturing the repo
+# root (everything before `/.claude/`).
+_WORKTREE_RE = re.compile(
+    r"^(.+?)[/\\]\.claude[/\\]worktrees[/\\][^/\\]+",
+    re.IGNORECASE,
+)
+
+# Maps tool name → the field in tool_input that holds the file path.
+_PATH_FIELD = {
+    "Write": "file_path",
+    "Edit": "file_path",
+    "NotebookEdit": "notebook_path",
+}
+
+
+def _normalize(path: str) -> str:
+    return os.path.normcase(os.path.normpath(path))
+
+
+def main() -> None:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        sys.exit(0)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    if tool_name not in _PATH_FIELD:
+        sys.exit(0)
+
+    cwd = data.get("cwd", "")
+    m = _WORKTREE_RE.match(cwd)
+    if not m:
+        sys.exit(0)  # not in a worktree — nothing to enforce
+
+    canonical_root = m.group(1)   # e.g. C:/Users/brown/Git/dev-env
+    worktree_root = m.group(0)    # e.g. C:/Users/brown/Git/dev-env/.claude/worktrees/dreamy-feistel-e004d7
+
+    file_path = data.get("tool_input", {}).get(_PATH_FIELD[tool_name], "")
+    if not file_path or not os.path.isabs(file_path):
+        sys.exit(0)  # relative paths are fine
+
+    canonical_norm = _normalize(canonical_root)
+    worktree_norm = _normalize(worktree_root)
+    file_norm = _normalize(file_path)
+
+    # Must start with canonical root (with separator) to be in-scope.
+    if not (file_norm == canonical_norm or file_norm.startswith(canonical_norm + os.sep)):
+        sys.exit(0)
+
+    # Already inside the worktree — correct.
+    if file_norm == worktree_norm or file_norm.startswith(worktree_norm + os.sep):
+        sys.exit(0)
+
+    # Path targets the canonical root but not the active worktree — block.
+    try:
+        rel = os.path.relpath(file_path, canonical_root)
+        corrected = os.path.join(worktree_root, rel)
+    except ValueError:
+        corrected = "<could not compute — use worktree_root + relative path>"
+
+    reason = (
+        f"[worktree-path-guard] BLOCKED: {tool_name} targets the canonical repo root, "
+        f"not the active worktree. Files written here will land on the main working tree "
+        f"and will not be visible from the worktree.\n"
+        f"\n"
+        f"  Attempted : {file_path}\n"
+        f"  Worktree  : {worktree_root}\n"
+        f"  Corrected : {corrected}\n"
+        f"\n"
+        f"Re-issue with the corrected path."
+    )
+    print(json.dumps({"reason": reason}))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -38,6 +38,33 @@
             "command": "python3 C:/Users/brown/.claude/scripts/pre-pr-create-check.py"
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -144,14 +144,22 @@ Fires on every user prompt, before Claude processes it.
 
 ---
 
-### PreToolUse (Bash only)
+### PreToolUse
 
-Fires before each Bash tool call. Matched with `"matcher": "Bash"`.
+Fires before matched tool calls. Matcher values are set per entry in `settings.json`.
+
+#### Bash hooks
 
 | Script | Trigger condition | What it does |
 |--------|------------------|-------------|
 | `pre-commit-branch-check.py` | Command contains `git commit` | Emits the current branch name as a confirmation checkpoint before the commit runs. |
 | `pre-pr-create-check.py` | Command contains `gh pr create` | Emits a test-verification checklist and a documentation-gap warning (if `claude/skills/`, `claude/hooks/`, `claude/scripts/`, or `claude/routines/` were changed without updating `README.md` or `docs/REFERENCE.md`). Enforces the "test before PR" and doc-reconciliation rules from CLAUDE.md. |
+
+#### Write / Edit / NotebookEdit hooks
+
+| Script | Trigger condition | What it does |
+|--------|------------------|-------------|
+| `pre-tool-use-worktree-path-check.py` | Session `cwd` is inside a Claude-managed worktree and `file_path` (or `notebook_path`) is absolute and starts with the canonical repo root | **Blocks** the tool call (exit 2) with a message naming the attempted path, the active worktree root, and the corrected path. No-op when the session is not in a worktree or when the path already targets the worktree root. [ADR-024](adr/024-worktree-path-guard-hook.md) |
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -112,7 +112,7 @@ Scaffolds a new project's journal home (`sessions/<slug>/`) in engineering-journ
 
 ## Hooks
 
-All hooks are **advisory** — they emit `systemMessage` reminders via exit 2 but do not block tool execution. No hook exits with a non-zero code that prevents the matched tool from running.
+Most hooks are **advisory** — they emit `systemMessage` reminders but do not block tool execution. The exception is `pre-tool-use-worktree-path-check.py` (a `PreToolUse` hook), which exits 2 with a `{"reason": "..."}` payload to block `Write`, `Edit`, and `NotebookEdit` calls that target the canonical repo root instead of the active worktree.
 
 Configuration is in `claude/settings.json` (symlinked to `~/.claude/settings.json`).
 See [ADR-007](adr/007-hook-command-invocation.md) for why hooks call `python3` directly rather than via a `bash -c` wrapper.

--- a/docs/adr/024-worktree-path-guard-hook.md
+++ b/docs/adr/024-worktree-path-guard-hook.md
@@ -1,0 +1,72 @@
+# ADR-024: PreToolUse Hook to Block Canonical-Root Writes from Worktrees
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Tags:** hooks, worktrees, pre-tool-use, file-safety, write, edit
+
+---
+
+## Context
+
+Claude Code sessions launched inside a worktree (`<repo>/.claude/worktrees/<name>/`) receive `cwd` pointing at the worktree directory. However, when the model constructs an absolute `file_path` starting at the canonical repo root (e.g., `C:/Users/brown/Git/dev-env/docs/foo.md`), the Write/Edit/NotebookEdit tools resolve that path against the host filesystem — landing on the **main working tree**, not the worktree.
+
+The failure is silent: no error fires, the session continues, and the file appears on the wrong tree. Recovery is mechanical (`cp` into the worktree, `rm` orphans) but costs tokens and risks orphans being missed entirely.
+
+This failure was documented three times in career-playbook sessions (most recent: PR #275, stub `2026-05-22_140307.stub.md`). Tracked downstream at `brownm09/career-playbook#276`.
+
+The failure is harness-level — any repo using Claude-managed worktrees is vulnerable. A per-project CLAUDE.md heuristic only protects one repo and relies on the model reading and obeying it mid-session, which is precisely what failed three times.
+
+---
+
+## Decision
+
+Add a new `PreToolUse` hook (`pre-tool-use-worktree-path-check.py`) that fires on `Write`, `Edit`, and `NotebookEdit` tool calls.
+
+**Logic:**
+1. If `cwd` does not match the pattern `.../.claude/worktrees/<name>`, exit 0 (no-op).
+2. Extract `canonical_root` (everything before `/.claude/`) and `worktree_root` (`canonical_root + /.claude/worktrees/<name>`).
+3. Read `file_path` (Write/Edit) or `notebook_path` (NotebookEdit) from tool input.
+4. If the path is relative → exit 0.
+5. If the path starts with `canonical_root` but **not** `worktree_root` → exit 2 with a blocking `{"reason": "..."}` message naming the attempted path, the active worktree root, and the corrected path.
+6. Otherwise → exit 0.
+
+**Wired** in `claude/settings.json` under `hooks.PreToolUse` with three separate matcher entries (`Write`, `Edit`, `NotebookEdit`), each invoking the same script.
+
+---
+
+## Judgment calls
+
+### Block (exit 2), not rewrite
+
+Silently rewriting the path would be the same class of silent failure in the opposite direction: the model issues one path, something else executes. Blocking forces the model to re-issue with the correct path, which is the behavior we want to reinforce and that makes the fix visible in the session transcript.
+
+### Scope: Write / Edit / NotebookEdit only, not Bash
+
+Bash commands can write files via redirects, `cp`, `mv`, here-docs, and other mechanisms that are harder to parse reliably from a command string. The three file tools have a well-defined path field in structured tool input. Bash is deferred — extend only if a recurrence happens through that surface.
+
+### Three separate matcher entries, not one unmatched entry
+
+Using explicit matchers (`"matcher": "Write"`, etc.) limits the hook to only those three tool call types. An unmatched entry would fire on every PreToolUse event (including Bash, Glob, Grep, etc.), adding overhead for no benefit.
+
+### No path rewriting in the error message when `os.path.relpath` raises ValueError
+
+On Windows, `os.path.relpath` raises `ValueError` when source and target are on different drives. The hook falls back to a descriptive placeholder rather than crashing, preserving the blocking behavior.
+
+---
+
+## Consequences
+
+- **Write/Edit/NotebookEdit calls with wrong absolute paths now fail immediately** with a clear message instead of silently landing on the main working tree.
+- **No-op outside worktrees** — the hook exits 0 instantly when `cwd` does not match the worktree pattern.
+- **Coverage gap remains for Bash** — commands like `cp`, `tee`, or here-doc redirects that write to the canonical root are not intercepted. This is acceptable for now given the complexity; extend if recurrence is observed.
+- **ADR warranted** because the hook is a new file under `claude/scripts/`, is wired in `claude/settings.json`, and establishes a harness-level safety invariant applicable to all repos using Claude-managed worktrees.
+
+---
+
+## References
+
+- `claude/scripts/pre-tool-use-worktree-path-check.py` — implementation
+- `claude/settings.json` — hook wiring
+- `brownm09/career-playbook#276` — downstream symptom tracker
+- Engineering-journal `sessions/career-playbook/2026-05-22_140307.stub.md` — third occurrence
+- [Claude Code Hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks) — hook exit codes and JSON output format

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -28,3 +28,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [021](021-auto-stub-on-pr-push.md) | Auto-Write Journal Stub on git push to Open PR Branch | 2026-05-11 | Accepted | journal, stubs, hooks, post-tool-use, git-push, automation |
 | [022](022-test-coverage-gate-before-pr.md) | Test Coverage Gate: Require Declaration of New Testable Behavior Before PR | 2026-05-16 | Accepted | testing, coverage, workflow, git, pr, blocking-rule |
 | [023](023-generic-required-fields-issue-hook.md) | Generic `required_fields` Config for Issue/PR Project-Board Hook | 2026-05-16 | Accepted | hooks, github-project, post-tool-use, hook-config, automation, workflow |
+| [024](024-worktree-path-guard-hook.md) | PreToolUse Hook to Block Canonical-Root Writes from Worktrees | 2026-05-23 | Accepted | hooks, worktrees, pre-tool-use, file-safety, write, edit |


### PR DESCRIPTION
## Summary

- Adds `pre-tool-use-worktree-path-check.py` — a blocking `PreToolUse` hook that fires when a session running inside a Claude-managed worktree issues a `Write`, `Edit`, or `NotebookEdit` call whose absolute path targets the canonical repo root instead of the active worktree root.
- Wired in `settings.json` with three separate matchers (`Write`, `Edit`, `NotebookEdit`).
- Adds ADR-024 recording the block-not-rewrite and Bash-deferred judgment calls.
- Updates `README.md` and `docs/REFERENCE.md` hooks tables.

## What the hook does

1. If `cwd` does not match `.../.claude/worktrees/<name>`, exits 0 (no-op).
2. Extracts `canonical_root` and `worktree_root` from `cwd`.
3. Reads `file_path` (Write/Edit) or `notebook_path` (NotebookEdit).
4. If the path is absolute and starts with `canonical_root` but **not** `worktree_root` → exits 2, blocking the tool call with a message naming the attempted path, the worktree root, and the corrected path.
5. Otherwise exits 0.

## Testing

- `python3 -m py_compile claude/scripts/*.py` → **All OK**
- Manual acceptance: a session in a worktree that attempts `Write` to the canonical repo-root path will now receive a blocking error before the file is written, naming (a) the attempted path, (b) the current worktree root, (c) the corrected path.

Coverage gate: the hook has no automated test suite. This is consistent with all other hook scripts in `claude/scripts/` — they rely on the syntax check and manual verification. Tracked at #238.

Closes #238

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>