### PR TITLE
fix: trust gh stdout success marker in post-pr-merge-pull (closes #275)

### DIFF
--- a/claude/scripts/post-pr-merge-pull.py
+++ b/claude/scripts/post-pr-merge-pull.py
@@ -105,13 +105,22 @@ def main() -> None:
 
     command = data.get("tool_input", {}).get("command", "")
     exit_code = data.get("tool_response", {}).get("exitCode", -1)
+    output = data.get("tool_response", {}).get("output", "")
     cwd = data.get("cwd", "")
 
     if "gh pr merge" not in command:
         sys.exit(0)
 
-    # Only pull when the merge actually succeeded
-    if exit_code != 0:
+    # `gh pr merge` from a worktree exits non-zero because local cleanup
+    # (`git checkout main`, branch delete) fails — even though the remote
+    # merge succeeded. Trust the stdout success marker too. (issue #275)
+    merge_succeeded = (
+        exit_code == 0
+        or "Merged pull request" in output
+        or "Squashed and merged" in output
+        or "Rebased and merged" in output
+    )
+    if not merge_succeeded:
         sys.exit(0)
 
     repo = extract_repo(command, cwd)


### PR DESCRIPTION
## Summary
- `post-pr-merge-pull.py` was bailing on `exit_code != 0` before calling `pull_main()`. `gh pr merge` exits non-zero from a worktree because its local cleanup (`git checkout main`, branch delete) fails — even though the remote merge succeeded. Result: local main stayed stale in every non-dev-env repo that lacks the `dev-env-sync` backstop.
- Now also treat the stdout success marker (`Merged pull request` / `Squashed and merged` / `Rebased and merged`) as success. Genuine failures (conflict, auth, branch protection, network) never emit those strings, so there are no false positives.

Closes #275.

## Testing
Project Testing command (`py -3 -m py_compile claude/scripts/*.py`) — passed.

Tests: 0 passed, 0 skipped, 0 failed (n/a — repo has no automated test suite; verification is the syntax-compile step + dry-run below).

**Dry-run verification:**
- Worktree-merge shape (`exitCode: 1`, output contains `✓ Squashed and merged pull request`): hook now reaches `pull_main()` (confirmed via stderr output past the early-return). Previously bailed silently.
- Genuine failure (`exitCode: 1`, no success marker): hook still exits silently. No false positive.

**`tool_response.output` contains gh stdout (review Q confirmation):** The sibling hook `claude/scripts/post-pr-merge-project.py` already reads `tool_response.output` from `gh pr merge` PostToolUse events and parses the PR number out of the `✓ Squashed and merged pull request #N` line (line 272: `extract_pr_number(output)`). That hook drives the project-board Done transition and has been working in production, so the field demonstrably contains gh's stdout success markers. The check added here keys off the same field with the same content shape.

**Coverage gate:** No new testable behavior beyond the existing hook contract. The repo has no Python test harness for hook scripts (intentional — see [ADR-007](docs/adr/007-hook-command-invocation.md)); dry-run verification above covers the behavior change.

**Suppression check:** clean (no JS suppressions touched — Python file).

**Test integrity check:** clean (no skip markers, deleted tests, or threshold changes).

## ADR-warrant
Not warranted — bug fix to existing hook, no rule/skill/workflow change. The CLAUDE.md "Merging a PR developed in a worktree" rule is unchanged; this fix makes the hook actually honor it.

## Doc-reconciliation
No updates needed — `README.md` and `docs/REFERENCE.md` already list this hook; behavior is now "works as originally intended."

## Test plan
- [ ] After merge, perform any worktree-based merge in a non-dev-env repo and confirm `[post-merge-pull] <repo>: local main updated` appears on stderr immediately, without needing the next prompt's `dev-env-sync` to catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
