### PR TITLE
Prevent Windows system sleep while Claude is processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Most hooks are advisory — they emit reminders but do not block tool execution.
 | UserPromptSubmit | `turn-count-hook.py` | Warns when session context token count exceeds threshold |
 | UserPromptSubmit | `multi-worktree-alert.py` | Lists active worktrees in `repo:branch` format when ≥2 are open |
 | UserPromptSubmit | `reconcile-open-prs.py` | Removes stale entries from `open-prs.jsonl` whose PRs are now merged/closed; emits surviving open PRs as session context |
+| UserPromptSubmit / Stop / Notification | `awake-blocker.py` | Spawns a detached watcher that holds a Windows system-sleep lock while Claude is processing; releases on Stop or Notification |
 | PreToolUse (Bash) | `pre-commit-branch-check.py` | Emits current branch as a checkpoint before `git commit` |
 | PreToolUse (Bash) | `pre-pr-create-check.py` | Emits test-verification checklist, documentation-gap warning, and pre-existing-failure baseline advisory before `gh pr create` |
 | PreToolUse (Write/Edit/NotebookEdit) | `pre-tool-use-worktree-path-check.py` | Blocks file writes whose absolute path targets the canonical repo root instead of the active worktree |

--- a/claude/scripts/awake-blocker.py
+++ b/claude/scripts/awake-blocker.py
@@ -1,0 +1,186 @@
+"""Block Windows system sleep while Claude is processing.
+
+Invoked from settings.json hooks:
+  - UserPromptSubmit: start (idempotent — spawns watcher if not running, refreshes heartbeat)
+  - Stop / Notification: stop (removes sentinel, watcher exits within 1s)
+
+Mechanism: a detached background watcher process calls
+SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED) in a loop and exits
+when the sentinel file is missing or its heartbeat is older than HEARTBEAT_MAX_AGE.
+Exit clears the execution-state flag automatically.
+
+Safe-exit guard: any exception in hook mode exits 0 so a bug never blocks a prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRATCH = Path("C:/Users/brown/.claude/scratch")
+SENTINEL = SCRATCH / "awake.lock"
+PID_FILE = SCRATCH / "awake.pid"
+LOG_FILE = SCRATCH / "awake.log"
+
+# Heartbeat must be refreshed at least this often. UserPromptSubmit refreshes it on every prompt;
+# if the session crashes or is killed, the watcher self-terminates after this many seconds.
+HEARTBEAT_MAX_AGE = 30 * 60  # 30 minutes
+WATCHER_POLL_INTERVAL = 1.0   # seconds between sentinel checks
+EXEC_STATE_REFRESH = 30.0     # seconds between SetThreadExecutionState calls
+
+# SetThreadExecutionState flags
+ES_CONTINUOUS = 0x80000000
+ES_SYSTEM_REQUIRED = 0x00000001
+
+
+def _log(msg: str) -> None:
+    try:
+        SCRATCH.mkdir(parents=True, exist_ok=True)
+        with LOG_FILE.open("a", encoding="utf-8") as f:
+            f.write(f"{time.strftime('%Y-%m-%dT%H:%M:%S')} pid={os.getpid()} {msg}\n")
+    except Exception:
+        pass
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        # Windows: use tasklist via subprocess (no extra deps)
+        out = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return str(pid) in out.stdout
+    except Exception:
+        return False
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+    os.utime(path, None)
+
+
+def start() -> None:
+    """Ensure a watcher is running and refresh the heartbeat."""
+    SCRATCH.mkdir(parents=True, exist_ok=True)
+    _touch(SENTINEL)
+
+    # Is a watcher already alive?
+    if PID_FILE.exists():
+        try:
+            pid = int(PID_FILE.read_text(encoding="utf-8").strip())
+            if _pid_alive(pid):
+                return
+        except Exception:
+            pass
+
+    # Spawn detached watcher. DETACHED_PROCESS + CREATE_NEW_PROCESS_GROUP keeps it
+    # alive past the hook's exit and disconnects it from the parent's console.
+    DETACHED_PROCESS = 0x00000008
+    CREATE_NEW_PROCESS_GROUP = 0x00000200
+    creationflags = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+
+    proc = subprocess.Popen(
+        ["py", "-3", str(Path(__file__).resolve()), "--watcher"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        creationflags=creationflags,
+        close_fds=True,
+    )
+    try:
+        PID_FILE.write_text(str(proc.pid), encoding="utf-8")
+    except Exception:
+        pass
+    _log(f"spawned watcher pid={proc.pid}")
+
+
+def stop() -> None:
+    """Remove the sentinel; the watcher will exit on its next poll."""
+    try:
+        SENTINEL.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def watcher() -> None:
+    """Background loop: hold the wake-lock while sentinel is fresh."""
+    import ctypes
+    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+    kernel32.SetThreadExecutionState.argtypes = [ctypes.c_uint]
+    kernel32.SetThreadExecutionState.restype = ctypes.c_uint
+
+    _log("watcher start")
+    last_refresh = 0.0
+    try:
+        while True:
+            if not SENTINEL.exists():
+                _log("watcher exit: sentinel missing")
+                break
+            try:
+                age = time.time() - SENTINEL.stat().st_mtime
+            except FileNotFoundError:
+                _log("watcher exit: sentinel removed")
+                break
+            if age > HEARTBEAT_MAX_AGE:
+                _log(f"watcher exit: heartbeat stale ({age:.0f}s)")
+                break
+
+            now = time.time()
+            if now - last_refresh >= EXEC_STATE_REFRESH:
+                kernel32.SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)
+                last_refresh = now
+
+            time.sleep(WATCHER_POLL_INTERVAL)
+    finally:
+        # Clear the flag explicitly (also auto-clears on process exit).
+        try:
+            kernel32.SetThreadExecutionState(ES_CONTINUOUS)
+        except Exception:
+            pass
+        try:
+            PID_FILE.unlink(missing_ok=True)
+        except Exception:
+            pass
+        _log("watcher done")
+
+
+def _hook_event() -> str:
+    # Prefer stdin JSON (Claude Code's hook contract); fall back to env var.
+    try:
+        raw = sys.stdin.read()
+        if raw:
+            data = json.loads(raw)
+            ev = data.get("hook_event_name") or data.get("event") or ""
+            if ev:
+                return ev
+    except Exception:
+        pass
+    return os.environ.get("CLAUDE_HOOK_EVENT_NAME", "")
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--watcher":
+        watcher()
+        return 0
+
+    try:
+        ev = _hook_event()
+        if ev == "UserPromptSubmit":
+            start()
+        elif ev in ("Stop", "Notification"):
+            stop()
+        # Unknown event: no-op.
+    except Exception as exc:
+        _log(f"hook error: {exc!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/scripts/awake-blocker.py
+++ b/claude/scripts/awake-blocker.py
@@ -9,6 +9,9 @@ SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED) in a loop and exits
 when the sentinel file is missing or its heartbeat is older than HEARTBEAT_MAX_AGE.
 Exit clears the execution-state flag automatically.
 
+Platform: Windows only. On non-Windows the hook is a silent no-op (no log line,
+no Popen, no error).
+
 Safe-exit guard: any exception in hook mode exits 0 so a bug never blocks a prompt.
 """
 
