### PR TITLE
[config] Add suppression policy and ADR-026: no silent workarounds

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -262,8 +262,10 @@ If the error exists on the base branch, do **not** suppress it. File a GitHub is
 **Rule 3 — Pre-PR suppression check (required before `gh pr create`).**
 Run this from the repo root and review every match before opening a PR:
 ```bash
-git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|!\s*[;,)]|\?\? null)'
+git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
 ```
+The pattern covers end-of-expression assertions (`!;`, `!,`, `!)`) and chained access (`!.`, `![`). It does not catch every `!` — also scan added lines in the diff manually for any remaining `!` that could be a suppression.
+
 If the output is non-empty:
 - Each line must map to a Rule 1 justification note in the PR body, **or**
 - The suppression must be removed and replaced with a proper fix.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -68,6 +68,7 @@ If the project has no automated tests, the section must say so explicitly and de
 - **Create an issue before changing files.** When a user's question or request will result in file changes, create a GitHub issue first with `gh issue create` — describe the problem or goal, not the implementation. Do this before writing any code or editing any files. For a single-line change, ask the user whether an issue is warranted before creating one; anything longer than one line warrants an issue without prompting. Exception: engineering-journal draft branches (`draft/YYYY-MM-DD`) may omit an issue. Every PR must then reference the issue via a `Closes #N` line in the PR body.
 - **Test before PR.** Before running `gh pr create`, execute the project's test command defined in `## Testing` in the project CLAUDE.md. Tests must pass (or the failure must be explained and documented). Include what was tested and the outcome in the PR body. **If no `## Testing` section exists in the project CLAUDE.md, stop and ask the user to add one — do not open the PR until it is present.**
   - **Coverage gate.** Also ask whether the change introduces testable behavior not covered by existing tests. If yes, add tests before creating the PR, or explicitly document in the PR body why they are deferred (which tests, what tracks them, why deferral is acceptable). Enforced behaviorally by the author and by `/review` Step 2d (see [ADR-022](../docs/adr/022-test-coverage-gate-before-pr.md)).
+  - **Suppression check.** Also run the pre-PR suppression grep from `## Code Quality` — any new suppression without a PR-body justification blocks the PR.
 - **ADR-warrant check.** Evaluate whether the change warrants an architectural decision record at three explicit checkpoints: (1) immediately after a plan is approved (post-`ExitPlanMode`), or at the start of the first file edit for sessions without an explicit planning phase; (2) immediately after `gh pr create` returns; and (3) immediately before `gh pr merge`. A change warrants an ADR when any of the following hold: it changes a rule, hook, skill, or settings value documented in `claude/`; it introduces or restructures a directory under `claude/` (skills, hooks, scripts, routines); it establishes or changes a workflow rule that other CLAUDE.md files reference; or its rationale would be hard to recover from `git log` alone six months later. ADRs for global rules go in dev-env [`docs/adr/`](../docs/adr/INDEX.md); ADRs for project-specific decisions go in that project's `docs/adr/`. **If warranted and not yet written, write the ADR and update `INDEX.md` before merging — never merge a qualifying change without an ADR record.**
   - **Warrant check lookup:** Scan `docs/adr/INDEX.md` tags first — the Tags column covers every ADR's domain keywords. If no tag matches the change type, the warrant check requires no additional file reads. Only open individual ADR files when a tag match suggests a possible overlap or conflict.
   - **Proactive template (opt-in):** When checkpoint 1 fires and the change is clearly ADR-worthy, create the ADR template file on the branch immediately using the next available ADR number and the `NNN-kebab-case-title.md` naming convention, rather than waiting until checkpoint 3. Fill in context and the decision rationale as work proceeds; the ADR is 80% complete by the time `gh pr create` runs, with no extra end-of-session step. This approach is preferable for complex multi-file changes where the full rationale is known upfront. For exploratory work where the decision may not crystallize until checkpoint 2 or 3, write the ADR at whichever checkpoint it becomes clear.
@@ -239,6 +240,37 @@ gh project item-edit --project-id PVT_kwHOAjEKvM4BWKFe --id "$ITEM_ID" \
 Run `python3 -m py_compile claude/scripts/*.py` from the repo root to verify all hook scripts are free of syntax errors.
 
 For docs-only changes to `claude/CLAUDE.md`: run `grep -n 'date -u' claude/CLAUDE.md` and confirm every match is in an internal operational artifact context (lock files, log timestamps) — not in stub filename or branch name descriptions.
