### PR TITLE
journal-compose: add Start here dashboard block to top-level README

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -516,6 +516,12 @@ echo '{"stub":"YYYY-MM-DD_HHMMSS.stub.md","topic":"<H2 heading>","tokens":{"inpu
 
 - `prs_opened`: PR numbers opened during this session (e.g., `[54]`). Empty array if none.
 - `prs_closed`: PR numbers reviewed/merged during this session (e.g., `[54]`). Empty array if none.
+- `priorities` (optional): array of items to surface on the top-level README "Start here" dashboard.
+  Each entry: `label` (required string, short title); `ref` (optional string, `owner/repo#N` or
+  freeform key used for dedupe); `why` (optional string, one-sentence rationale). Example:
+  `"priorities":[{"label":"Staging gate fix","ref":"lifting-logbook#346","why":"blocks next deploy"}]`.
+  `/journal-compose` aggregates these across all projects (deduped by `ref`, capped at 5) — see
+  [ADR-032](https://github.com/brownm09/dev-env/blob/main/docs/adr/032-journal-start-here-dashboard.md).
 
 The manifest lets `/journal-compose` see the session count, topics, token data, and PR lifecycle
 without reading individual stubs. It is advisory: if the manifest is missing or has fewer entries

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -779,6 +779,104 @@ Top-level entry format (labeled bullets, no prose block):
 If the project does not yet appear in the README, add a new `### <Project>` section
 under `## Projects` using this format.
 
+## Step 8a — Update top-level "Start here" dashboard block
+
+After Step 8, refresh the marker-delimited block at the top of `engineering-journal/README.md`. This block surfaces a freshness stamp and the top 3–5 cross-project priorities. It is rewritten on every compose; it is not hand-edited between composes. See [ADR-032](https://github.com/brownm09/dev-env/blob/main/docs/adr/032-journal-start-here-dashboard.md) for rationale.
+
+**Aggregate the priority list (max 5 entries, deduped by `ref`):**
+
+```bash
+TMPFILE="C:/Users/brown/.claude/scratch/tmp_start_here_$$.json"
+node -e "
+  const fs = require('fs'); const path = require('path');
+  const root = 'C:/Users/brown/Git/engineering-journal';
+  const date = 'YYYY-MM-DD';   // <-- substitute the compose date
+  const items = [];
+  const seen = new Set();
+  const push = (it) => {
+    const key = (it.ref || '').trim() || ('__no_ref_' + items.length);
+    if (seen.has(key)) return;
+    seen.add(key);
+    items.push(it);
+  };
+  const sessionsDir = path.join(root, 'sessions');
+  const projects = fs.readdirSync(sessionsDir).filter(d =>
+    fs.statSync(path.join(sessionsDir, d)).isDirectory());
+  // Source 1: today's manifests
+  for (const proj of projects) {
+    const f = path.join(sessionsDir, proj, date + '.manifest.jsonl');
+    if (!fs.existsSync(f)) continue;
+    for (const line of fs.readFileSync(f,'utf8').split('\n').filter(Boolean)) {
+      try {
+        const m = JSON.parse(line);
+        for (const p of (m.priorities || [])) {
+          push({ source:'manifest', project:proj, label:p.label, ref:p.ref||'', why:p.why||'' });
+        }
+      } catch (e) {}
+    }
+  }
+  // Source 2: open-prs.jsonl across projects (fills to 5)
+  if (items.length < 5) {
+    for (const proj of projects) {
+      if (items.length >= 5) break;
+      const f = path.join(sessionsDir, proj, 'open-prs.jsonl');
+      if (!fs.existsSync(f)) continue;
+      for (const line of fs.readFileSync(f,'utf8').split('\n').filter(Boolean)) {
+        if (items.length >= 5) break;
+        try {
+          const o = JSON.parse(line);
+          const ref = (o.url||'').replace(/^https:\/\/github.com\//,'').replace(/\/pull\//,'#');
+          push({ source:'open-prs', project:proj, label:o.topic||('PR #'+o.pr), ref, why:'open since '+o.opened, url:o.url });
+        } catch (e) {}
+      }
+    }
+  }
+  fs.writeFileSync('$TMPFILE', JSON.stringify(items.slice(0,5), null, 2));
+  console.log('PRIORITY_COUNT=' + Math.min(items.length, 5));
+"
+```
+
+**Render the block:**
+
+```
+<!-- start-here:begin -->
+**Last composed:** YYYY-MM-DD
+
+## Start here
+
+Top priorities across all projects (max 5):
+
+1. **[<ref-or-label>](<url>) — <label>** *(<project>)* — <why>
+2. ...
+
+<!-- start-here:end -->
+```
+
+If `PRIORITY_COUNT=0`, render the body as `*No flagged priorities and no open PRs.*` (omit the numbered list).
+
+For each item:
+- If `ref` matches `owner/repo#N`, render as `[#N](https://github.com/owner/repo/<pull|issues>/N)`. Default to `/pull/` unless the manifest entry specifies `/issues/`.
+- If `ref` is absent and the source is `open-prs`, use `url` directly.
+- If neither is available, render the label without a link.
+- Always italicize the project name in parentheses after the label.
+- Append `— <why>` only if `why` is non-empty.
+
+**Insert or replace in `engineering-journal/README.md`:**
+
+1. Read the current README.
+2. If `<!-- start-here:begin -->` and `<!-- start-here:end -->` both exist, replace everything between (and including) the markers with the new block.
+3. Otherwise, insert the new block immediately above the first `## Projects` heading, with one blank line before `## Projects`.
+4. Use the Edit tool with `replace_all: false` — there is only ever one such block in the file.
+
+The block lives above any `## Projects` H2 and below the file's top-level `# Engineering Journal` title.
+
+Tell the user: "Start here block refreshed with N item(s)."
+
+Clean up:
+```bash
+rm -f "$TMPFILE"
+```
+
 ## Step 9 — Delete stub files and release lock
 
 Delete all stubs for the date and release the compose lock:

--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -793,8 +793,18 @@ node -e "
   const date = 'YYYY-MM-DD';   // <-- substitute the compose date
   const items = [];
   const seen = new Set();
+  // Normalize refs to a single canonical form so manifest-style 'repo#N' and
+  // open-prs-derived 'owner/repo#N' dedup against each other. Convention:
+  // strip the owner prefix — manifests are owner-less by convention.
+  const normRef = (r) => {
+    const s = (r || '').trim();
+    if (!s) return '';
+    const m = s.match(/^[^\/]+\/([^#]+#\d+)$/);
+    return m ? m[1] : s;
+  };
   const push = (it) => {
-    const key = (it.ref || '').trim() || ('__no_ref_' + items.length);
+    const norm = normRef(it.ref);
+    const key = norm || ('__no_ref_' + items.length);
     if (seen.has(key)) return;
     seen.add(key);
     items.push(it);
@@ -838,6 +848,9 @@ node -e "
 
 **Render the block:**
 
+Read `$TMPFILE` (an array of `{source, project, label, ref, why, url?}` objects, max 5).
+For each entry, render one numbered bullet per the rules below the template.
+
 ```
 <!-- start-here:begin -->
 **Last composed:** YYYY-MM-DD
@@ -855,9 +868,9 @@ Top priorities across all projects (max 5):
 If `PRIORITY_COUNT=0`, render the body as `*No flagged priorities and no open PRs.*` (omit the numbered list).
 
 For each item:
-- If `ref` matches `owner/repo#N`, render as `[#N](https://github.com/owner/repo/<pull|issues>/N)`. Default to `/pull/` unless the manifest entry specifies `/issues/`.
-- If `ref` is absent and the source is `open-prs`, use `url` directly.
-- If neither is available, render the label without a link.
+- If the source is `open-prs`, use `url` directly as the link target.
+- Else if `ref` (post-normalization) matches `repo#N` or `owner/repo#N`, render the link as `https://github.com/<owner>/<repo>/pull/N`. Use `brownm09` as the owner when the manifest ref omits it. A GitHub `/pull/N` URL 302s to `/issues/N` when N is an issue, so always emitting `/pull/` is safe.
+- If neither a `url` nor a parseable `ref` is available, render the label without a link.
 - Always italicize the project name in parentheses after the label.
 - Append `— <why>` only if `why` is non-empty.
 
@@ -867,6 +880,7 @@ For each item:
 2. If `<!-- start-here:begin -->` and `<!-- start-here:end -->` both exist, replace everything between (and including) the markers with the new block.
 3. Otherwise, insert the new block immediately above the first `## Projects` heading, with one blank line before `## Projects`.
 4. Use the Edit tool with `replace_all: false` — there is only ever one such block in the file.
+5. **Anchor-missing abort:** if neither the marker pair nor a `## Projects` heading is present, do not silently skip. Report `START_HERE_INSERT_FAILED: anchor not found` to the user and continue the compose (Step 9 onward) — the rest of the journal still ships, but the dashboard refresh is flagged so the README structural drift gets diagnosed.
 
 The block lives above any `## Projects` H2 and below the file's top-level `# Engineering Journal` title.
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -41,7 +41,7 @@ Expands a one-line idea into a full proposal document, creates a linked GitHub i
 /journal-compose [YYYY-MM-DD]
 ```
 
-Composes the end-of-day engineering journal from the day's stub files. Discovers all `YYYY-MM-DD_*.stub.md` files, sorts and merges them, produces the canonical 11-section document, commits to the `draft/YYYY-MM-DD` branch, and opens a PR.
+Composes the end-of-day engineering journal from the day's stub files. Discovers all `YYYY-MM-DD_*.stub.md` files, sorts and merges them, produces the canonical 11-section document, commits to the `draft/YYYY-MM-DD` branch, and opens a PR. Also refreshes the marker-delimited `## Start here` block at the top of `engineering-journal/README.md` (freshness stamp + top 3–5 cross-project priorities aggregated from manifest `priorities` arrays and `open-prs.jsonl` — see [ADR-032](adr/032-journal-start-here-dashboard.md)).
 
 **Constraint:** must run in a dedicated session with no prior task work. If other tasks were handled before invocation, the skill refuses with an error message.
 

--- a/docs/adr/032-journal-start-here-dashboard.md
+++ b/docs/adr/032-journal-start-here-dashboard.md
@@ -1,0 +1,97 @@
+# ADR-032 — Top-of-README "Start here" Dashboard in journal-compose
+
+**Date:** 2026-05-28
+**Status:** Accepted
+**Closes:** [dev-env#286](https://github.com/brownm09/dev-env/issues/286)
+**Tags:** journal, composition, skill, readme, manifest, dashboard
+**Related:** [ADR-001](001-per-session-stub-files.md), [ADR-002](002-journal-compose-session-isolation.md), [ADR-019](019-doc-reconciliation-enforcement.md)
+
+---
+
+## Context
+
+`engineering-journal/README.md` is the user's daily on-ramp to 11 active project journals. Today every project gets a `### <Project Name>` section with `Recent:` / `Open:` / `Next:` / `Repo:` / `Journal:` bullets (`journal-compose` Step 8), and each `sessions/<project>/README.md` gets a Progress Summary plus a "Where to start next session" paragraph (Step 7).
+
+In practice, opening the root README the next morning still requires scanning all 11 project sections to reconstruct two questions: "what was actively worked yesterday?" and "what are the 3–5 most important things to pick up next?" The data is present — distributed across 11 `Next:` bullets and `sessions/*/open-prs.jsonl` files — but no view aggregates it. The user explicitly asked for a single landing block that surfaces both, refreshed on every compose, plus a freshness stamp so staleness is obvious.
+
+The composition rules ([ADR-001](001-per-session-stub-files.md), [ADR-002](002-journal-compose-session-isolation.md)) already pass per-session metadata through the manifest (`stub`, `topic`, `tokens`, `prs_opened`, `prs_closed`). Cross-project priority is the one signal the user has been tracking in their head — extending the manifest is the natural place to make it explicit and aggregatable.
+
+---
+
+## Decision
+
+`/journal-compose` writes a new marker-delimited block at the top of `engineering-journal/README.md`, above `## Projects`, on every successful compose:
+
+```markdown
+<!-- start-here:begin -->
+**Last composed:** YYYY-MM-DD
+
+## Start here
+
+Top priorities across all projects (max 5):
+
+1. **[ref](url) — label** *(project)* — why
+2. ...
+<!-- start-here:end -->
+```
+
+The block's content is derived from two sources, aggregated at compose time, deduped by `ref`, capped at 5:
+
+1. **`priorities` arrays from every manifest written for the compose date**, across all `sessions/*/`. This is the explicit "I'm flagging this" channel — highest signal.
+2. **`open-prs.jsonl` entries across all projects**, used to fill the list when today's flags total fewer than 5.
+
+The manifest schema gains one optional field:
+
+```json
+"priorities": [
+  {"label": "Staging integration test gate fix", "ref": "lifting-logbook#346", "why": "blocks next staging deploy"}
+]
+```
+
+`label` is required (string). `ref` and `why` are optional (string). No other keys are accepted. The validator (`engineering-journal/scripts/validate-jsonl.js`) enforces this in a companion PR.
+
+The empty case (no priorities flagged today and no open PRs) renders an explicit `*No flagged priorities and no open PRs.*` line rather than omitting the block — explicit empty state beats invisible drift.
+
+---
+
+## Rationale
+
+**Why a marker-delimited block instead of a section heading the existing Step 8 rewrites?** Step 8 finds each project's `### <Project Name>` heading by name and rewrites within it. The new block sits above `## Projects` and has no semantic parent to anchor on, so explicit `<!-- start-here:begin -->` / `<!-- start-here:end -->` markers are needed for the overwrite to be idempotent. The markers are inert in rendered Markdown and visible in source — there is no risk of user content accidentally landing inside them.
+
+**Why aggregate at compose time rather than maintaining the list incrementally?** Composes already touch every manifest and `open-prs.jsonl` for the date. Aggregation adds one `node -e` pass over data the skill is already loading. Maintaining the list incrementally (e.g., a stop-hook that recomputes after every session) would couple a daily artifact to per-session events and add a cross-project read on every session close.
+
+**Why an explicit `priorities` field instead of inferring priority from per-project `Next:` bullets?** Inference is unreliable — `Next:` bullets are written by the skill after composition and reflect the *end* of a session, not what the user views as cross-project priority. The explicit field lets the session author flag what they care about during stub authoring, when intent is freshest. The field is optional; sessions that don't set it simply contribute nothing to the top-5 list.
+
+**Why dedupe by `ref`?** A priority flagged in today's manifest and the same PR sitting in `open-prs.jsonl` is one item, not two. `ref` is the natural key — `owner/repo#N` for GitHub references, freeform otherwise. Entries without `ref` are never considered duplicates of anything.
+
+**Why cap at 5?** The user explicitly asked for "3–5 high-priority issues." Beyond 5 the dashboard becomes a second catalog, defeating the purpose. If more than 5 items are flagged, the surplus is silently dropped — the manifest is the audit trail, not the dashboard.
+
+---
+
+## Consequences
+
+**Forced:** every compose rewrites the marker-delimited block. The freshness stamp surfaces stale-ness without a separate check. Sessions that flag priorities see them propagate to the top of the README on the next compose. The validator rejects malformed `priorities` entries at the manifest level, before they reach compose.
+
+**Cost:** one new optional manifest field that future schema migrations have to account for. The skill gains one new step (Step 8a) with a new aggregation rule. The user has to remember to flag priorities in stubs — there is no enforcement that priorities are flagged, only that flagged priorities are well-formed.
+
+**Detection:** if the `## Start here` block disappears or stops updating, the symptoms are (a) `**Last composed:**` showing a stale date, (b) the marker pair missing from the rendered README, (c) priorities flagged in recent manifests not appearing in the block. (b) means the skill failed during Step 8a; (a) and (c) without (b) mean composes have stopped running.
+
+---
+
+## Alternatives considered
+
+**A — Single hand-curated `START_HERE.md` at repo root.** Rejected: requires the user to maintain it between composes; defeats the goal of automated daily refresh.
+
+**B — Aggregate from per-project `Next:` bullets only.** Rejected: see Rationale — `Next:` is end-of-session output, not user intent. Inference produces a noisy list.
+
+**C — Persist priorities across days until explicitly resolved.** Rejected: today's manifest is the highest-signal channel. Persisting yesterday's priorities risks the list becoming a stale to-do log. `open-prs.jsonl` already carries the cross-day signal for in-flight work; that's enough.
+
+**D (chosen) — Marker-delimited block at top of root README, fed by explicit manifest `priorities` + `open-prs.jsonl` fallback, rewritten every compose.** Preserves user control over what's flagged, automates the aggregation, makes freshness visible.
+
+---
+
+## References
+
+- [ADR-001 — Per-Session Stub Files for Journal Composition](001-per-session-stub-files.md)
+- [ADR-002 — Journal-Compose Session Isolation](002-journal-compose-session-isolation.md)
+- [ADR-019 — Documentation Reconciliation Enforcement](019-doc-reconciliation-enforcement.md)

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -36,3 +36,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [029](029-test-integrity-policy.md) | Test Integrity Policy: No Silent Degradation of Existing Tests | 2026-05-27 | Accepted | testing, quality, review, suppression-parallel, workflow, pre-pr |
 | [030](030-baseline-test-failure-policy.md) | Pre-existing Test Failure Policy: Baseline + Fix-on-Touch | 2026-05-27 | Accepted | testing, quality, pre-pr, baseline, fix-on-touch, workflow |
 | [031](031-auto-merge-disabled.md) | Auto-Merge Disabled Across All Repos | 2026-05-28 | Accepted | git, pr, merge, workflow, hooks, post-merge |
+| [032](032-journal-start-here-dashboard.md) | Top-of-README "Start here" Dashboard in journal-compose | 2026-05-28 | Accepted | journal, composition, skill, readme, manifest, dashboard |


### PR DESCRIPTION
## Summary

- Adds Step 8a to `/journal-compose` that rewrites a marker-delimited `## Start here` block at the top of `engineering-journal/README.md` on every compose
- Block contains a `**Last composed:**` freshness stamp + the top 3–5 cross-project priorities, aggregated from a new optional manifest field plus `open-prs.jsonl` fallback (deduped by `ref`, capped at 5)
- Extends manifest schema with optional `priorities` array (`label` required; `ref`/`why` optional)
- Records the design decision in [ADR-032](docs/adr/032-journal-start-here-dashboard.md); updates `INDEX.md`

Closes #286

## Companion PR

Engineering-journal PR (to land after this merges):
- Extend `scripts/validate-jsonl.js` to accept the optional `priorities` field on manifest lines
- Add a note to `engineering-journal/CLAUDE.md` that the marker-delimited block is skill-owned

## Testing

Ran the project test command from `dev-env/CLAUDE.md`:
```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
```
Result: **all hook scripts parse cleanly.** No hook scripts were modified in this PR.

Tests: N/A — no automated test suite covers the skill markdown itself. End-to-end verification is in the plan file (`~/.claude/plans/is-the-journal-compose-skill-robust-pony.md`) and will run on the next real `/journal-compose` invocation.

**Pre-PR suppression check:**
```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|\?\? null)'
```
No matches — this PR adds no suppressions.

**Pre-PR test-integrity check:** No test files modified, no skip markers added, no coverage thresholds changed.

**Coverage gate:** The new behavior (Step 8a aggregation + Edit) has no automated test coverage; engineering-journal has no skill test harness. The validator change in the companion PR is the closest enforceable test and will cover the schema half.

## Test plan

- [ ] After merge, manually re-symlink check: `~/.claude/skills/journal-compose/SKILL.md` should reflect the new Step 8a
- [ ] Next real `/journal-compose` run — verify the block appears above `## Projects` in engineering-journal README
- [ ] Re-compose later that week — verify the block is replaced (not appended)
- [ ] Flag a priority in a stub manifest, compose, verify it surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)