@@ -25,6 +28,7 @@ SCRATCH = Path("C:/Users/brown/.claude/scratch")
 SENTINEL = SCRATCH / "awake.lock"
 PID_FILE = SCRATCH / "awake.pid"
 LOG_FILE = SCRATCH / "awake.log"
+LOG_FILE_ROTATED = SCRATCH / "awake.log.1"
 
 # Heartbeat must be refreshed at least this often. UserPromptSubmit refreshes it on every prompt;
 # if the session crashes or is killed, the watcher self-terminates after this many seconds.
@@ -32,30 +36,80 @@ HEARTBEAT_MAX_AGE = 30 * 60  # 30 minutes
 WATCHER_POLL_INTERVAL = 1.0   # seconds between sentinel checks
 EXEC_STATE_REFRESH = 30.0     # seconds between SetThreadExecutionState calls
 
+# Log rotation: when LOG_FILE exceeds this many bytes, rotate to LOG_FILE_ROTATED.
+LOG_MAX_BYTES = 256 * 1024  # 256 KiB
+
+# Watcher process image name — used together with PID to defeat PID-reuse false positives.
+WATCHER_IMAGE = "py.exe"
+
 # SetThreadExecutionState flags
 ES_CONTINUOUS = 0x80000000
 ES_SYSTEM_REQUIRED = 0x00000001