+
+---
+
+## Code Quality
+
+### Suppression policy
+
+A *suppression* is any of the following: `!` (non-null assertion), `?? null` to coerce away `undefined`, `// @ts-ignore`, `// @ts-expect-error`, `eslint-disable` (line or block), or an explicit type cast used to silence an error rather than for a legitimate narrowing.
+
+**Rule 1 — No suppression without justification.**
+Every suppression that lands in a PR must be accompanied by a PR-body note explaining why a proper fix was not appropriate. The note must name the specific lines and state the invariant the suppression relies on.
+
+**Rule 2 — Pre-existing errors must be filed, not silenced.**
+Before adding a suppression, determine whether the error predates the current branch:
+```bash
+git stash && npm test 2>&1 | grep -i error; git stash pop
+```
+If the error exists on the base branch, do **not** suppress it. File a GitHub issue (or batch it into an existing one) and leave the error unmodified. Only suppressions for errors introduced by the current branch are ever permissible — and only with Rule 1 justification.
+
+**Rule 3 — Pre-PR suppression check (required before `gh pr create`).**
+Run this from the repo root and review every match before opening a PR:
+```bash
+git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|!\s*[;,)]|\?\? null)'
+```
+If the output is non-empty:
+- Each line must map to a Rule 1 justification note in the PR body, **or**
+- The suppression must be removed and replaced with a proper fix.
+
+A PR that adds suppressions with no PR-body justification is not mergeable.
+
+See [ADR-026](../docs/adr/026-suppression-policy.md) for rationale.
 
 ---
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -73,6 +73,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 C:/Users/brown/.claude/scripts/session-mode-prompt.py"
+          },
+          {
+            "type": "command",
             "command": "python3 C:/Users/brown/.claude/scripts/dev-env-sync.py"
           },
           {

--- a/docs/adr/026-suppression-policy.md
+++ b/docs/adr/026-suppression-policy.md
@@ -1,0 +1,55 @@
+# ADR-026 — Suppression Policy: No Silent Workarounds for Type and Lint Errors
+
+**Date:** 2026-05-24
+**Status:** Accepted
+**Tags:** code-quality, typescript, eslint, workflow, suppression, pre-pr
+
+---
+
+## Context
+
+PR [lifting-logbook#338](https://github.com/brownm09/lifting-logbook/pull/338) added six TypeScript suppressions (`!` non-null assertions, `?? null` coercions) to `apps/api/prisma/seed.ts` to satisfy the compiler under `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`. The suppressions silenced the errors without changing the underlying code structure. The existing "Test before PR" rule only required that tests pass — it did not distinguish between tests passing because the code is correct and tests passing because suppressions were added.
+
+Left unaddressed, suppressions accumulate and normalize. Each one makes the next feel more acceptable, eroding the value of strict TypeScript and ESLint settings over time. The pre-PR checklist had no mechanism to surface new suppressions before a PR was opened.
+
+---
+
+## Decision
+
+Add a `## Code Quality` section to `claude/CLAUDE.md` with three binding rules:
+
+1. **No suppression without justification.** Every suppression that lands in a PR must be accompanied by a PR-body note naming the specific lines and the invariant the suppression relies on. "The compiler is wrong" is not a justification; "index is always in bounds because the loop bounds equal the tuple length" is.
+
+2. **Pre-existing errors must be filed, not silenced.** Before adding a suppression, determine whether the error predates the current branch by running the test suite on the base. If the error exists without the current branch's changes, file a GitHub issue (or batch it into an existing one) and leave the error unmodified. Only suppressions for errors *introduced by the current branch* are permissible — and only with Rule 1 justification.
+
+3. **Pre-PR suppression grep (required before `gh pr create`).** Run:
+   ```bash
+   git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|!\s*[;,)]|\?\? null)'
+   ```
+   Any match must map to a Rule 1 justification note in the PR body, or the suppression must be replaced with a proper fix. A PR that adds suppressions with no PR-body justification is not mergeable.
+
+A one-line cross-reference is also appended to the "Test before PR" bullet in `## Git Workflow` so the suppression check appears at the same decision point.
+
+A *suppression* is defined as: `!` (non-null assertion), `?? null` to coerce away `undefined`, `// @ts-ignore`, `// @ts-expect-error`, `eslint-disable` (line or block), or an explicit type cast whose purpose is to silence an error rather than to perform a legitimate narrowing.
+
+---
+
+## Consequences
+
+**Positive:**
+- Suppressions become visible artifacts that require acknowledgment before merge.
+- Pre-existing errors can no longer accumulate silently across PRs — they must be tracked in issues.
+- The grep check takes under 5 seconds and runs at the same point as the existing test command.
+
+**Negative:**
+- Every suppression, even clearly safe ones (e.g., a non-null assertion on a loop-bounded index), requires a PR-body note. This is a deliberate friction cost.
+- Identifying whether an error is pre-existing requires running the test suite twice (once with and once without the branch changes). For large repos this adds time; the check is behaviorally enforced rather than automated.
+
+---
+
+## References
+
+- [TypeScript `noUncheckedIndexedAccess` — TypeScript 4.1 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#checked-indexed-accesses---nouncheckedindexedaccess)
+- [ESLint `eslint-disable` comments — ESLint documentation](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1)
+- [lifting-logbook#338](https://github.com/brownm09/lifting-logbook/pull/338) — the PR that prompted this ADR
+- [lifting-logbook#343](https://github.com/brownm09/lifting-logbook/issues/343) — batch issue to clean up the suppressions introduced in #338

--- a/docs/adr/026-suppression-policy.md
+++ b/docs/adr/026-suppression-policy.md
@@ -24,7 +24,7 @@ Add a `## Code Quality` section to `claude/CLAUDE.md` with three binding rules:
 
 3. **Pre-PR suppression grep (required before `gh pr create`).** Run:
    ```bash
-   git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|!\s*[;,)]|\?\? null)'
+   git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
    ```
    Any match must map to a Rule 1 justification note in the PR body, or the suppression must be replaced with a proper fix. A PR that adds suppressions with no PR-body justification is not mergeable.
 
@@ -40,6 +40,7 @@ A *suppression* is defined as: `!` (non-null assertion), `?? null` to coerce awa
 - Suppressions become visible artifacts that require acknowledgment before merge.
 - Pre-existing errors can no longer accumulate silently across PRs — they must be tracked in issues.
 - The grep check takes under 5 seconds and runs at the same point as the existing test command.
+- The grep pattern covers end-of-expression assertions (`!;`, `!,`, `!)`) and chained access (`!.`, `![`). It does not catch every possible `!` form; a manual scan of added `!` occurrences in the diff is still required to confirm completeness.
 
 **Negative:**
 - Every suppression, even clearly safe ones (e.g., a non-null assertion on a loop-bounded index), requires a PR-body note. This is a deliberate friction cost.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -30,3 +30,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [023](023-generic-required-fields-issue-hook.md) | Generic `required_fields` Config for Issue/PR Project-Board Hook | 2026-05-16 | Accepted | hooks, github-project, post-tool-use, hook-config, automation, workflow |
 | [024](024-worktree-path-guard-hook.md) | PreToolUse Hook to Block Canonical-Root Writes from Worktrees | 2026-05-23 | Accepted | hooks, worktrees, pre-tool-use, file-safety, write, edit |
 | [025](025-default-plan-mode.md) | Default Plan Mode | 2026-05-23 | Accepted | config, settings, plan-mode, workflow, defaults |
+| [026](026-suppression-policy.md) | Suppression Policy: No Silent Workarounds for Type and Lint Errors | 2026-05-24 | Accepted | code-quality, typescript, eslint, workflow, suppression, pre-pr |


### PR DESCRIPTION
## Summary

- Adds a `## Code Quality` section to `claude/CLAUDE.md` with three binding rules for TypeScript/lint suppressions
- Appends a suppression-check cross-reference to the existing "Test before PR" bullet in `## Git Workflow`
- Writes ADR-026 documenting the decision and rationale
- Updates `docs/adr/INDEX.md` with the new ADR row

## Rules introduced

**Rule 1 — No suppression without justification.** Every suppression in a PR must have a PR-body note naming the lines and the invariant relied on.

**Rule 2 — Pre-existing errors must be filed, not silenced.** If an error predates the current branch, file a GitHub issue (batch if multiple) and leave the error unmodified.

**Rule 3 — Pre-PR suppression grep.** Run before every \`gh pr create\`:
\`\`\`bash
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|!\s*[;,)]|\?\? null)'
\`\`\`

## Suppression check results for this PR

The grep matched two lines in \`claude/CLAUDE.md\` itself:
1. The definition sentence (contains the literal strings as examples of what counts as a suppression)
2. The grep command example in Rule 3

Both are documentation — no actual suppressions are introduced. This is a known false positive from pattern-matching a doc that defines the patterns.

## Testing

- \`python3 -m py_compile claude/scripts/*.py\` — **Syntax OK**
- Suppression grep diff reviewed — two matches are documentation lines, not suppressions (see above)
- ADR-026 appears in \`docs/adr/INDEX.md\`

## Linked

- Closes #251
- lifting-logbook#343 is the first batch of suppressions to clean up under this policy

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>