### PR TITLE
Use pyw -3 for hook commands to suppress console window flash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@ Run from the repo root to verify all hook scripts are syntax-clean:
 py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
 ```
 
+Additionally, run the `pyw -3` stdio verification (Windows-only — confirms `pythonw.exe` honors parent-supplied pipes, the invariant ADR-007's 2026-06-01 decision relies on):
+
+```bash
+py -3 claude/scripts/tests/test_pyw_stdio.py
+```
+
 (On Windows, `python3` resolves to the Microsoft Store stub; use `py -3` — see [ADR-007](docs/adr/007-hook-command-invocation.md).)
 
 For docs-only changes to `claude/CLAUDE.md`: run `grep -n 'date -u' claude/CLAUDE.md` and

--- a/claude/scripts/tests/test_pyw_stdio.py
+++ b/claude/scripts/tests/test_pyw_stdio.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Verify `pyw -3` stdio behavior for Claude Code hook compatibility.
+
+`pythonw.exe` (which `pyw -3` resolves to) is built against the Windows
+subsystem rather than the console subsystem. The known wrinkle: when the
+parent process does NOT supply stdio handles, `pythonw` leaves
+`sys.stdin`, `sys.stdout`, and `sys.stderr` set to `None` instead of
+wiring them to a console. Any hook script that touches stdio under those
+conditions would crash with `AttributeError: 'NoneType' object has no
+attribute 'read'` (or `write`, or `flush`).
+
+Claude Code spawns hooks with stdio pipes (it has to — that's how it
+delivers the hook event payload as JSON on stdin and reads the
+`systemMessage` JSON back on stdout). So the question is empirical: does
+`pyw -3` honor parent-supplied pipes the same way `py -3` does?
+
+This test answers that question by running `pyw -3` under
+`subprocess.Popen` with `stdin=PIPE, stdout=PIPE, stderr=PIPE` — exactly
+the shape Claude Code uses — and asserting:
+
+  1. `sys.stdin`, `sys.stdout`, `sys.stderr` are all non-None inside the
+     child.
+  2. Bytes written to the child's stdin are readable via `sys.stdin.read()`.
+  3. Bytes the child writes to `sys.stdout` reach the parent intact.
+  4. A synthetic Claude-Code-shaped hook (reads JSON on stdin, writes
+     `systemMessage` JSON to stdout, exits 0) round-trips correctly.
+  5. Every hook script referenced from `claude/settings.json` exists on
+     disk under `claude/scripts/` and is syntactically valid Python —
+     the test does not invoke real hooks (many have side effects:
+     scratch writes, git fetches, project board mutations).
+
+If any check fails, the `pyw -3` swap in `claude/settings.json` is not
+safe and should be reverted.
+
+Usage:
+    py -3 claude/scripts/tests/test_pyw_stdio.py
+
+The test runs under `py -3` (a console-attached parent); the
+subprocess invocations under test are `pyw -3`. Exit 0 = all pass.
+"""
+
+import ast
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# tests/ -> scripts/ -> claude/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SETTINGS = REPO_ROOT / "claude" / "settings.json"
+HOOKS_DIR = REPO_ROOT / "claude" / "scripts"
+
+
+def _require_pyw() -> str:
+    pyw = shutil.which("pyw")
+    if not pyw:
+        raise RuntimeError(
+            "`pyw` is not on PATH. This test only runs on Windows with the "
+            "python.org Python Launcher installed. ADR-007 covers the "
+            "Windows-only scope of the hook invocation rule."
+        )
+    return pyw
+
+
+def test_pyw_stdio_wired_when_parent_supplies_pipes() -> str:
+    """Direct invariant: pyw -3 with subprocess.PIPE must NOT leave stdio None."""
+    _require_pyw()
+    program = (
+        "import sys, json\n"
+        "payload = sys.stdin.read()\n"
+        "result = {\n"
+        "    'stdin_is_none': sys.stdin is None,\n"
+        "    'stdout_is_none': sys.stdout is None,\n"
+        "    'stderr_is_none': sys.stderr is None,\n"
+        "    'stdin_payload': payload,\n"
+        "}\n"
+        "sys.stdout.write(json.dumps(result))\n"
+        "sys.stdout.flush()\n"
+        "sys.stderr.write('stderr-channel-ok')\n"
+    )
+    input_payload = '{"hook_event_name":"UserPromptSubmit","prompt":"probe"}'
+    proc = subprocess.run(
+        ["pyw", "-3", "-c", program],
+        input=input_payload,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"pyw -3 -c <program> exited {proc.returncode}; "
+            f"stderr={proc.stderr!r}"
+        )
+    try:
+        result = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise AssertionError(
+            f"pyw stdout was not valid JSON (suggests stdio truncation): "
+            f"stdout={proc.stdout!r}; error={e}"
+        )
+    if result["stdin_is_none"]:
+        raise AssertionError("sys.stdin is None inside pyw -3 child")
+    if result["stdout_is_none"]:
+        raise AssertionError("sys.stdout is None inside pyw -3 child")
+    if result["stderr_is_none"]:
+        raise AssertionError("sys.stderr is None inside pyw -3 child")
+    if result["stdin_payload"] != input_payload:
+        raise AssertionError(
+            f"stdin payload round-trip mismatch: sent {input_payload!r}, "
+            f"received {result['stdin_payload']!r}"
+        )
+    if proc.stderr != "stderr-channel-ok":
+        raise AssertionError(
+            f"stderr channel not propagated: got {proc.stderr!r}"
+        )
+    return "stdin/stdout/stderr all wired; stdin payload round-trips; stderr channel propagates"
+
+
+def test_pyw_runs_claude_code_shaped_hook_end_to_end() -> str:
+    """End-to-end: a hook that mimics Claude Code's contract must work."""
+    _require_pyw()
+    # Synthetic hook: reads a JSON event from stdin, writes a Claude-shaped
+    # JSON response to stdout (the `{"systemMessage": "..."}` pattern used
+    # by real hooks like post-compact.py and dev-env-sync.py), exits 0.
+    synthetic = (
+        "import sys, json\n"
+        "event = json.loads(sys.stdin.read())\n"
+        "resp = {'systemMessage': 'echo:' + event.get('hook_event_name','')}\n"
+        "sys.stdout.write(json.dumps(resp))\n"
+        "sys.stdout.flush()\n"
+        "sys.exit(0)\n"
+    )
+    event_payload = json.dumps(
+        {
+            "session_id": "test",
+            "hook_event_name": "PostCompact",
+            "transcript_path": "",
+            "cwd": str(REPO_ROOT),
+        }
+    )
+    proc = subprocess.run(
+        ["pyw", "-3", "-c", synthetic],
+        input=event_payload,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"synthetic hook exited {proc.returncode}; stderr={proc.stderr!r}"
+        )
+    resp = json.loads(proc.stdout)
+    if resp.get("systemMessage") != "echo:PostCompact":
+        raise AssertionError(
+            f"synthetic hook response wrong: {resp!r}"
+        )
+    return "Claude-Code-shaped JSON-in/JSON-out hook contract works under pyw -3"
+
+
+def _collect_hook_scripts() -> list[str]:
+    """Pull every distinct script path referenced from settings.json hook commands."""
+    settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    hooks = settings.get("hooks", {})
+    scripts: set[str] = set()
+    for event_entries in hooks.values():
+        for entry in event_entries:
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command", "")
+                parts = cmd.split()
+                # Expected shape: "pyw -3 C:/.../scripts/<name>.py"
+                if len(parts) >= 3 and parts[2].endswith(".py"):
+                    scripts.add(parts[2])
+    return sorted(scripts)
+
+
+def test_all_settings_hooks_use_pyw_and_resolve_to_repo() -> str:
+    """Every hook command must invoke `pyw -3` and point at a real script in this repo."""
+    settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    hooks = settings.get("hooks", {})
+    bad_launcher: list[str] = []
+    missing: list[str] = []
+    syntax_errors: list[str] = []
+    total = 0
+    for event_entries in hooks.values():
+        for entry in event_entries:
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command", "")
+                parts = cmd.split()
+                if len(parts) < 3 or not parts[2].endswith(".py"):
+                    continue
+                total += 1
+                launcher = parts[0]
+                if launcher != "pyw":
+                    bad_launcher.append(cmd)
+                    continue
+                local = HOOKS_DIR / Path(parts[2]).name
+                if not local.exists():
+                    missing.append(local.name)
+                    continue
+                try:
+                    ast.parse(local.read_text(encoding="utf-8"), filename=str(local))
+                except SyntaxError as e:
+                    syntax_errors.append(f"{local.name}: {e}")
+    problems: list[str] = []
+    if bad_launcher:
+        problems.append(f"non-pyw launchers: {bad_launcher}")
+    if missing:
+        problems.append(f"missing scripts: {missing}")
+    if syntax_errors:
+        problems.append("syntax errors:\n  " + "\n  ".join(syntax_errors))
+    if problems:
+        raise AssertionError("\n".join(problems))
+    return f"{total} hook commands all use `pyw -3` and resolve to syntactically valid scripts in {HOOKS_DIR.name}/"
+
+
+def main() -> int:
+    tests = [
+        ("pyw -3 stdio wired when parent supplies pipes", test_pyw_stdio_wired_when_parent_supplies_pipes),
+        ("pyw -3 runs Claude-Code-shaped hook end-to-end", test_pyw_runs_claude_code_shaped_hook_end_to_end),
+        ("all settings.json hooks use pyw -3 and resolve", test_all_settings_hooks_use_pyw_and_resolve_to_repo),
+    ]
+    failed = 0
+    passed_names: list[str] = []
+    for name, fn in tests:
+        try:
+            detail = fn()
+            print(f"PASS: {name}")
+            print(f"      {detail}")
+            passed_names.append(name)
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL: {name}")
+            for line in str(e).splitlines():
+                print(f"      {line}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR: {name}: {type(e).__name__}: {e}")
+    print()
+    print(f"Tests: {len(tests) - failed} passed, 0 skipped, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -33,11 +33,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/pre-commit-branch-check.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/pre-commit-branch-check.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/pre-pr-create-check.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/pre-pr-create-check.py"
           }
         ]
       },
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
           }
         ]
       },
@@ -55,7 +55,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
           }
         ]
       },
@@ -64,7 +64,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/pre-tool-use-worktree-path-check.py"
           }
         ]
       }
@@ -74,39 +74,39 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/session-mode-prompt.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/session-mode-prompt.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/dev-env-sync.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/dev-env-sync.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/new-day-journal-check.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/new-day-journal-check.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/journal-onboard-check.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/journal-onboard-check.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/turn-count-hook.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/turn-count-hook.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/multi-worktree-alert.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/multi-worktree-alert.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/worktree-npm-install.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/worktree-npm-install.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/reconcile-open-prs.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/reconcile-open-prs.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
           }
         ]
       }
@@ -116,15 +116,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/token-tracker.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/token-tracker.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/journal-stop-check.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/journal-stop-check.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
           }
         ]
       }
@@ -134,7 +134,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/awake-blocker.py"
           }
         ]
       }
@@ -144,7 +144,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/post-compact.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/post-compact.py"
           }
         ]
       }
@@ -155,27 +155,27 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/pr-merge-reminder.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/pr-merge-reminder.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/post-tool-use.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/post-tool-use.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/post-pr-merge-pull.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/post-pr-merge-pull.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/stub-push-archive-reminder.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/stub-push-archive-reminder.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/post-pr-merge-project.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/post-pr-merge-project.py"
           },
           {
             "type": "command",
-            "command": "py -3 C:/Users/brown/.claude/scripts/usage-snapshot.py"
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/usage-snapshot.py"
           }
         ]
       }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -116,7 +116,7 @@ Scaffolds a new project's journal home (`sessions/<slug>/`) in engineering-journ
 Most hooks are **advisory** — they emit `systemMessage` reminders but do not block tool execution. The exception is `pre-tool-use-worktree-path-check.py` (a `PreToolUse` hook), which exits 2 with a `{"reason": "..."}` payload to block `Write`, `Edit`, and `NotebookEdit` calls that target the canonical repo root instead of the active worktree.
 
 Configuration is in `claude/settings.json` (symlinked to `~/.claude/settings.json`).
-See [ADR-007](adr/007-hook-command-invocation.md) for why hooks invoke scripts via `py -3` (the Windows Python Launcher) rather than `python3` directly or wrapped in `bash -c`.
+See [ADR-007](adr/007-hook-command-invocation.md) for why hooks invoke scripts via `pyw -3` (the windowless variant of the Windows Python Launcher) rather than `python3` directly, wrapped in `bash -c`, or via `py -3` (which flashes a console window per spawn). Shell-invoked Python (the `## Testing` command, the `pre-push` hook) continues to use `py -3`.
 
 #### Machine-local permissions
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -116,7 +116,7 @@ Scaffolds a new project's journal home (`sessions/<slug>/`) in engineering-journ
 Most hooks are **advisory** — they emit `systemMessage` reminders but do not block tool execution. The exception is `pre-tool-use-worktree-path-check.py` (a `PreToolUse` hook), which exits 2 with a `{"reason": "..."}` payload to block `Write`, `Edit`, and `NotebookEdit` calls that target the canonical repo root instead of the active worktree.
 
 Configuration is in `claude/settings.json` (symlinked to `~/.claude/settings.json`).