+
+# Notification subtypes for which we should release the wake-lock. Other subtypes
+# (status surfaces, transient banners) leave the lock held so the machine does not
+# sleep mid-turn. If Claude Code's payload omits the subtype field entirely, fall
+# back to releasing (preserves the original ADR-033 behavior).
+NOTIFICATION_IDLE_SUBTYPES = {
+    "permission",          # waiting on user to approve a tool call
+    "permission_request",
+    "waiting_for_input",
+    "idle",
+}
+
+
+def _is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def _rotate_log_if_large() -> None:
+    try:
+        if LOG_FILE.exists() and LOG_FILE.stat().st_size > LOG_MAX_BYTES:
+            # Best-effort single-generation rotation; ignore replace errors.
+            try:
+                if LOG_FILE_ROTATED.exists():
+                    LOG_FILE_ROTATED.unlink()
+            except Exception:
+                pass
+            try:
+                LOG_FILE.replace(LOG_FILE_ROTATED)
+            except Exception:
+                pass
+    except Exception:
+        pass
 
 
 def _log(msg: str) -> None:
     try:
         SCRATCH.mkdir(parents=True, exist_ok=True)
+        _rotate_log_if_large()
         with LOG_FILE.open("a", encoding="utf-8") as f:
             f.write(f"{time.strftime('%Y-%m-%dT%H:%M:%S')} pid={os.getpid()} {msg}\n")
     except Exception:
         pass
 
 
-def _pid_alive(pid: int) -> bool:
+def _pid_is_watcher(pid: int) -> bool:
+    """Return True only if a process with this PID exists AND its image matches WATCHER_IMAGE.
+
+    Filtering on image name defeats PID-reuse false positives: when Windows recycles
+    a dead watcher's PID for an unrelated process, the PID-only check would
+    incorrectly report "watcher alive" and start() would skip spawning, silently
+    dropping sleep protection. tasklist's combined PID + IMAGENAME filter resolves it.
+    """
     if pid <= 0:
         return False
     try:
-        # Windows: use tasklist via subprocess (no extra deps)
         out = subprocess.run(
-            ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+            ["tasklist", "/FI", f"PID eq {pid}", "/FI", f"IMAGENAME eq {WATCHER_IMAGE}", "/NH"],
             capture_output=True, text=True, timeout=5,
         )
-        return str(pid) in out.stdout
+        stdout = out.stdout or ""
+        # When no process matches, tasklist prints "INFO: No tasks are running ...".
+        # On a match, the row contains both the image name and the PID.
+        if "No tasks" in stdout:
+            return False
+        return WATCHER_IMAGE.lower() in stdout.lower() and str(pid) in stdout
     except Exception:
         return False
 
@@ -75,7 +129,7 @@ def start() -> None:
     if PID_FILE.exists():
         try:
             pid = int(PID_FILE.read_text(encoding="utf-8").strip())
-            if _pid_alive(pid):
+            if _pid_is_watcher(pid):
                 return
         except Exception:
             pass
@@ -151,31 +205,58 @@ def watcher() -> None:
         _log("watcher done")
 
 
