### PR TITLE
[config] Global lockfile-drift prevention: pre-push hook + dependency-edit rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Hooks that spawn subprocesses (`git`, `gh`, `bash`, …) must `import _winsubp` 
 | Stop | `token-tracker.py` | Aggregates session token usage to `scratch/token-sessions.jsonl` |
 | Stop | `journal-stop-check.py` | Checks sentinel flag and stale open journal stubs at session end; emits closing reminder if stub was pushed this session |
 | PostCompact | `post-compact.py` | Emits compaction status line (trigger type + remaining tokens) |
-| Git pre-push | `hooks/pre-push` | Warns when branch merge base diverges from `origin/main` in squash-merge repos |
+| Git pre-push | `hooks/pre-push` | Warns when branch merge base diverges from `origin/main` in squash-merge repos; blocks engineering-journal pushes to already-merged draft branches; blocks pushes that drift `package-lock.json` from `package.json` (see [ADR-036](docs/adr/036-lockfile-drift-prevention.md)) |
 
 ## Routines
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -359,6 +359,22 @@ A PR that adds new failures or lists no PR-body justification for outstanding `p
 
 **Scope note.** The first implementation supports Jest only. Pytest, Go `testing`, and Rust have different JSON output formats and each needs its own parser — a clean run in a non-Jest repo is not evidence the policy applies. The opt-in flag should stay off in repos whose test runners are not yet supported.
 
+### Dependency and lockfile policy
+
+In any npm repo, `package-lock.json` must stay in sync with the dependency ranges declared in `package.json`. When they drift, `npm ci` refuses to install (it requires an in-sync lockfile) and CI fails at the install step with a cryptic `EUSAGE` error — and `main` can go red. The motivating incident is lifting-logbook #432/#433, where clerk-backend, clerk-shared, and react drift reddened `main` and required reactive recovery PRs. See [ADR-036](../docs/adr/036-lockfile-drift-prevention.md) for the full defense-in-depth rationale.
+
+**Rule 1 — Edit a dependency, regenerate the lockfile, commit both together.**
+Any change that adds, removes, or changes the version range of a dependency in a `package.json` (root or workspace) **must** run `npm install` and commit the regenerated `package-lock.json` in the **same** change. Never commit a `package.json` dependency edit without its lockfile update.
+
+**Rule 2 — Pre-PR lockfile-sync check (required before `gh pr create` when any `package.json` changed).**
+Run this from the repo root and confirm it exits clean before opening the PR:
+```bash
+npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json
+```
+A non-empty diff means the lockfile is out of sync — run `npm install`, commit the result, and re-run the check. The same check runs automatically in the global `pre-push` hook (it blocks the push on drift) and should run in each repo's CI as an early step; the pre-PR run catches it before either fires.
+
+**Scope note.** Applies to npm/`package-lock.json` repos. Yarn (`yarn.lock`) and pnpm (`pnpm-lock.yaml`) have equivalent drift failure modes but different regeneration commands (`yarn install`, `pnpm install --lockfile-only`) — extend the check per repo before relying on it there.
+
 ---
 
 ## Hook Safety

--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -66,28 +66,32 @@ done
 # Lockfile-drift guard: when a pushed package.json changed, verify package-lock.json
 # is in sync with it, and block the push on drift so CI never hits the cryptic
 # `npm ci` EUSAGE error. Skips cleanly when npm is absent or the repo has no root
-# lockfile. The check is non-destructive — the working-tree lockfile is always
-# restored, whatever the outcome.
+# lockfile. The check is non-destructive — the working-tree lockfile is restored on
+# every exit path (including SIGINT/SIGTERM) by a trap, and the backup is held
+# outside the repo (mktemp) so an interrupted run never leaves a stray file behind.
+# Note: the check evaluates the current working tree, not the exact pushed tree; for
+# the common clean-tree push of HEAD these coincide, and CI is authoritative on the
+# committed state regardless.
 if [ "$PKG_TOUCHED" = "1" ] && command -v npm >/dev/null 2>&1; then
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
   if [ -n "$repo_root" ] && [ -f "$repo_root/package.json" ] && [ -f "$repo_root/package-lock.json" ]; then
     lock="$repo_root/package-lock.json"
-    backup="${lock}.prepush.bak"
+    backup=$(mktemp 2>/dev/null) || backup="${lock}.prepush.bak"
     cp "$lock" "$backup"
+    restore_lock() { [ -n "$backup" ] && cp "$backup" "$lock" 2>/dev/null; rm -f "$backup" 2>/dev/null; }
+    trap 'restore_lock' EXIT
+    trap 'restore_lock; exit 1' INT TERM
     ( cd "$repo_root" && npm install --package-lock-only --ignore-scripts >/dev/null 2>&1 )
     npm_rc=$?
     if [ "$npm_rc" -ne 0 ]; then
-      cp "$backup" "$lock"; rm -f "$backup"
       echo "WARNING: pre-push lockfile-drift check skipped (npm exited $npm_rc; offline?)." >&2
     elif ! diff -q "$lock" "$backup" >/dev/null 2>&1; then
-      cp "$backup" "$lock"; rm -f "$backup"
       echo "ERROR: package-lock.json is out of sync with package.json in $repo_root." >&2
       echo "A dependency was changed without regenerating the lockfile; CI 'npm ci' will fail." >&2
       echo "Fix: run 'npm install' in that repo and commit the updated package-lock.json, then re-push." >&2
-      exit 1  # block push; intentionally skips per-repo hook chain — push is fully blocked
-    else
-      cp "$backup" "$lock"; rm -f "$backup"
+      exit 1  # trap restores the working-tree lockfile; push is fully blocked
     fi
+    # Success or skip: the EXIT trap restores the lockfile and removes the backup.
   fi
 fi
 

--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -47,7 +47,49 @@ while read local_ref local_sha remote_ref remote_sha; do
       fi
     fi
   fi
+
+  # Detect whether the push range touches any package.json (root or workspace).
+  # Consumed by the lockfile-drift guard after the loop (Layer 3 of the lockfile
+  # defense — see dev-env ADR-036 and lifting-logbook#435).
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    base=$(git rev-parse origin/main 2>/dev/null)
+    [ -n "$base" ] && pkg_range="$base..$local_sha" || pkg_range=""
+  else
+    pkg_range="$remote_sha..$local_sha"
+  fi
+  if [ -n "$pkg_range" ] && \
+     git diff --name-only "$pkg_range" 2>/dev/null | grep -qE '(^|/)package\.json$'; then
+    PKG_TOUCHED=1
+  fi
 done
+
+# Lockfile-drift guard: when a pushed package.json changed, verify package-lock.json
+# is in sync with it, and block the push on drift so CI never hits the cryptic
+# `npm ci` EUSAGE error. Skips cleanly when npm is absent or the repo has no root
+# lockfile. The check is non-destructive — the working-tree lockfile is always
+# restored, whatever the outcome.
+if [ "$PKG_TOUCHED" = "1" ] && command -v npm >/dev/null 2>&1; then
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -n "$repo_root" ] && [ -f "$repo_root/package.json" ] && [ -f "$repo_root/package-lock.json" ]; then
+    lock="$repo_root/package-lock.json"
+    backup="${lock}.prepush.bak"
+    cp "$lock" "$backup"
+    ( cd "$repo_root" && npm install --package-lock-only --ignore-scripts >/dev/null 2>&1 )
+    npm_rc=$?
+    if [ "$npm_rc" -ne 0 ]; then
+      cp "$backup" "$lock"; rm -f "$backup"
+      echo "WARNING: pre-push lockfile-drift check skipped (npm exited $npm_rc; offline?)." >&2
+    elif ! diff -q "$lock" "$backup" >/dev/null 2>&1; then
+      cp "$backup" "$lock"; rm -f "$backup"
+      echo "ERROR: package-lock.json is out of sync with package.json in $repo_root." >&2
+      echo "A dependency was changed without regenerating the lockfile; CI 'npm ci' will fail." >&2
+      echo "Fix: run 'npm install' in that repo and commit the updated package-lock.json, then re-push." >&2
+      exit 1  # block push; intentionally skips per-repo hook chain — push is fully blocked
+    else
+      cp "$backup" "$lock"; rm -f "$backup"
+    fi
+  fi
+fi
 
 # Chain to per-repo hook if one exists (preserves Husky, git-secrets, corporate hooks, etc.)
 REPO_HOOK="$(git rev-parse --git-dir)/hooks/pre-push"

--- a/docs/adr/036-lockfile-drift-prevention.md
+++ b/docs/adr/036-lockfile-drift-prevention.md
@@ -54,11 +54,13 @@ layers, which apply to every npm repo without per-repo wiring.
    (`npm install --package-lock-only --ignore-scripts`) and compares it to the working-tree
    lockfile. On any difference, prints an actionable message and **blocks the push** (`exit 1`).
 
-The check is **non-destructive**: the working-tree lockfile is backed up before regeneration and
-restored on every code path (drift, no-drift, and npm failure), so the hook never leaves the tree
-modified. If `npm` exits non-zero (e.g. offline), the check is **skipped with a warning, not
-blocked** — a tooling failure must not wedge an unrelated push. The block path `exit 1`s before the
-per-repo hook chain, consistent with the hook's existing fully-blocking journal case.
+The check is **non-destructive**: the working-tree lockfile is backed up (to a `mktemp` file
+outside the repo) before regeneration and restored on every exit path by a `trap` — drift,
+no-drift, npm failure, and SIGINT/SIGTERM — so neither an interrupted run nor a normal one ever
+leaves the tree modified or a stray backup in the repo. If `npm` exits non-zero (e.g. offline),
+the check is **skipped with a warning, not blocked** — a tooling failure must not wedge an
+unrelated push. The block path `exit 1`s before the per-repo hook chain, consistent with the
+hook's existing fully-blocking journal case.
 
 It extends the *existing* `pre-push` file rather than adding a second hook because `core.hooksPath`
 resolves a single `pre-push` per repo; a second file would silently never run.

--- a/docs/adr/036-lockfile-drift-prevention.md
+++ b/docs/adr/036-lockfile-drift-prevention.md
@@ -1,0 +1,124 @@
+# ADR-036 — Lockfile-Drift Prevention: Global Pre-Push Hook + Dependency-Edit Rule
+
+**Date:** 2026-06-03
+**Status:** Accepted
+**Closes:** [dev-env#305](https://github.com/brownm09/dev-env/issues/305)
+**Tags:** hooks, pre-push, npm, lockfile, package-lock, ci, global-rule, code-quality
+**Related:** [ADR-005](005-global-core-hooks-path.md), [ADR-026](026-suppression-policy.md), [ADR-029](029-test-integrity-policy.md)
+
+---
+
+## Context
+
+In any npm repo, `package-lock.json` records the exact resolved dependency tree implied by the
+version ranges in `package.json`. `npm ci` — the install command used in CI — **refuses to run when
+the two are out of sync**, by design: it exists to install exactly what the lockfile pins, and an
+inconsistent lockfile means the pinned tree no longer satisfies the declared ranges. The refusal
+surfaces as a terse `EUSAGE` error that names neither the offending dependency nor the root cause.
+
+When an author edits a dependency range in `package.json` but does not regenerate and commit the
+lockfile, the lockfile drifts. The drift is invisible locally (where `npm install`, which *updates*
+the lockfile, is the common command) and only bites in CI, where `npm ci` runs against the committed
+lockfile. The result is a red `main` and a reactive recovery PR.
+
+This happened on `brownm09/lifting-logbook`: clerk-backend, clerk-shared, and react ranges drifted
+from the committed lockfile, `main` CI went red at the `npm ci` step, and it was fixed reactively in
+[lifting-logbook#432](https://github.com/brownm09/lifting-logbook/pull/432) /
+[#433](https://github.com/brownm09/lifting-logbook/pull/433). Nothing prevented recurrence.
+
+A defense-in-depth response has four layers, two of them repo-local and two global (cross-repo):
+
+| # | Layer | Where | Catches drift… |
+|---|-------|-------|----------------|
+| 1 | Branch protection requiring CI checks | repo settings | at merge (red checks block non-admin merge) |
+| 2 | CI lockfile-sync guard (clear message) | repo `ci.yml` | in CI, before the cryptic `npm ci` error |
+| 3 | **Global pre-push hook** | dev-env `claude/hooks/pre-push` | **locally, before the push leaves the machine** |
+| 4 | **Global dependency-edit rule** | dev-env `claude/CLAUDE.md` | at authoring time (forcing function for Claude) |
+
+Layers 1 and 2 are repo-local (implemented for lifting-logbook in
+[#435](https://github.com/brownm09/lifting-logbook/issues/435)). This ADR covers the two **global**
+layers, which apply to every npm repo without per-repo wiring.
+
+---
+
+## Decision
+
+**Layer 3 — extend the existing global `pre-push` hook.** The hook already runs for every repo via
+`core.hooksPath` ([ADR-005](005-global-core-hooks-path.md)). Add a block that:
+
+1. While iterating the pushed refs, flags whether the push range (`<remote_sha>..<local_sha>`, or
+   `origin/main..<local_sha>` for a new branch) touches any `package.json` (root or workspace, via
+   `grep -qE '(^|/)package\.json$'`).
+2. After the loop, only if a `package.json` changed **and** `npm` is on `PATH` **and** the repo has
+   a root `package.json` + `package-lock.json`, regenerates the lockfile metadata
+   (`npm install --package-lock-only --ignore-scripts`) and compares it to the working-tree
+   lockfile. On any difference, prints an actionable message and **blocks the push** (`exit 1`).
+
+The check is **non-destructive**: the working-tree lockfile is backed up before regeneration and
+restored on every code path (drift, no-drift, and npm failure), so the hook never leaves the tree
+modified. If `npm` exits non-zero (e.g. offline), the check is **skipped with a warning, not
+blocked** — a tooling failure must not wedge an unrelated push. The block path `exit 1`s before the
+per-repo hook chain, consistent with the hook's existing fully-blocking journal case.
+
+It extends the *existing* `pre-push` file rather than adding a second hook because `core.hooksPath`
+resolves a single `pre-push` per repo; a second file would silently never run.
+
+**Layer 4 — add a "Dependency and lockfile policy" rule to `claude/CLAUDE.md`** (under Code Quality,
+alongside the Suppression and Test Integrity policies):
+
+- **Rule 1:** editing a dependency in any `package.json` requires running `npm install` and
+  committing the regenerated `package-lock.json` in the same change.
+- **Rule 2:** a pre-PR lockfile-sync check
+  (`npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json`)
+  when any `package.json` changed.
+
+Layer 4 is the forcing function at authoring time; Layer 3 is the automated backstop if the author
+(human or Claude) forgets.
+
+---
+
+## Consequences
+
+- A push that drifts the lockfile is blocked at the source, on the machine, before CI runs — the
+  fastest possible feedback and zero red `main`.
+- The guard runs only when a pushed `package.json` actually changed, so the overwhelming majority of
+  pushes pay nothing. Non-npm repos (no root lockfile) and npm-absent environments skip cleanly.
+- The check costs one `npm install --package-lock-only` (no `node_modules` write, no scripts) on the
+  pushes that do touch `package.json` — a few seconds, occasionally a dependency-resolution network
+  round-trip.
+- The hook is non-destructive and chains to any repo-level `.git/hooks/pre-push`, so it composes
+  with Husky, git-secrets, and corporate hooks.
+- Layer 4 binds Claude behaviorally even in repos that have not yet adopted Layers 1–2.
+
+---
+
+## Alternatives Considered
+
+- **Compare the regenerated lockfile against `HEAD` instead of the working-tree copy.** Rejected:
+  it produces false positives when the working tree legitimately has staged lockfile edits, and it
+  couples the check to commit state. Comparing the regenerated lockfile to the pre-regeneration
+  working-tree copy is a pure "does `package.json` imply a different lockfile than the one on disk?"
+  test, independent of what is committed.
+- **Block (not skip) when `npm` fails or is offline.** Rejected: a transient resolution failure or
+  an offline push is unrelated to lockfile correctness; blocking would wedge legitimate pushes. The
+  hook warns and proceeds, leaving CI (Layer 2) as the backstop.
+- **A separate dedicated lockfile hook file.** Rejected: `core.hooksPath` runs one `pre-push` per
+  repo, so a second file would never execute. Extending the existing hook is the only correct shape.
+- **Rely on Layers 1–2 alone.** Rejected as insufficient: they catch drift only after the push
+  reaches GitHub and CI runs. The local hook (Layer 3) gives immediate feedback, and the CLAUDE.md
+  rule (Layer 4) prevents the drift from being authored in the first place.
+
+---
+
+## References
+
+- [npm-ci](https://docs.npmjs.com/cli/v10/commands/npm-ci) — official docs: `npm ci` requires an
+  existing `package-lock.json` that is in sync with `package.json`, and errors out otherwise.
+- [npm-install — `--package-lock-only`](https://docs.npmjs.com/cli/v10/commands/npm-install) —
+  regenerates `package-lock.json` from `package.json` without writing `node_modules`; the basis of
+  the drift check.
+- [Git `githooks` — `pre-push`](https://git-scm.com/docs/githooks#_pre_push) — the hook's stdin ref
+  format (`<local ref> <local sha> <remote ref> <remote sha>`) and exit-code semantics (non-zero
+  aborts the push).
+- [Git `core.hooksPath`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath)
+  — how a single global hooks directory applies across all repos (see [ADR-005](005-global-core-hooks-path.md)).

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -40,3 +40,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [033](033-prevent-system-sleep-while-processing.md) | Prevent System Sleep While Claude Is Processing | 2026-05-29 | Accepted | hooks, windows, sleep, UserPromptSubmit, Stop, Notification, background-process |
 | [034](034-error-message-diligence.md) | Error Message Diligence | 2026-06-01 | Accepted | workflow, diagnosis, ci, error-handling, claude-behavior, global-rule |
 | [035](035-git-push-delete-web-session-constraint.md) | `git push --delete` Fails in Claude Code Web Sessions | 2026-06-03 | Accepted | git, web-session, sandbox, proxy, shallow-clone, branch-deletion, workflow, global-rule |
+| [036](036-lockfile-drift-prevention.md) | Lockfile-Drift Prevention: Global Pre-Push Hook + Dependency-Edit Rule | 2026-06-03 | Accepted | hooks, pre-push, npm, lockfile, package-lock, ci, global-rule, code-quality |


### PR DESCRIPTION
## Summary

Layers 3 and 4 of a 4-layer lockfile-drift defense (layers 1–2 are per-repo: branch protection + a CI guard, implemented for lifting-logbook in [lifting-logbook#435](https://github.com/brownm09/lifting-logbook/issues/435)). Background: a `package.json`/`package-lock.json` drift turned lifting-logbook `main` red at `npm ci` (fixed reactively in #432/#433). These two **global** layers apply to every npm repo with no per-repo wiring.

### Layer 3 — global `pre-push` hook (`claude/hooks/pre-push`)
Extends the existing hook (one `pre-push` per repo under `core.hooksPath`, so extension — not a second file — is the only correct shape). When the push range touches any `package.json` (root or workspace), it regenerates the lockfile metadata and **blocks the push on drift** with an actionable message. Properties:
- **Non-destructive:** backs up and restores the working-tree lockfile on every path (drift / in-sync / npm-failure).
- **Skips cleanly** when `npm` is absent or the repo has no root lockfile.
- **Does not block on tooling failure** (npm offline → warn + proceed; CI remains the backstop).
- **Chains** to any repo-level `.git/hooks/pre-push`.

### Layer 4 — `claude/CLAUDE.md` 'Dependency and lockfile policy'
Rule 1: editing a dependency requires regenerating + committing `package-lock.json` in the same change. Rule 2: a pre-PR lockfile-sync check (`npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json`).

### Docs
New [ADR-036](docs/adr/036-lockfile-drift-prevention.md) (covers both layers, with primary-source references); `docs/adr/INDEX.md` row; `README.md` hooks-table row updated (doc-reconciliation).

## Testing

dev-env has no Jest suite; verification per the project `## Testing` section plus targeted functional tests:

- `py -3 -c "import ast ..." claude/scripts/*.py` → **ALL PYTHON SCRIPTS PARSE OK**
- `bash -n claude/hooks/pre-push` → **HOOK SYNTAX OK**
- **Functional (guard core, against a real npm repo):**
  - Drifted `@types/jest` range → **BLOCK(drift)**, lockfile restored **PRISTINE**, backup cleaned up.
  - In-sync lockfile → **PASS(in-sync)**.
  - `npm` absent → **SKIP cleanly** (exit 0, no block).
  - Working tree clean after all paths.
- Suppression / test-integrity greps on the diff: **(none)**.

No automated test failures. Diff is one bash hook + three markdown/docs files; no Python scripts changed.

## Acceptance Criteria

- [x] Hook blocks a drifting push with an actionable message
- [x] Chains to a pre-existing repo-level `.git/hooks/pre-push`
- [x] Skips cleanly (exit 0) when `npm` is not on PATH
- [x] Works under Git Bash on Windows; respects the three hook invariants
- [x] `claude/CLAUDE.md` documents the dependency-edit + pre-PR lockfile-sync rule
- [x] ADR covers both layers; INDEX + README updated

Closes #305