-See [ADR-007](adr/007-hook-command-invocation.md) for why hooks invoke scripts via `pyw -3` (the windowless variant of the Windows Python Launcher) rather than `python3` directly, wrapped in `bash -c`, or via `py -3` (which flashes a console window per spawn). Shell-invoked Python (the `## Testing` command, the `pre-push` hook) continues to use `py -3`.
+See [ADR-007](adr/007-hook-command-invocation.md) for why hooks invoke scripts via `pyw -3` (the windowless variant of the Windows Python Launcher) rather than `python3` directly, wrapped in `bash -c`, or via `py -3` (which flashes a console window per spawn). Shell-invoked Python (the `## Testing` command, skill `py -3` examples, and the `pre-push` hook) continues to use `py -3`.
 
 #### Machine-local permissions
 

--- a/docs/adr/007-hook-command-invocation.md
+++ b/docs/adr/007-hook-command-invocation.md
@@ -45,24 +45,37 @@ The failure mode this ADR predicted occurred. On this machine, `python3` resolve
 - Absolute path (`C:/.../Python312/python.exe`) is deterministic but breaks on every Python upgrade.
 - `py -3` defers version selection to the Python Launcher, which discovers all installed Pythons and picks the latest Python 3.
 
+### 2026-06-01 — Switched hook commands `py -3` → `pyw -3` ([dev-env#294](https://github.com/brownm09/dev-env/issues/294))
+
+`py.exe` invokes `python.exe`, which is built against the Windows console subsystem. Each hook spawn briefly allocates and tears down a console window — visible as a flash on every prompt and tool call. With ~25 hooks across PreToolUse, UserPromptSubmit, Stop, PostToolUse, etc., the flashes are frequent enough to be a persistent cosmetic annoyance.
+
+**Fix:** Swap `py -3` → `pyw -3` in `settings.json` hook commands only. `pyw.exe` is the Python Launcher's windowless variant — it invokes `pythonw.exe` (Windows subsystem), so no console allocation. Stdin/stdout/stderr still work normally over the pipes Claude Code wires to the subprocess.
+
+**Scope:** Hook command entries only. Left unchanged:
+- `Bash(py -3 *)` permission entries — these govern Claude running `py` via the Bash tool, which executes inside the existing Git Bash shell and does not pop a window.
+- The `## Testing` command and skill/script `py -3` examples — these run from a shell.
+- The `pre-push` hook — runs from a shell (`git push` context).
+
 ---
 
 ## Decision
 