-def _hook_event() -> str:
-    # Prefer stdin JSON (Claude Code's hook contract); fall back to env var.
+def _read_hook_payload() -> tuple[str, dict]:
+    """Return (event_name, full_payload_dict). Empty event on parse failure."""
     try:
         raw = sys.stdin.read()
         if raw:
             data = json.loads(raw)
             ev = data.get("hook_event_name") or data.get("event") or ""
-            if ev:
-                return ev
+            return ev, data if isinstance(data, dict) else {}
     except Exception:
         pass
-    return os.environ.get("CLAUDE_HOOK_EVENT_NAME", "")
+    return os.environ.get("CLAUDE_HOOK_EVENT_NAME", ""), {}
+
+
+def _notification_should_release(payload: dict) -> bool:
+    """Inspect Notification payload to decide whether to release the wake-lock.
+
+    Claude Code passes additional notification-specific fields alongside
+    hook_event_name. The exact schema varies; we look at the most plausible field
+    names. If none are present, fall back to releasing (the original ADR-033
+    decision — release on every Notification).
+    """
+    for field in ("notification_type", "type", "subtype", "kind"):
+        value = payload.get(field)
+        if isinstance(value, str) and value:
+            return value.lower() in NOTIFICATION_IDLE_SUBTYPES
+    # No subtype information available — preserve original behavior.
+    return True
 
 
 def main() -> int:
     if len(sys.argv) > 1 and sys.argv[1] == "--watcher":
+        # Watcher process: only run on Windows (ctypes.windll is Windows-only).
+        if not _is_windows():
+            return 0
         watcher()
         return 0
 
+    # Hook entry-point. Short-circuit on non-Windows — the wake-lock mechanism
+    # (SetThreadExecutionState, tasklist, DETACHED_PROCESS) is Windows-only, so
+    # there is nothing useful to do elsewhere. Silent no-op (no log line, no Popen).
+    if not _is_windows():
+        return 0
+
     try:
-        ev = _hook_event()
+        ev, payload = _read_hook_payload()
         if ev == "UserPromptSubmit":
             start()
-        elif ev in ("Stop", "Notification"):
+        elif ev == "Stop":
             stop()
+        elif ev == "Notification":
+            if _notification_should_release(payload):
+                stop()
         # Unknown event: no-op.
     except Exception as exc:
         _log(f"hook error: {exc!r}")

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -103,6 +103,10 @@
           {
             "type": "command",
             "command": "py -3 C:/Users/brown/.claude/scripts/reconcile-open-prs.py"
+          },
+          {
+            "type": "command",
+            "command": "py -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
           }
         ]
       }
@@ -117,6 +121,20 @@
           {
             "type": "command",
             "command": "py -3 C:/Users/brown/.claude/scripts/journal-stop-check.py"
+          },
+          {
+            "type": "command",
+            "command": "py -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "py -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
           }
         ]
       }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -143,6 +143,7 @@ Fires on every user prompt, before Claude processes it.
 | `turn-count-hook.py` | Warns when session context accumulates past a threshold. Primary signal: token count; secondary: turn count. Configurable via `"turn_threshold"` in `.claude/hook-config.json` (default: 50). |
 | `multi-worktree-alert.py` | When ≥2 git worktrees are active, emits a list in `repo:branch` format, starring the current one. Fires on every prompt. Suppressed in Claude-managed worktree sessions (`.claude/worktrees/` in cwd). |
 | `reconcile-open-prs.py` | Runs once per session (per-session sentinel in `scratch/`). Calls `gh pr view` for each entry in every `sessions/*/open-prs.jsonl` in engineering-journal; removes entries whose PRs are MERGED or CLOSED; emits a `systemMessage` listing surviving open PRs and any removals. Does not commit — modified files are picked up by the next stub commit. Fails safe: `gh` errors leave the entry intact. [ADR-018](adr/018-reconcile-open-prs-hook.md) |
