### PR TITLE
Repair incomplete worktree node_modules

### DIFF
--- a/claude/scripts/worktree-npm-install.py
+++ b/claude/scripts/worktree-npm-install.py
@@ -21,9 +21,70 @@ Stdin JSON shape (UserPromptSubmit):
 Exit 0 always — advisory only, never blocks.
 """
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+
+def emit(message: str) -> None:
+    print(json.dumps({"systemMessage": message}))
+    sys.stdout.flush()
+
+
+def main_checkout_for_worktree(cwd_path: Path) -> Path | None:
+    parts = cwd_path.parts
+    try:
+        claude_idx = parts.index(".claude")
+    except ValueError:
+        return None
+    if claude_idx + 1 >= len(parts) or parts[claude_idx + 1] != "worktrees":
+        return None
+    return Path(*parts[:claude_idx])
+
+
+def copy_if_missing(main_root: Path, cwd_path: Path, relative: str) -> bool:
+    source = main_root / "node_modules" / relative
+    target = cwd_path / "node_modules" / relative
+    if target.exists() or not source.exists():
+        return False
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    return True
+
+
+def repair_known_incomplete_worktree_modules(cwd_path: Path) -> list[str]:
+    """Repair known postinstall-skip artifacts from the main checkout when possible."""
+    if not (cwd_path / "node_modules").exists():
+        return []
+
+    main_root = main_checkout_for_worktree(cwd_path)
+    if not main_root or main_root == cwd_path or not (main_root / "node_modules").exists():
+        return []
+
+    repaired: list[str] = []
+    for relative in (
+        "std-env/dist/index.mjs",
+        "std-env/dist/index.d.mts",
+        "std-env/dist/index.d.ts",
+    ):
+        if copy_if_missing(main_root, cwd_path, relative):
+            repaired.append(relative)
+
+    turbo_relative = "@turbo/windows-64/bin/turbo.exe"
+    source_turbo = main_root / "node_modules" / turbo_relative
+    target_turbo = cwd_path / "node_modules" / turbo_relative
+    if source_turbo.exists() and target_turbo.exists():
+        try:
+            source_size = source_turbo.stat().st_size
+            target_size = target_turbo.stat().st_size
+        except OSError:
+            source_size = target_size = 0
+        if source_size > 1_000_000 and 0 < target_size < 1_000_000:
+            shutil.copy2(source_turbo, target_turbo)
+            repaired.append(turbo_relative)
+
+    return repaired
 
 
 def main() -> None:
@@ -54,7 +115,14 @@ def main() -> None:
     if not (cwd_path / "package.json").exists():
         sys.exit(0)
 
-    # node_modules presence is the sentinel — already installed, nothing to do.
+    repaired = repair_known_incomplete_worktree_modules(cwd_path)
+    if repaired:
+        emit(
+            "[worktree-npm-install] repaired incomplete worktree node_modules "
+            f"from the main checkout: {', '.join(repaired)}"
+        )
+
+    # node_modules presence is the sentinel — already installed, nothing else to do.
     if (cwd_path / "node_modules").exists():
         sys.exit(0)
 
@@ -64,13 +132,10 @@ def main() -> None:
 
     # Emit a progress message before starting — install can take 30–120 s on large
     # monorepos and the first prompt would otherwise appear to hang without feedback.
-    print(json.dumps({
-        "systemMessage": (
-            f"[worktree-npm-install] node_modules absent — running `{cmd}`. "
-            "This may take up to a few minutes on a large repo…"
-        )
-    }))
-    sys.stdout.flush()
+    emit(
+        f"[worktree-npm-install] node_modules absent — running `{cmd}`. "
+        "This may take up to a few minutes on a large repo…"
+    )
 
     try:
         result = subprocess.run(
@@ -85,21 +150,17 @@ def main() -> None:
         sys.exit(0)
 
     if result.returncode == 0:
-        print(json.dumps({
-            "systemMessage": (
-                f"[worktree-npm-install] `{cmd}` succeeded — "
-                "packages installed. node_modules is ready."
-            )
-        }))
+        emit(
+            f"[worktree-npm-install] `{cmd}` succeeded — "
+            "packages installed. node_modules is ready."
+        )
     else:
         stderr_excerpt = result.stderr.strip()[:300] if result.stderr else "(no stderr)"
-        print(json.dumps({
-            "systemMessage": (
-                f"[worktree-npm-install] `{cmd}` failed "
-                f"(exit {result.returncode}). "
-                f"Run it manually before testing.\n{stderr_excerpt}"
-            )
-        }))
+        emit(
+            f"[worktree-npm-install] `{cmd}` failed "
+            f"(exit {result.returncode}). "
+            f"Run it manually before testing.\n{stderr_excerpt}"
+        )
 
     sys.exit(0)
 


### PR DESCRIPTION
## Summary
- Repair known incomplete Claude worktree `node_modules` artifacts from the main checkout when `node_modules` already exists.
- Restore missing `std-env` ESM/type files and replace a tiny Windows Turbo stub with the real main-checkout binary when available.
- Keep the hook advisory and non-blocking; no credential or external state access.

## Verification
- `python -m py_compile claude\scripts\worktree-npm-install.py`
- Simulated `.claude/worktrees/<name>` repair case for missing `std-env` files and a 9 KB `@turbo/windows-64` stub.

Fixes #242