-Invoke hook scripts as **`py -3 C:/path/to/script.py`** — no `bash -c` wrapper, no bare `python3`.
+Invoke hook scripts as **`pyw -3 C:/path/to/script.py`** in `settings.json` hook command entries — no `bash -c` wrapper, no bare `python3`, no `py -3` (which flashes a console window per spawn).
 
-`py.exe` (the Windows Python Launcher) must be installed and on the Windows system PATH. It ships with python.org installers by default.
+Outside of `settings.json` hook commands, continue to use `py -3` (shell-invoked contexts do not flash).
 
-If a future Claude Code version invokes hooks through a different shell context (e.g., a hook runner that pre-resolves to Git Bash where `python3` is the user-shell alias), this decision may revisit. Until then, `py -3` is the only invocation that works reliably from Claude Code's non-interactive hook context on Windows.
+`py.exe` and `pyw.exe` both ship with the python.org installer's Python Launcher for Windows.
+
+If a future Claude Code version invokes hooks through a different shell context (e.g., a hook runner that pre-resolves to Git Bash where `python3` is the user-shell alias), this decision may revisit. Until then, `pyw -3` is the invocation that works reliably from Claude Code's non-interactive hook context on Windows without flashing a console.
 
 ---
 
 ## Consequences
 
-- All hook entries in `settings.json` use `py -3 C:/...` syntax.
-- The `## Testing` test commands in this repo and downstream projects also use `py -3` — running `python3 -m py_compile ...` would silently no-op on this machine.
-- Any new hook added to this repo must follow the same pattern.
-- If `py.exe` is missing on a future machine, install the python.org distribution which bundles the launcher.
+- All hook command entries in `settings.json` use `pyw -3 C:/...` syntax.
+- Shell-invoked Python (the `## Testing` command, skill docs, the `pre-push` hook) continues to use `py -3`.
+- Any new hook added to this repo must follow the `pyw -3` pattern for its `settings.json` entry.
+- If `py.exe` or `pyw.exe` is missing on a future machine, install the python.org distribution which bundles the launcher.
 
 ---
 