+| `awake-blocker.py` (start) | On UserPromptSubmit, spawns a detached watcher (if not already running) that holds a Windows system-sleep lock via `kernel32!SetThreadExecutionState(ES_CONTINUOUS \| ES_SYSTEM_REQUIRED)`. Refreshes the sentinel heartbeat on every prompt. Watcher self-terminates if the sentinel is missing or older than 30 minutes (crash safety). Idempotent. Display sleep is not blocked — only system sleep. [ADR-033](adr/033-prevent-system-sleep-while-processing.md) |
 
 ---
 
@@ -188,6 +189,7 @@ Fires when the Claude Code session ends (user exits or `/stop`).
 |--------|-------------|
 | `token-tracker.py` | Reads the session JSONL, aggregates token usage, and appends a record to `~/.claude/scratch/token-sessions.jsonl`. Supports Sonnet 4.6, Opus 4.6, and Haiku 4.5 pricing. |
 | `journal-stop-check.py` | Checks for the stub-push sentinel flag (emits a closing message reminding the user to archive if found), then checks for stale open journal stubs and unmerged draft branches, emitting a closing message if any are found. Exit 0 always. |
+| `awake-blocker.py` (stop) | Removes the sleep-block sentinel; the detached watcher polls every second and exits within ~1s, releasing the system-sleep lock. Also registered on `Notification` for the same effect when Claude pauses for input/permission. [ADR-033](adr/033-prevent-system-sleep-while-processing.md) |
 
 ---
 

--- a/docs/adr/033-prevent-system-sleep-while-processing.md
+++ b/docs/adr/033-prevent-system-sleep-while-processing.md
@@ -24,8 +24,8 @@ Three constraints shape any hook-based approach:
 
 Add `claude/scripts/awake-blocker.py`, a single script with three modes:
 
-- **`start` mode** — invoked from `UserPromptSubmit`. Touches a sentinel file (`scratch/awake.lock`) to refresh its mtime as a heartbeat. If `scratch/awake.pid` names a live process, returns immediately. Otherwise spawns a detached watcher (`subprocess.Popen` with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`) running this same script with `--watcher`, and writes the watcher PID to `awake.pid`.
-- **`stop` mode** — invoked from `Stop` and `Notification`. Deletes the sentinel file. The watcher's next poll (within 1 second) observes the missing sentinel, clears the execution-state flag, and exits.
+- **`start` mode** — invoked from `UserPromptSubmit`. Touches a sentinel file (`scratch/awake.lock`) to refresh its mtime as a heartbeat. If `scratch/awake.pid` names a live process **whose image name is `py.exe`**, returns immediately. The image-name filter defeats Windows PID-reuse false positives: a dead watcher's PID can be recycled for an unrelated process, and a PID-only check would silently skip respawning. Otherwise spawns a detached watcher (`subprocess.Popen` with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`) running this same script with `--watcher`, and writes the watcher PID to `awake.pid`.
+- **`stop` mode** — invoked from `Stop` and (subtype-aware) `Notification`. Deletes the sentinel file. The watcher's next poll (within 1 second) observes the missing sentinel, clears the execution-state flag, and exits.
 - **`--watcher` mode** — the detached background loop. Every second: check sentinel exists; check sentinel mtime is within 30 minutes; call `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)` every 30 seconds (no need to call on every poll). On loop exit: explicitly clear the flag via `SetThreadExecutionState(ES_CONTINUOUS)` and remove `awake.pid`.
 
 Wire into `settings.json` hooks:
@@ -47,6 +47,10 @@ The hook entry-point dispatches on the `hook_event_name` field from the stdin JS
 **Why `ES_SYSTEM_REQUIRED` only, not `ES_DISPLAY_REQUIRED`.** The goal is to keep computation running, not to keep the monitor lit. Display sleep is a separate user-visible behavior and should follow the user's power-plan settings.
 
 **Why three hook events, not two.** `Stop` fires when Claude's turn ends. `Notification` fires when Claude is explicitly waiting on user input or permission — same semantic ("Claude is idle") but happens mid-turn. Both should release the lock so the machine can sleep during a permission-prompt pause.
