### PR TITLE
journal-compose: add fidelity guard and canonical-path check

### DIFF
--- a/claude/skills/journal-compose/SKILL.md
+++ b/claude/skills/journal-compose/SKILL.md
@@ -216,9 +216,13 @@ Step 4 — Fetch real token data. Sanitize the project name first (slashes → u
   then parse as shown in SKILL.md Step 4.
 
 Step 5 — Compose the 11-section document. Follow SKILL.md Step 5 exactly.
+  **Fidelity floor.** Your composed dialogue sections must preserve the technical detail in the source stubs. As a rough heuristic, your composed document's line count should be ≥ 80% of the combined stub line count. A journal that compresses to < 50% of source-stub length is a quality failure — re-read the stubs and expand before writing. Reproduce code blocks, file paths, exact PR/issue numbers, and decision rationale verbatim where the stub provides them. Synthesis is allowed only when stubs duplicate each other; raw compression of unique content is not.
 
 Step 6 — Write the output file to:
   C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD-<slug>.md
+  **Canonical path check.** Your output path must begin with `C:/Users/brown/Git/engineering-journal/sessions/<project>/`. If your current working directory is a worktree (path contains `.claude/worktrees/`), DO NOT use the worktree-relative path — use the absolute canonical path. Writing to a worktree path requires a post-hoc file move and breaks the commit flow.
+
+Step 6.5 — Self-check before claiming done. After writing the file, run `wc -l` on it and compare to the combined source stub line count. If the journal is < 50% of source length, the compose is incomplete — expand it before proceeding. Report the ratio in your final status as `LINE_COUNT=<n> SOURCE_LINES=<m> FIDELITY=<n/m>`.
 
 Do NOT do Steps 7–11 (no README edits, no git add/commit/push, no PR).
 
@@ -226,6 +230,9 @@ When done, report exactly this structure:
   OUTPUT_FILE=<absolute path>
   SLUG=<slug>
   META_TRIGGERS=<none | comma-separated list of trigger types found>
+  LINE_COUNT=<n>
+  SOURCE_LINES=<m>
+  FIDELITY=<n/m>
   STATUS=done
 ```
 
@@ -500,6 +507,8 @@ Reformat for readability (code fences, bullets) but preserve meaning.
 
 Label sessions: `## Session 1 — <slug title>`, `## Session 2 — <slug title>`, etc.
 
+**Fidelity floor.** The composed dialogue sections must preserve the technical detail in the source stubs. As a rough heuristic, the composed document's line count should be ≥ 80% of the combined stub line count. A journal that compresses to < 50% of source-stub length is a quality failure — re-read the stubs and expand before writing. Reproduce code blocks, file paths, exact PR/issue numbers, and decision rationale verbatim where the stub provides them. Synthesis is allowed only when stubs duplicate each other; raw compression of unique content is not.
+
 ---
 
 ### Section 6 — Open Items / Next Steps
@@ -713,6 +722,12 @@ Write the composed document to:
 ```
 C:/Users/brown/Git/engineering-journal/sessions/<project>/YYYY-MM-DD-<slug>.md
 ```
+
+- **Canonical path check.** The output path must begin with `C:/Users/brown/Git/engineering-journal/sessions/<project>/`. If the current working directory is a worktree (path contains `.claude/worktrees/`), DO NOT use the worktree-relative path — use the absolute canonical path. Writing to a worktree path requires a post-hoc file move and breaks the commit flow.
+
+## Step 6.5 — Self-check before claiming done
+
+After writing the file, run `wc -l` on it and compare to the combined source stub line count. If the journal is < 50% of source length, the compose is incomplete — expand it before proceeding. Report the ratio in your final status: `LINE_COUNT=<n> SOURCE_LINES=<m> FIDELITY=<n/m>`.
 
 ## Step 7 — Update the folder README
 


### PR DESCRIPTION
## Summary

Three additions to `claude/skills/journal-compose/SKILL.md` to prevent under-fidelity journals from shipping:

1. **Fidelity floor** (Step 5 + Phase 1 subagent template) — composed dialogue must preserve technical detail; >=80% of combined stub line count is the target, <50% is a quality failure requiring re-read and expansion.
2. **Canonical-path check** (Step 6 + Phase 1 subagent template) — output must go to the canonical `engineering-journal/sessions/<project>/` path, never a `.claude/worktrees/` path.
3. **Step 6.5 self-check** — `wc -l` the output, compare to combined stub lines, abort+expand if <50%, report `LINE_COUNT/SOURCE_LINES/FIDELITY` in final status.

## Motivation

During a 3-day backfill compose run, Haiku subagents over-compressed several journals. The worst case: `dev-env/2026-05-27` produced a 60-line journal from 10 stubs totaling 477 lines (~12% fidelity). A secondary issue: subagents wrote output to worktree-relative paths, forcing post-hoc moves.

## Testing

Docs-only change to a skill markdown file. Ran the hook script syntax check from CLAUDE.md → Testing: `py -3 -c "import ast,...; ..."` against `claude/scripts/*.py` — OK (no Python changes, just verifying the repo invariant holds).

Tests: 0 passed, 0 skipped, 0 failed (n/a — docs-only).

No suppressions, no test-integrity violations, no new test coverage required (skill behavior change is procedural guidance to the model, not executable code).

Closes #290