--- a/docs/adr/007-hook-command-invocation.md
+++ b/docs/adr/007-hook-command-invocation.md
@@ -73,7 +73,7 @@ If a future Claude Code version invokes hooks through a different shell context 
 ## Consequences
 
 - All hook command entries in `settings.json` use `pyw -3 C:/...` syntax.
-- Shell-invoked Python (the `## Testing` command, skill docs, the `pre-push` hook) continues to use `py -3`.
+- Shell-invoked Python (the `## Testing` command, skill docs, the `pre-push` hook) continues to use `py -3`. Note that `python3` still resolves to the Microsoft Store App Execution Alias on this machine — shell commands must use `py -3`, not `python3`, or they will silently no-op (e.g., `python3 -m py_compile ...` produces no error and no compiled output).
 - Any new hook added to this repo must follow the `pyw -3` pattern for its `settings.json` entry.
 - If `py.exe` or `pyw.exe` is missing on a future machine, install the python.org distribution which bundles the launcher.
 


### PR DESCRIPTION
## Summary

Swap `py -3` → `pyw -3` in `claude/settings.json` hook command entries (~25 hooks). `py.exe` invokes `python.exe` (console subsystem), so each hook spawn briefly allocates a console window — visible as a flash on every prompt and tool call. `pyw -3` invokes `pythonw.exe` (Windows subsystem), no console allocation. Stdin/stdout/stderr still work normally over the pipes Claude Code wires up to the subprocess.

Scope: `settings.json` hook commands only. Left unchanged:
- `Bash(py -3 *)` permission entries — Claude invoking via the Bash tool runs inside Git Bash, no flash.
- The `## Testing` command and skill `py -3` examples — shell contexts.
- The `pre-push` hook — runs from a `git push` context.

ADR-007 amended with a 2026-06-01 decision section recording the swap and scope. `docs/REFERENCE.md` updated to match.

Closes #294

## Testing

```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
node -e "JSON.parse(require('fs').readFileSync('claude/settings.json','utf8'))"
```

Both pass. Verified via grep that 25 hook commands now use `pyw -3` and zero `"command": "py -3` remain.

`Tests: 0 passed, 0 skipped, 0 failed (n/a)` — no automated test suite; verification is the syntax + JSON parse pair above per the `## Testing` section in the project CLAUDE.md.

No new testable behavior introduced (config change to invocation only). Suppression check: clean. Test-integrity check: n/a (no test files touched).

## Test plan

- [x] Hook scripts parse cleanly
- [x] settings.json parses as valid JSON
- [x] Hook command grep shows 25× `pyw -3`, 0× `py -3`
- [ ] After merge, observe no console window flash on next session's hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)