+
+**Why subtype-aware Notification handling.** `Notification` may fire for non-idle reasons (status surfaces, transient banners). The hook inspects the payload's `notification_type` / `type` / `subtype` / `kind` field and only releases the wake-lock on idle/permission-wait subtypes. If no subtype field is present, it falls back to releasing — preserving the original behavior on Claude Code builds whose payload lacks the field.
+
+**Why an explicit non-Windows short-circuit.** Without it, every UserPromptSubmit on Linux/macOS would invoke `Popen(["py", "-3", ...])` with Windows-only `creationflags`, the safe-exit guard would catch the failure, and a `hook error:` line would accumulate in `awake.log` on every prompt. The platform check at the top of `main()` makes the hook a true no-op off-Windows: no log line, no Popen, no error.
 
 **Why not PowerToys Awake.** PowerToys Awake is an external dependency and provides no hook-driven start/stop. The ctypes approach is self-contained, ~150 lines, and ships with the dev-env repo.
 
@@ -71,7 +75,9 @@ The hook entry-point dispatches on the `hook_event_name` field from the stdin JS
 - No external dependencies — pure stdlib + ctypes.
 
 **Negative:**
-- Windows-only. The script no-ops cleanly on other platforms (the ctypes call is gated inside `--watcher` mode and would raise on import; the hook-mode dispatch never reaches it), but the feature provides no value outside Windows.
+- Windows-only. The hook short-circuits cleanly on other platforms via a `sys.platform == "win32"` check in `main()` — no log line, no Popen, no error — but the feature provides no value outside Windows.
 - One additional hook script in three hook events. Hook overhead is ~50ms per invocation per [ADR-027](027-userpromptsubmit-blocking-hook-conventions.md) measurements; the start path is a fast PID-alive check when a watcher is already running.
-- A detached background `py` process appears in Task Manager while a session is active. Documented behavior.
+- A detached background `py.exe` process appears in Task Manager while a session is active. Documented behavior.
 - External CI waiting after `Stop` fires (user has returned control to Claude, Claude has returned, user is now waiting on remote CI) is not covered — hooks have no signal for "user is watching CI". Out of scope.
+- **Multi-session sentinel is shared.** Two concurrent Claude sessions share a single `awake.lock` / `awake.pid`. If session A's `Stop` fires while session B is still mid-turn, the watcher exits within ~1 s; session B's next `UserPromptSubmit` respawns a watcher, but the gap window is real. Acceptable for single-session use; multi-session use should accept brief lapses or extend the script to track active session IDs in the sentinel.
+- `awake.log` is single-generation rotated at 256 KiB (`awake.log` → `awake.log.1`). Older history is overwritten.

