### PR TITLE
fix: scope session-mode-prompt marker per session-id

### DIFF
--- a/claude/scripts/session-mode-prompt.py
+++ b/claude/scripts/session-mode-prompt.py
@@ -25,7 +25,8 @@ import sys
 import time
 import traceback
 
-MARKER = "C:/Users/brown/.claude/scratch/session_mode_ack.txt"
+MARKER_DIR = "C:/Users/brown/.claude/scratch"
+MARKER_PREFIX = "session_mode_ack_"
 LOG_PATH = "C:/Users/brown/.claude/scratch/session-mode-prompt.log"
 COOLDOWN_SECS = 120  # covers the re-submit window after user sees the prompt
 
@@ -65,16 +66,21 @@ def main():
         sys.exit(0)
 
     now = time.time()
-    event["session_id"] = data.get("session_id", "")
+    session_id = data.get("session_id", "unknown")
+    event["session_id"] = session_id
     prompt = data.get("prompt", "")
     event["prompt_prefix"] = prompt[:80]
     event["permission_mode"] = data.get("permission_mode", "")
 
-    marker_exists = os.path.exists(MARKER)
+    # Per-session marker: each session gets its own cooldown file so sessions
+    # opening within COOLDOWN_SECS of each other don't suppress each other's banners.
+    safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", session_id)
+    marker = os.path.join(MARKER_DIR, f"{MARKER_PREFIX}{safe_id}.txt")
+    marker_exists = os.path.exists(marker)
     event["marker_exists"] = marker_exists
     if marker_exists:
         try:
-            age = now - os.path.getmtime(MARKER)
+            age = now - os.path.getmtime(marker)
             event["marker_age_sec"] = round(age, 2)
             if age < COOLDOWN_SECS:
                 event["stage"] = "cooldown_passthrough"
@@ -84,6 +90,19 @@ def main():
         except Exception as e:
             event["marker_stat_error"] = repr(e)
 
+    # Prune stale per-session markers (older than COOLDOWN_SECS) to keep scratch/ clean.
+    try:
+        for fname in os.listdir(MARKER_DIR):
+            if fname.startswith(MARKER_PREFIX) and fname.endswith(".txt"):
+                fpath = os.path.join(MARKER_DIR, fname)
+                try:
+                    if now - os.path.getmtime(fpath) >= COOLDOWN_SECS:
+                        os.remove(fpath)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
     if _AUTOMATED_PREFIX.match(prompt):
         event["stage"] = "automated_suppressed"
         event["exit"] = 0
@@ -91,7 +110,7 @@ def main():
         sys.exit(0)
 
     try:
-        with open(MARKER, "w") as f:
+        with open(marker, "w") as f:
             f.write(str(now))
         event["marker_written"] = True
     except Exception as e:


### PR DESCRIPTION
## Summary

- The cooldown marker was a single global file (`session_mode_ack.txt`), so any session opening within 120 seconds of another session's banner display got a free pass — even though it had never seen the banner itself.
- Fix: use a per-session marker file (`session_mode_ack_{session_id}.txt`) so the cooldown is scoped to the re-submit window within a single session only.
- Added pruning of expired per-session markers on each invocation to keep `scratch/` clean.

## Root cause (from log)

```
01:07:10  session 1f02952d  banner printed   (marker written)
01:08:19  session e379b24a  cooldown passthrough  marker_age=68s  <-- missed banner
```

## Test plan

- [ ] `py -3 -m py_compile claude/scripts/*.py` — passes
- [ ] Open a new session within 120 seconds of this one; confirm the banner appears in the new session

## Suppression check

No suppressions added.

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)