### PR TITLE
config: enable agentPushNotifEnabled for agent session push notifications

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -162,5 +162,6 @@
       }
     ]
   },
-  "effortLevel": "medium"
+  "effortLevel": "medium",
+  "agentPushNotifEnabled": true
 }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -330,3 +330,4 @@ The active defaults in `claude/settings.json`:
 | `model` | `claude-sonnet-4-6` | Default model for all session phases. See [ADR-025](adr/025-default-plan-mode.md). |
 | `permissions.defaultMode` | `plan` | Every session starts in plan mode — no edits until the user approves a plan. Override per-session with Shift+Tab. See [ADR-025](adr/025-default-plan-mode.md). |
 | `effortLevel` | `medium` | Applies to all model tiers. Increase to `high` or `xhigh` for intelligence-sensitive sessions (e.g., full cover letter workflow). |
+| `agentPushNotifEnabled` | `true` | Fires a push notification when an agent session completes. |


### PR DESCRIPTION
## Summary
- Adds `"agentPushNotifEnabled": true` to `claude/settings.json` so Claude Code fires push notifications when agent sessions complete.

## Test plan
- [ ] `python3 -m py_compile claude/scripts/*.py` — no hook scripts changed, passes trivially.

## Notes
This setting was stashed on the now-defunct `fix/revert-opusplan-model` branch. That branch's substantive commits were already superseded by PR #243. This PR extracts the only remaining useful change.

Closes #253

🤖 Generated with [Claude Code](https://claude.ai/claude-code)