--- a/docs/adr/033-prevent-system-sleep-while-processing.md
+++ b/docs/adr/033-prevent-system-sleep-while-processing.md
@@ -1,0 +1,77 @@
+# ADR-033 — Prevent System Sleep While Claude Is Processing
+
+**Date:** 2026-05-29
+**Status:** Accepted
+**Closes:** [dev-env#288](https://github.com/brownm09/dev-env/issues/288)
+**Tags:** hooks, windows, sleep, UserPromptSubmit, Stop, Notification, background-process
+**Related:** [ADR-006](006-dev-env-sync-on-every-prompt.md), [ADR-027](027-userpromptsubmit-blocking-hook-conventions.md)
+
+---
+
+## Context
+
+On Windows, long Claude turns (large agent fan-out, multi-file edits, CI polling) can run past the system idle-sleep timeout. When the machine sleeps, the Claude process tree is suspended; on wake, the session must resume from a degraded state. Manually toggling sleep settings or launching [Microsoft PowerToys Awake](https://learn.microsoft.com/en-us/windows/powertoys/awake) before every long session is friction, and global "never sleep" is overkill — sleep is desirable when Claude is idle (waiting on input or permission).
+
+Three constraints shape any hook-based approach:
+
+1. **Hook scripts are short-lived child processes.** Calling Windows' [`SetThreadExecutionState`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate) directly from a hook does nothing — the flag clears on process exit. The wake-lock must be held by a persistent process the hook spawns.
+2. **Orphan-safety.** If the Claude session crashes or is killed, no Stop hook fires. A naive long-lived watcher would leave the machine permanently awake. The watcher needs a heartbeat-with-timeout.
+3. **Idempotency.** UserPromptSubmit fires on every prompt. Spawning a new watcher each time would leak processes; spawning a watcher when one is already healthy is wasted work.
+
+---
+
+## Decision
+
+Add `claude/scripts/awake-blocker.py`, a single script with three modes:
+
+- **`start` mode** — invoked from `UserPromptSubmit`. Touches a sentinel file (`scratch/awake.lock`) to refresh its mtime as a heartbeat. If `scratch/awake.pid` names a live process, returns immediately. Otherwise spawns a detached watcher (`subprocess.Popen` with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`) running this same script with `--watcher`, and writes the watcher PID to `awake.pid`.
+- **`stop` mode** — invoked from `Stop` and `Notification`. Deletes the sentinel file. The watcher's next poll (within 1 second) observes the missing sentinel, clears the execution-state flag, and exits.
+- **`--watcher` mode** — the detached background loop. Every second: check sentinel exists; check sentinel mtime is within 30 minutes; call `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)` every 30 seconds (no need to call on every poll). On loop exit: explicitly clear the flag via `SetThreadExecutionState(ES_CONTINUOUS)` and remove `awake.pid`.
+
+Wire into `settings.json` hooks:
+
+- `UserPromptSubmit` — append `awake-blocker.py`
+- `Stop` — append `awake-blocker.py`
+- `Notification` — register `awake-blocker.py` (new hook block)
+
+The hook entry-point dispatches on the `hook_event_name` field from the stdin JSON Claude Code passes to every hook ([hooks reference](https://docs.claude.com/en/docs/claude-code/hooks)).
+
+---
+
+## Rationale
+
+**Why a sentinel file rather than a pipe/socket.** Files survive crashes; a pipe/socket requires a coordinated handshake to clean up. File mtime gives us the heartbeat for free.
+
+**Why a 30-minute heartbeat timeout.** Long enough that the largest realistic single turn (multi-agent workflow, CI poll loop) will not stale out, short enough that an orphaned watcher cannot keep the machine awake overnight. The heartbeat is refreshed on every UserPromptSubmit, so any interactive session resets the timer.
+
+**Why `ES_SYSTEM_REQUIRED` only, not `ES_DISPLAY_REQUIRED`.** The goal is to keep computation running, not to keep the monitor lit. Display sleep is a separate user-visible behavior and should follow the user's power-plan settings.
+
+**Why three hook events, not two.** `Stop` fires when Claude's turn ends. `Notification` fires when Claude is explicitly waiting on user input or permission — same semantic ("Claude is idle") but happens mid-turn. Both should release the lock so the machine can sleep during a permission-prompt pause.
+
+**Why not PowerToys Awake.** PowerToys Awake is an external dependency and provides no hook-driven start/stop. The ctypes approach is self-contained, ~150 lines, and ships with the dev-env repo.
+
+**Why a single script with mode dispatch instead of three.** The watcher and the hook entry-point share the sentinel/PID-file paths and constants. Splitting would duplicate that contract. The script is small enough that the dispatch is trivial.
+
+---
+
+## Alternatives considered
+
+- **`powercfg /requestsoverride PROCESS claude.exe SYSTEM DISPLAY`** — persistent across reboots, no hook needed. Rejected: blanket "never sleep when Claude is installed" defeats the goal of allowing idle sleep.
+- **PowerToys Awake CLI from hooks** — `Start-Process PowerToys.Awake.exe --time-limit 0` from start hook, `Stop-Process` from stop hook. Rejected: external dependency, PID-file management still needed, no equivalent heartbeat-with-timeout safety.
+- **Per-turn PowerShell wrapper** (`claude-awake` function in `$PROFILE`) — works without hooks but requires the user to remember to invoke a different command. Useful as a fallback for users who do not want hook spawn behavior; not mutually exclusive with this ADR.
+
+---
+
+## Consequences
+
+**Positive:**
+- Long Claude turns complete without hitting Windows sleep.
+- Idle waits (waiting on user, after Stop) allow normal sleep.
+- Crash-safe: orphaned watcher self-terminates within 30 minutes.
+- No external dependencies — pure stdlib + ctypes.
+
+**Negative:**
+- Windows-only. The script no-ops cleanly on other platforms (the ctypes call is gated inside `--watcher` mode and would raise on import; the hook-mode dispatch never reaches it), but the feature provides no value outside Windows.
+- One additional hook script in three hook events. Hook overhead is ~50ms per invocation per [ADR-027](027-userpromptsubmit-blocking-hook-conventions.md) measurements; the start path is a fast PID-alive check when a watcher is already running.
+- A detached background `py` process appears in Task Manager while a session is active. Documented behavior.
+- External CI waiting after `Stop` fires (user has returned control to Claude, Claude has returned, user is now waiting on remote CI) is not covered — hooks have no signal for "user is watching CI". Out of scope.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -37,3 +37,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [030](030-baseline-test-failure-policy.md) | Pre-existing Test Failure Policy: Baseline + Fix-on-Touch | 2026-05-27 | Accepted | testing, quality, pre-pr, baseline, fix-on-touch, workflow |
 | [031](031-auto-merge-disabled.md) | Auto-Merge Disabled Across All Repos | 2026-05-28 | Accepted | git, pr, merge, workflow, hooks, post-merge |
 | [032](032-journal-start-here-dashboard.md) | Top-of-README "Start here" Dashboard in journal-compose | 2026-05-28 | Accepted | journal, composition, skill, readme, manifest, dashboard |
+| [033](033-prevent-system-sleep-while-processing.md) | Prevent System Sleep While Claude Is Processing | 2026-05-29 | Accepted | hooks, windows, sleep, UserPromptSubmit, Stop, Notification, background-process |


### PR DESCRIPTION
## Summary

Hook-driven sleep prevention for Windows. UserPromptSubmit blocks system sleep; Stop / Notification releases it. Machine sleeps only while Claude is idle (waiting on user input or permission).

- New script `claude/scripts/awake-blocker.py` with `start` / `stop` / `--watcher` modes.
- Registered in `settings.json` on UserPromptSubmit, Stop, and (new block) Notification.
- Detached watcher holds `SetThreadExecutionState(ES_CONTINUOUS \| ES_SYSTEM_REQUIRED)`; sentinel file + 30-min heartbeat timeout for orphan safety.
- ADR-033 records design and alternatives.

Closes #288

## Testing

`py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py` — OK.
`py -3 -c "import json; json.load(open('claude/settings.json'))"` — OK (validated settings.json shape).

No automated tests for hook scripts in this repo. Manual verification deferred to post-merge (the script only takes effect once `~/.claude/settings.json` symlink picks up the merged file, which requires being on `main` in the canonical worktree). Verification plan: open a session, run a long agent fan-out, confirm machine does not sleep; let Stop fire, confirm watcher exits (check `scratch/awake.log`).

Tests: 0 passed, 0 skipped, 0 failed (syntax-only).

### Coverage gate

No automated test infrastructure in dev-env covers hook-script behavior. The watcher's correctness depends on Windows API and OS scheduler behavior that is impractical to fake. Deferring tests is consistent with how other hook scripts in `claude/scripts/` are validated (syntax + manual).

### Suppression / test-integrity / baseline checks

- Suppression policy patterns target TS/JS — not applicable to a pure-Python change. No `# type: ignore`, `# noqa`, or equivalent silencers added.
- No test-integrity violations (no test files modified).
- Baseline-tests not configured for dev-env.

## ADR-warrant + doc-reconciliation

- ADR-033 added; INDEX updated.
- README hooks table + REFERENCE UserPromptSubmit and Stop sections updated.