### PR TITLE
fix: switch syntax-check command to ast.parse (closes #276)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ guidelines, and journal conventions are defined there and apply to every project
 Run from the repo root to verify all hook scripts are syntax-clean:
 
 ```bash
-py -3 -m py_compile claude/scripts/*.py
+py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
 ```
 
 (On Windows, `python3` resolves to the Microsoft Store stub; use `py -3` — see [ADR-007](docs/adr/007-hook-command-invocation.md).)

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -240,7 +240,15 @@ gh project item-edit --project-id PVT_kwHOAjEKvM4BWKFe --id "$ITEM_ID" \
 
 ## Testing
 
-Run `py -3 -m py_compile claude/scripts/*.py` from the repo root to verify all hook scripts are free of syntax errors. On Windows, `python3` resolves to the Microsoft Store stub — use `py -3` (the Windows Python Launcher). See [ADR-007](../docs/adr/007-hook-command-invocation.md).
+Run the following from the repo root to verify all hook scripts are free of syntax errors:
+
+```bash
+py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
+```
+
+`ast.parse` is used instead of `py_compile` because the latter writes `.pyc` files into `claude/scripts/__pycache__/` as a side effect (see [dev-env#276](https://github.com/brownm09/dev-env/issues/276)). Neither `-B` nor `PYTHONDONTWRITEBYTECODE=1` suppresses that — they only affect implicit caching on import, not explicit compilation.
+
+On Windows, `python3` resolves to the Microsoft Store stub — use `py -3` (the Windows Python Launcher). See [ADR-007](../docs/adr/007-hook-command-invocation.md).
 
 For docs-only changes to `claude/CLAUDE.md`: run `grep -n 'date -u' claude/CLAUDE.md` and confirm every match is in an internal operational artifact context (lock files, log timestamps) — not in stub filename or branch name descriptions.
 

--- a/docs/adr/019-doc-reconciliation-enforcement.md
+++ b/docs/adr/019-doc-reconciliation-enforcement.md
@@ -113,5 +113,5 @@ enough complexity to warrant a new script.
 2. Attempt `gh pr create` — confirm hook emits the documentation warning.
 3. Run `/review` on that PR — confirm a blocking "Documentation" finding appears.
 4. Add the README.md change, re-run `/review` — confirm finding is absent.
-5. Run `py -3 -m py_compile claude/scripts/pre-pr-create-check.py` — no syntax errors.
+5. Run `py -3 -c "import ast; ast.parse(open('claude/scripts/pre-pr-create-check.py',encoding='utf-8').read())"` — no syntax errors.
 6. Tracked in [dev-env#217](https://github.com/brownm09/dev-env/issues/217).

--- a/docs/adr/019-doc-reconciliation-enforcement.md
+++ b/docs/adr/019-doc-reconciliation-enforcement.md
@@ -113,5 +113,5 @@ enough complexity to warrant a new script.
 2. Attempt `gh pr create` — confirm hook emits the documentation warning.
 3. Run `/review` on that PR — confirm a blocking "Documentation" finding appears.
 4. Add the README.md change, re-run `/review` — confirm finding is absent.
-5. Run `py -3 -c "import ast; ast.parse(open('claude/scripts/pre-pr-create-check.py',encoding='utf-8').read())"` — no syntax errors.
+5. Run `py -3 -c "import ast; ast.parse(open('claude/scripts/pre-pr-create-check.py',encoding='utf-8').read(),'claude/scripts/pre-pr-create-check.py')"` — no syntax errors.
 6. Tracked in [dev-env#217](https://github.com/brownm09/dev-env/issues/217).


### PR DESCRIPTION
## Summary
- Replaces `py -3 -m py_compile claude/scripts/*.py` with an `ast.parse`-based one-liner in the `## Testing` sections of `CLAUDE.md` and `claude/CLAUDE.md`, plus the ADR-019 verification step.
- `py_compile` writes `.pyc` files into `claude/scripts/__pycache__/` on every run — already caught once by an accidental `git add` (commit `d01856f`). The `.gitignore` now blocks them, but the noise still lands on disk.
- The fixes proposed in the issue (`-B` flag / `PYTHONDONTWRITEBYTECODE=1`) do not work — both only affect implicit bytecode caching on import; explicit `py_compile` is unaffected. Verified empirically before writing the patch (24 `.pyc` files still produced under `-B`).
- `ast.parse` performs the same syntax validation with zero side effects.

## Why not other approaches
- `python -X pycache_prefix=DIR -m py_compile ...` would redirect output but requires a scratch dir parameter.
- A dedicated `check-syntax.py` helper script would add surface area for what is a one-line concern.

## Testing
Ran the new command from the repo root:

```
$ py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
$ ls claude/scripts/__pycache__ 2>&1 || echo "no __pycache__"
no __pycache__
```

No automated test suite for this repo (docs/config only). The `## Testing` command in `claude/CLAUDE.md` *is* the test command, and it runs clean.

Tests: 0 passed, 0 skipped, 0 failed (manual verification — no automated suite)

Suppression / test-integrity grep: not applicable (no code changed).

## ADR warrant
Not warranted per the issue: documentation-text fix to a testing instruction; no rule change, no skill/hook/script/routine added or modified. `docs/adr/INDEX.md` not updated.

## Documentation Maintenance
No skill/hook/script/routine added, removed, renamed, or behavior-changed → no README or REFERENCE.md updates required.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)