### PR TITLE
fix: replace Unicode box-drawing chars with ASCII in session-mode-prompt

### DIFF
--- a/claude/scripts/session-mode-prompt.py
+++ b/claude/scripts/session-mode-prompt.py
@@ -49,8 +49,8 @@ def main():
     except Exception as e:
         sys.stderr.write(f"session-mode-prompt: could not write marker: {e}\n")
 
-    print("─────────────────────────────────────────────────")
-    print("New session — confirm your permission mode:")
+    print("-------------------------------------------------")
+    print("New session -- confirm your permission mode:")
     print("")
     print("  plan       Claude asks before making any edits  (settings default)")
     print("  bypass     Claude acts immediately without asking")
@@ -58,7 +58,7 @@ def main():
     print("")
     print("Press Shift+Tab to cycle modes if needed,")
     print("then re-submit your prompt to continue.")
-    print("─────────────────────────────────────────────────")
+    print("-------------------------------------------------")
     sys.exit(2)
 
 


### PR DESCRIPTION
## Problem

`session-mode-prompt.py` used the U+2500 BOX DRAWINGS LIGHT HORIZONTAL character (`─`) in its divider lines. The Windows default codepage (`cp1252`) cannot encode this character, so the hook crashed with:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-48
```

When a `UserPromptSubmit` hook exits with code 1 (error) rather than 2 (intentional block), Claude Code does not block the prompt — the permission-mode reminder was never shown and sessions started silently.

## Fix

Replace all `─` divider characters with plain ASCII `-`.

## Testing

```
python3 -m py_compile claude/scripts/*.py  # passes
```

Manual test from canonical dev-env directory (non-worktree, Windows terminal):
- Removed marker file, ran hook with first-turn message payload
- Confirmed exit code 2 and prompt output after fix (verified in Git Bash)

Closes #257