### PR TITLE
fix: prune routine syncs its own worktree instead of primary checkout

### DIFF
--- a/claude/routines/prune-stale-worktrees/SKILL.md
+++ b/claude/routines/prune-stale-worktrees/SKILL.md
@@ -9,12 +9,15 @@ Prune stale Claude session worktrees across all git repos under `C:/Users/brown/
 **Objective:** For every git repo directly under `C:/Users/brown/Git`, remove all `claude/*` worktrees whose branches are fully merged into `origin/main` and have no uncommitted changes. Also remove any non-primary worktrees accidentally checked out on `main`. Report the pruned/skipped summary per repo and a combined total.
 
 **Steps:**
-0. Sync the dev-env working tree to `origin/main`:
-   - Invoke `sync-routine-worktree` with `REPO=C:/Users/brown/Git/dev-env`, `VERIFY_FILE=claude/scripts/prune-merged-worktrees.py`, `PREFIX=prune-stale-worktrees`.
+0. Determine the current worktree's git root, then sync it to `origin/main`:
+   ```bash
+   WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+   ```
+   Invoke `sync-routine-worktree` with `REPO=$WORKTREE_ROOT`, `VERIFY_FILE=claude/scripts/prune-merged-worktrees.py`, `PREFIX=prune-stale-worktrees`.
    - If it returns **ABORT**, stop — the push notification has already been sent.
 1. Run the prune script in scan-dir mode:
    ```bash
-   python C:/Users/brown/Git/dev-env/claude/scripts/prune-merged-worktrees.py \
+   python "$WORKTREE_ROOT/claude/scripts/prune-merged-worktrees.py" \
      --scan-dir C:/Users/brown/Git
    ```
 2. Report the per-repo output: how many worktrees were pruned and skipped in each repo, and the reason for each skip.


### PR DESCRIPTION
## Summary

- `prune-stale-worktrees` was passing `REPO=C:/Users/brown/Git/dev-env` (the primary checkout) to `sync-routine-worktree`
- If the primary checkout was on a feature branch with uncommitted changes, `git rebase origin/main` failed and the routine aborted without scanning any worktrees
- Fix: use `$(git rev-parse --show-toplevel)` so the routine syncs its own `claude/*` worktree — the sync skill handles `claude/*` branches with `--hard reset`, which never fails on dirty state

Closes #247

## Test plan

- [ ] Docs-only change to SKILL.md — no Python scripts modified; `python3 -m py_compile claude/scripts/*.py` passes (confirmed)
- [ ] Next scheduled prune run will proceed even when primary dev-env checkout is on a dirty feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)