### PR TITLE
fix: change journal-hook stale-artifact directive to passive reminder

### DIFF
--- a/claude/scripts/new-day-journal-check.py
+++ b/claude/scripts/new-day-journal-check.py
@@ -231,10 +231,10 @@ def main() -> None:
         artifact_path = Path(stale[0]).as_posix()
         artifact_date = os.path.basename(stale[0])[:10]  # YYYY-MM-DD prefix
         messages.append(
-            f"[journal-hook] Stale draft artifact detected: {artifact_path}\n"
-            f"The engineering journal draft from {artifact_date} was never composed.\n"
-            f"Before responding to the user's message, invoke the journal-compose skill "
-            f"to close out the {artifact_date} session. Then proceed with the user's request."
+            f"[journal-hook] Stale draft artifact detected ({artifact_date}): {artifact_path} — "
+            f"the engineering journal draft from {artifact_date} was never composed. "
+            f"Mention this to the user at a natural pause and suggest running /journal-compose "
+            f"in a dedicated session. Do not defer or interrupt the user's current request."
         )
 
     unmerged = unmerged_draft_branches()
@@ -256,7 +256,7 @@ def main() -> None:
         )
 
     if messages:
-        print("\n".join(messages))
+        print(json.dumps({"systemMessage": " ".join(messages)}))
         if session_id:
             try:
                 (SCRATCH / f"journal_hook_{session_id}.flag").touch()


### PR DESCRIPTION
## Summary

- Removes the "Before responding to the user's message, invoke the journal-compose skill" override from `new-day-journal-check.py`'s stale-artifact message — this was injected as a system-level directive that caused Claude to attempt journal composition before handling the user's actual request, producing 3-4 messages of session-start friction
- Replaces it with a soft advisory Claude surfaces at a natural pause, aligned with the CLAUDE.md "never compose proactively" rule
- Switches output from raw `print()` to `json.dumps({"systemMessage": ...})` for consistency with `reconcile-open-prs.py`

**Root cause breakdown:**
- `session-mode-prompt.py` (exit 2) = 1 guaranteed re-send per new session — intentional, by design
- `new-day-journal-check.py` commanding directive = 1-2 additional messages when stale artifacts exist — **this PR fixes that**

Closes #267

## Testing

```
py -3 -m py_compile claude/scripts/*.py
```
All scripts compile clean. No automated test for hook message text; verified by code review that the new message removes the "Before responding" override language and uses the standard JSON output format.

No new suppressions introduced.