### PR TITLE
Add Error Message Diligence rule to global CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -405,6 +405,26 @@ Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handle
 
 ---
 
+## Error Message Diligence
+
+Error messages emitted by CI workflow guards, hooks, bots, and library exceptions are written by the *author of the guard* — they describe what the author thinks went wrong, not what actually went wrong. When a single check stands in for multiple upstream states (a job skipped because its `needs:` failed, a downstream output that defaults to empty when an earlier step never ran, a generic catch-block re-raise), the message can be confidently misleading. Restating that message as a diagnosis to the user, to a bot thread, or in a PR comment propagates the wrong root cause and produces follow-up corrections that cost more than the original verification would have.
+
+Before acting on any automation- or library-emitted error message in a non-trivial situation, complete three diligence steps:
+
+1. **Locate the emitting line.** Find the file and line that printed the message. Read the conditional or `raise` site directly — do not infer it from the message text.
+2. **Read the condition the code actually evaluates.** The literal expression (`if X != 'true'`, `if not config.get('key')`) is the ground truth. The message is a human-readable label for that expression and may have drifted.
+3. **Distinguish the upstream signal from the message's narrative.** If the evaluated condition can be false for multiple reasons — secret missing, upstream job skipped, network 5xx during a fetch, schema mismatch — trace one level up before accepting the message's framing. For CI: check the parent job's status and `needs:` chain. For hooks/scripts: check the input that produced the falsy value, not just the falsy value itself.
+
+When uncertain after the three steps, surface the uncertainty explicitly: "the guard printed X; I have not yet confirmed the underlying condition" rather than restating X as fact. This applies equally to user-facing messages, PR comments, and bot replies.
+
+**Anti-pattern:** quoting an emitted error message back to the user as the diagnosis without having read the emitting line. The message is evidence of *what was reported*, not evidence of *what is true*.
+
+**Exemption:** local errors where the message is reliable by construction — syntax errors, file-not-found at a path you just wrote, type errors with a specific symbol named — do not require the three-step trace. The rule targets guard messages that summarize composite upstream state.
+
+**Rationale incident.** lifting-logbook [PR #395](https://github.com/brownm09/lifting-logbook/pull/395) (2026-06-01). The `staging.yml` deploy-prereq guard printed a "Staging Clerk secret key is not configured" error and pointed to `docs/deploy.md` Step 4. The actual upstream chain was a transient 504 from Artifact Registry in `build-images` → `deploy-api` skipped because of `needs: build-images` → empty `clerk_configured` output → integration-tests' `!= 'true'` check fired the misconfig message. The secret was already correctly set. Both the github-actions bot and I reported the wrong root cause until the user pushed back. Full trace: [PR #395 comment](https://github.com/brownm09/lifting-logbook/pull/395#issuecomment-4594434736). See [ADR-034](../docs/adr/034-error-message-diligence.md).
+
+---
+
 ## Documentation and Citations
 
 When writing or updating any architectural documentation (ADRs, design docs, READMEs):

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -409,7 +409,7 @@ Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handle
 
 Error messages emitted by CI workflow guards, hooks, bots, and library exceptions are written by the *author of the guard* — they describe what the author thinks went wrong, not what actually went wrong. When a single check stands in for multiple upstream states (a job skipped because its `needs:` failed, a downstream output that defaults to empty when an earlier step never ran, a generic catch-block re-raise), the message can be confidently misleading. Restating that message as a diagnosis to the user, to a bot thread, or in a PR comment propagates the wrong root cause and produces follow-up corrections that cost more than the original verification would have.
 
-Before acting on any automation- or library-emitted error message in a non-trivial situation, complete three diligence steps:
+Before acting on any automation- or library-emitted error message not covered by the Exemption below, complete three diligence steps:
 
 1. **Locate the emitting line.** Find the file and line that printed the message. Read the conditional or `raise` site directly — do not infer it from the message text.
 2. **Read the condition the code actually evaluates.** The literal expression (`if X != 'true'`, `if not config.get('key')`) is the ground truth. The message is a human-readable label for that expression and may have drifted.
@@ -419,7 +419,7 @@ When uncertain after the three steps, surface the uncertainty explicitly: "the g
 
 **Anti-pattern:** quoting an emitted error message back to the user as the diagnosis without having read the emitting line. The message is evidence of *what was reported*, not evidence of *what is true*.
 
-**Exemption:** local errors where the message is reliable by construction — syntax errors, file-not-found at a path you just wrote, type errors with a specific symbol named — do not require the three-step trace. The rule targets guard messages that summarize composite upstream state.
+**Exemption:** local errors where the message is reliable by construction — syntax errors, file-not-found at a path you just wrote, static type-checker errors that name the offending symbol (TypeScript `TS2304`, Pyright `reportUndefinedVariable`, etc.) — do not require the three-step trace. The rule targets guard messages that summarize composite upstream state.
 
 **Rationale incident.** lifting-logbook [PR #395](https://github.com/brownm09/lifting-logbook/pull/395) (2026-06-01). The `staging.yml` deploy-prereq guard printed a "Staging Clerk secret key is not configured" error and pointed to `docs/deploy.md` Step 4. The actual upstream chain was a transient 504 from Artifact Registry in `build-images` → `deploy-api` skipped because of `needs: build-images` → empty `clerk_configured` output → integration-tests' `!= 'true'` check fired the misconfig message. The secret was already correctly set. Both the github-actions bot and I reported the wrong root cause until the user pushed back. Full trace: [PR #395 comment](https://github.com/brownm09/lifting-logbook/pull/395#issuecomment-4594434736). See [ADR-034](../docs/adr/034-error-message-diligence.md).
 

--- a/docs/adr/034-error-message-diligence.md
+++ b/docs/adr/034-error-message-diligence.md
@@ -1,0 +1,78 @@
+# ADR-034 — Error Message Diligence
+
+**Date:** 2026-06-01
+**Status:** Accepted
+**Closes:** [dev-env#296](https://github.com/brownm09/dev-env/issues/296)
+**Tags:** workflow, diagnosis, ci, error-handling, claude-behavior, global-rule
+**Related:** [ADR-004](004-pr-review-reads-from-remote.md), [ADR-008](008-plan-then-optimize-forcing-function.md)
+
+---
+
+## Context
+
+CI guards, hooks, bots, and library exceptions emit error messages written by the *author of the guard*. The message describes what the author predicted would go wrong at that condition, not what is actually true at runtime. A single conditional check often stands in for several upstream states:
+
+- A GitHub Actions job skipped because a job in its `needs:` chain failed — downstream outputs default to the empty string, and a `!= 'true'` check fires the "feature not configured" branch even when the feature is configured.
+- A try/except that re-raises with a generic message — the original cause is in the traceback, not in the surface string.
+- A health check that bundles connectivity, auth, and configuration into a single boolean — the message names only one of the three.
+
+When I have repeated an emitted message back to the user as a diagnosis without verifying the underlying condition, the cost has consistently exceeded the cost of the verification itself: a misdirected PR comment, a wrong issue, or a user push-back that requires a follow-up correction.
+
+The existing global CLAUDE.md has rules about reading remote state ([ADR-004](004-pr-review-reads-from-remote.md)), planning before acting ([ADR-008](008-plan-then-optimize-forcing-function.md)), and primary-source citation, but nothing that names the specific failure mode of treating a guard's *narrative* as the *diagnosis*.
+
+---
+
+## Decision
+
+Add a new `## Error Message Diligence` section to `claude/CLAUDE.md`, placed between **Context & Token Efficiency** and **Documentation and Citations**. The rule directs three diligence steps before acting on any non-trivial automation- or library-emitted error message:
+
+1. Locate the emitting line.
+2. Read the condition the code actually evaluates (the literal expression, not the human-readable label).
+3. Distinguish the upstream signal from the message's narrative — for CI, follow `needs:` chains; for hooks and scripts, trace to the input that produced the falsy value.
+
+When uncertain after the three steps, the rule requires explicit hedging ("the guard printed X; I have not yet confirmed the underlying condition") rather than restating the message as fact. Naming the anti-pattern — quoting an emitted message back as a diagnosis — makes the violation easier to recognize mid-turn. An exemption carves out local errors that are reliable by construction (syntax errors, file-not-found at a path just written, type errors with a specific symbol named).
+
+The section cites the lifting-logbook [PR #395](https://github.com/brownm09/lifting-logbook/pull/395) incident inline as the rationale.
+
+---
+
+## Rationale
+
+**Why a behavioral rule rather than a hook.** The failure mode is judgment, not mechanics. A hook could grep for `staging.yml`-style guard messages in tool output, but it cannot decide whether the model is treating the message as evidence or as diagnosis. A rule in CLAUDE.md, read on every session, is the right altitude.
+
+**Why three steps and not one.** Step 1 alone ("read the emitting line") is what a careful reader would do without the rule; the failure mode is skipping that step. Splitting the diligence into three lets the rule call out the specific transition — *from* "the message says X" *to* "the code evaluates Y when Z is empty" — that the model omits when it propagates wrong root causes.
+
+**Why an explicit exemption.** Without one, the rule reads as "always trace every error message," which would burn tokens on the common case (a `FileNotFoundError` at a path just written by the same turn). Calling out the safe class — messages reliable by construction — keeps the rule's force on the dangerous class.
+
+**Why cite the incident inline.** The incident is the strongest forcing memory the rule has. Future sessions reading the section see a concrete worked example with a click-through to the actual misdiagnosis, not an abstract injunction.
+
+**Why placement between Context & Token Efficiency and Documentation and Citations.** Diagnosing errors is an information-gathering activity adjacent to planning and citation. Placing it near the planning rules clusters the "be careful about evidence" themes; placing it before the citation rule (which is also about evidence) signals their kinship.
+
+---
+
+## Alternatives considered
+
+- **Add to an existing section** (Code Quality, or Plan-Then-Optimize). Rejected: Code Quality is about written code, not about how the model reads runtime output; Plan-Then-Optimize is about efficiency, not evidence. A new top-level section makes the rule easier to find when triaging a future incident.
+- **Embed in `/review` skill prompts.** Rejected: the failure mode occurs across the whole workflow (PR comments, bot replies, issue filings), not only during review. A global rule covers all contexts.
+- **No written rule; rely on the incident memory.** Rejected: incidents do not propagate to future sessions without a written artifact.
+
+---
+
+## Consequences
+
+**Positive:**
+- Future sessions encountering a CI guard, hook, or bot error string have an explicit named anti-pattern to avoid and a three-step procedure to follow.
+- The rule generalizes — it applies equally to GitHub Actions, pre-commit hooks, dev-env scripts, and library exceptions.
+- The incident citation provides a concrete worked example that survives session boundaries.
+
+**Negative:**
+- Adds ~25 lines to global CLAUDE.md, which is read on every session.
+- The three-step procedure adds tokens to error-handling turns where the rule applies. Mitigated by the exemption clause for local errors.
+- Judgment-based rules have softer enforcement than mechanical hooks; compliance depends on session-by-session attention.
+
+---
+
+## References
+
+- Incident: [lifting-logbook PR #395 comment thread](https://github.com/brownm09/lifting-logbook/pull/395#issuecomment-4594434736)
+- [GitHub Actions job dependencies](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs) — primary source for `needs:` skip semantics that produced the misleading empty output in the incident.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -38,3 +38,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [031](031-auto-merge-disabled.md) | Auto-Merge Disabled Across All Repos | 2026-05-28 | Accepted | git, pr, merge, workflow, hooks, post-merge |
 | [032](032-journal-start-here-dashboard.md) | Top-of-README "Start here" Dashboard in journal-compose | 2026-05-28 | Accepted | journal, composition, skill, readme, manifest, dashboard |
 | [033](033-prevent-system-sleep-while-processing.md) | Prevent System Sleep While Claude Is Processing | 2026-05-29 | Accepted | hooks, windows, sleep, UserPromptSubmit, Stop, Notification, background-process |
+| [034](034-error-message-diligence.md) | Error Message Diligence | 2026-06-01 | Accepted | workflow, diagnosis, ci, error-handling, claude-behavior, global-rule |


### PR DESCRIPTION
## Summary

- Adds `## Error Message Diligence` section to `claude/CLAUDE.md` between Context & Token Efficiency and Documentation and Citations.
- Three diligence steps: locate the emitting line; read the literal condition; distinguish upstream signal from message narrative.
- Names the anti-pattern (quoting an emitted message as the diagnosis) and exempts errors reliable by construction (syntax, file-not-found at a just-written path).
- Cites lifting-logbook PR #395 (2026-06-01) inline as the rationale incident — transient Artifact Registry 504 misattributed to a missing Clerk secret by both the bot and Claude.
- Adds [ADR-034](docs/adr/034-error-message-diligence.md) documenting the rule, placement, and rejected alternatives; updates `docs/adr/INDEX.md`.

## Acceptance criteria (from #296)

- [x] New `## Error Message Diligence` section in `claude/CLAUDE.md`
- [x] Section names the three diligence steps and the anti-pattern explicitly
- [x] Section cites the lifting-logbook #395 incident with a link to the PR comment thread
- [x] ADR-034 written and added to `INDEX.md`
- [x] README / docs/REFERENCE.md updated if either inventories CLAUDE.md sections — neither currently does, so no update needed

## Testing

Ran from repo root:

```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
```

Result: clean (no syntax errors across all hook scripts). Tests: N/A passed, 0 skipped, 0 failed (instant) — this repo's automated test suite is the AST-parse check above; the rest is docs-only.

Also ran the docs-only date-format check:

```
grep -n 'date -u' claude/CLAUDE.md
```

Single match is the meta-instruction line that documents the check itself — not a stub-filename or branch-name use. No new `date -u` references introduced.

**Coverage gate.** No new testable behavior — the change is a global behavioral rule (CLAUDE.md text) plus an ADR. No automated test applies.

**Suppression check.** Clean — no `ts-ignore`, `eslint-disable`, `!`-suppression, or `?? null` additions in the diff (docs-only).

**Test integrity check.** Clean — no skip markers, deleted tests, lowered coverage thresholds, or bypass flags in the diff (docs-only).

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)