### PR TITLE
[test] Add behavioral self-test for the pre-push lockfile-drift guard

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -253,6 +253,12 @@ py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in
 
 On Windows, `python3` resolves to the Microsoft Store stub — use `py -3` (the Windows Python Launcher). See [ADR-007](../docs/adr/007-hook-command-invocation.md).
 
+When changing `claude/hooks/pre-push`, also run its behavioral self-test, which drives the real hook against throwaway fixture repos with a stubbed `npm` and asserts the lockfile-drift guard's BLOCK / PASS / SKIP paths, working-tree restoration, and repo-hook chaining (see [ADR-036](../docs/adr/036-lockfile-drift-prevention.md)):
+
+```bash
+bash claude/hooks/tests/test-pre-push-lockfile.sh
+```
+
 For docs-only changes to `claude/CLAUDE.md`: run `grep -n 'date -u' claude/CLAUDE.md` and confirm every match is in an internal operational artifact context (lock files, log timestamps) — not in stub filename or branch name descriptions.
 
 ---

--- a/claude/hooks/tests/test-pre-push-lockfile.sh
+++ b/claude/hooks/tests/test-pre-push-lockfile.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Self-test for the lockfile-drift guard in claude/hooks/pre-push (dev-env#308, ADR-036).
+#
+# Drives the REAL hook against throwaway fixture repos with a stubbed `npm`, asserting:
+#   - BLOCK (exit 1) on a drifted lockfile
+#   - PASS  (exit 0) on an in-sync lockfile
+#   - SKIP  (exit 0 + warning) when npm exits non-zero
+#   - SKIP  (exit 0) when npm is absent from PATH
+#   - the working tree is restored and no backup leaks into the repo on every path
+#   - a repo-level .git/hooks/pre-push still fires (chaining) on the pass path
+#
+# Portable to Git Bash on Windows and Linux CI. Run from anywhere:
+#   bash claude/hooks/tests/test-pre-push-lockfile.sh
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+HOOK="$SCRIPT_DIR/../pre-push"
+ZERO="0000000000000000000000000000000000000000"
+
+PASS=0
+FAIL=0
+note() { echo "  NOTE: $*"; }
+ok()   { echo "  ok: $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $*"; FAIL=$((FAIL + 1)); }
+
+# Build a fixture git repo: commit C1 (in-sync), then C2 touching package.json.
+# Echoes "<repo> <C1> <C2>".
+make_fixture() {
+  local repo
+  repo=$(mktemp -d)
+  (
+    cd "$repo" || exit 1
+    git init -q
+    git config user.email t@t.test
+    git config user.name test
+    git config commit.gpgsign false
+    printf '{\n  "name": "fix",\n  "version": "1.0.0",\n  "dependencies": { "left-pad": "^1.0.0" }\n}\n' > package.json
+    printf '{\n  "name": "fix",\n  "lockfileVersion": 3,\n  "packages": {}\n}\n' > package-lock.json
+    git add -A && git commit -qm c1
+    # C2 changes package.json so the push range trips PKG_TOUCHED.
+    printf '{\n  "name": "fix",\n  "version": "1.0.0",\n  "dependencies": { "left-pad": "^1.1.0" }\n}\n' > package.json
+    git add -A && git commit -qm c2
+  ) >/dev/null 2>&1 || return 1
+  local c1 c2
+  c2=$(git -C "$repo" rev-parse HEAD)
+  c1=$(git -C "$repo" rev-parse HEAD~1)
+  echo "$repo $c1 $c2"
+}
+
+# Write a stub `npm` into a fresh temp dir (OUTSIDE any repo) that behaves per
+# $TEST_NPM_MODE (drift|fail|pass). Echoes the bin dir; caller removes its parent.
+make_stub_npm() {
+  local bindir
+  bindir="$(mktemp -d)/bin"
+  mkdir -p "$bindir"
+  cat > "$bindir/npm" <<'NPM'
+#!/bin/bash
+# stub npm for the hook self-test; only `install --package-lock-only` matters.
+case "${TEST_NPM_MODE:-pass}" in
+  drift) printf '\n{"_drift":true}\n' >> package-lock.json; exit 0 ;;
+  fail)  exit 7 ;;
+  *)     exit 0 ;;   # pass: leave the lockfile untouched
+esac
+NPM
+  chmod +x "$bindir/npm"
+  echo "$bindir"
+}
+
+# Run the hook for an existing-branch push (remote=C1, local=C2).
+# Args: repo c1 c2 path_override mode. Echoes the hook exit code.
+run_hook() {
+  local repo="$1" c1="$2" c2="$3" pathv="$4" mode="$5"
+  (
+    cd "$repo" || exit 99
+    echo "refs/heads/main $c2 refs/heads/main $c1" | \
+      PATH="$pathv" TEST_NPM_MODE="$mode" bash "$HOOK" origin "file://$repo" >/dev/null 2>&1
+  )
+  echo $?
+}
+
+tree_clean() { [ -z "$(git -C "$1" status --porcelain)" ]; }
+no_stray_bak() { ! ls "$1"/package-lock.json.prepush.bak >/dev/null 2>&1; }
+
+echo "Testing $HOOK"
+[ -f "$HOOK" ] || { echo "FATAL: hook not found at $HOOK"; exit 1; }
+
+# --- Scenario 1: in-sync -> PASS (exit 0), tree clean ---
+echo "[1] in-sync lockfile -> PASS"
+read -r REPO C1 C2 <<<"$(make_fixture)"
+BIN=$(make_stub_npm "$REPO")
+RC=$(run_hook "$REPO" "$C1" "$C2" "$BIN:$PATH" pass)
+[ "$RC" = "0" ] && ok "exit 0" || bad "expected exit 0, got $RC"
+tree_clean "$REPO" && ok "working tree clean" || bad "working tree dirty after pass"
+no_stray_bak "$REPO" && ok "no stray backup" || bad "stray .prepush.bak left in repo"
+rm -rf "$REPO" "$(dirname "$BIN")"
+
+# --- Scenario 2: drift -> BLOCK (exit 1), tree restored ---
+echo "[2] drifted lockfile -> BLOCK"
+read -r REPO C1 C2 <<<"$(make_fixture)"
+BIN=$(make_stub_npm "$REPO")
+RC=$(run_hook "$REPO" "$C1" "$C2" "$BIN:$PATH" drift)
+[ "$RC" = "1" ] && ok "exit 1 (push blocked)" || bad "expected exit 1, got $RC"
+tree_clean "$REPO" && ok "working tree restored" || bad "lockfile not restored after block"
+no_stray_bak "$REPO" && ok "no stray backup" || bad "stray .prepush.bak left in repo"
+rm -rf "$REPO" "$(dirname "$BIN")"
+
+# --- Scenario 3: npm exits non-zero -> SKIP (exit 0) ---
+echo "[3] npm failure -> SKIP (no block)"
+read -r REPO C1 C2 <<<"$(make_fixture)"
+BIN=$(make_stub_npm "$REPO")
+RC=$(run_hook "$REPO" "$C1" "$C2" "$BIN:$PATH" fail)
+[ "$RC" = "0" ] && ok "exit 0 (not blocked on tooling failure)" || bad "expected exit 0, got $RC"
+tree_clean "$REPO" && ok "working tree clean" || bad "working tree dirty after skip"
+rm -rf "$REPO" "$(dirname "$BIN")"
+
+# --- Scenario 4: npm absent -> SKIP (exit 0) ---
+echo "[4] npm absent -> SKIP"
+read -r REPO C1 C2 <<<"$(make_fixture)"
+NPM_DIR=$(dirname "$(command -v npm 2>/dev/null || echo /nonexistent/npm)")
+MINPATH=$(printf '%s\n' $(echo "$PATH" | tr ':' '\n') | grep -v -F -x "$NPM_DIR" | paste -sd: -)
+if PATH="$MINPATH" command -v npm >/dev/null 2>&1; then
+  note "could not isolate npm from PATH on this host; skipping absent-npm assertion"
+else
+  RC=$(run_hook "$REPO" "$C1" "$C2" "$MINPATH" pass)
+  [ "$RC" = "0" ] && ok "exit 0 (guard skipped cleanly)" || bad "expected exit 0, got $RC"
+  tree_clean "$REPO" && ok "working tree clean" || bad "working tree dirty"
+fi
+rm -rf "$REPO"
+
+# --- Scenario 5: repo-level pre-push chaining fires on pass ---
+echo "[5] chaining to repo-level .git/hooks/pre-push"
+read -r REPO C1 C2 <<<"$(make_fixture)"
+BIN=$(make_stub_npm "$REPO")
+SENTINEL="$REPO/.chained"
+cat > "$REPO/.git/hooks/pre-push" <<CHAIN
+#!/bin/bash
+touch "$SENTINEL"
+exit 0
+CHAIN
+chmod +x "$REPO/.git/hooks/pre-push"
+RC=$(run_hook "$REPO" "$C1" "$C2" "$BIN:$PATH" pass)
+[ "$RC" = "0" ] && ok "exit 0" || bad "expected exit 0, got $RC"
+[ -f "$SENTINEL" ] && ok "repo-level hook was invoked" || bad "repo-level hook did not fire"
+rm -rf "$REPO" "$(dirname "$BIN")"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -210,7 +210,13 @@ Fires after `/compact` or auto-compact completes.
 
 A global git pre-push hook installed via `core.hooksPath` (see [ADR-005](adr/005-global-core-hooks-path.md)).
 
-**What it does:** before every `git push`, checks whether the branch's merge base diverges from `origin/main` in squash-merge repos. Warns when it detects a branch that was cut from a squash-merged ancestor (which would cause a rebase to fail). Chains to any existing per-repo `.git/hooks/pre-push` so repo-level hooks are preserved.
+**What it does:** before every `git push` it (1) checks whether the branch's merge base diverges from `origin/main` in squash-merge repos and warns when it detects a branch cut from a squash-merged ancestor (which would cause a rebase to fail); (2) blocks engineering-journal pushes to already-merged `draft/` branches; and (3) when the push range touches a `package.json`, runs a non-destructive **lockfile-drift guard** that regenerates lockfile metadata and blocks the push if `package-lock.json` is out of sync (see [ADR-036](adr/036-lockfile-drift-prevention.md)). It chains to any existing per-repo `.git/hooks/pre-push` so repo-level hooks are preserved.
+
+**Testing:** the lockfile-drift guard has a behavioral self-test that drives the real hook against fixture repos with a stubbed `npm`, asserting its BLOCK / PASS / SKIP paths, working-tree restoration, and repo-hook chaining. Run it after any change to the hook:
+
+```bash
+bash claude/hooks/tests/test-pre-push-lockfile.sh
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the follow-up deferred from the review of #307: a behavioral regression test for the lockfile-drift guard in `claude/hooks/pre-push` (added in #307 / ADR-036), which previously had only manual verification — unlike the Python hooks, which `test_pyw_stdio.py` guards.

`claude/hooks/tests/test-pre-push-lockfile.sh` drives the **real** hook against throwaway fixture git repos with a **stubbed `npm`** (no network, no real install), asserting:

| Scenario | Expected |
|---|---|
| Drifted lockfile | BLOCK (exit 1), working tree restored, no stray backup |
| In-sync lockfile | PASS (exit 0), tree clean, no stray backup |
| `npm` exits non-zero | SKIP (exit 0, warn — not blocked on tooling failure) |
| `npm` absent from PATH | SKIP (exit 0, guard skipped cleanly) |
| Repo-level `.git/hooks/pre-push` present | chained hook fires on the pass path |

The fixtures and stub bin live outside any repo (mktemp), so a clean working-tree assertion genuinely reflects the hook's restore behavior. Portable to Git Bash (Windows) and Linux CI.

It also doubles as a regression test for the #307 review hardening (trap-based restore, backup outside the repo): scenario 2 fails if the lockfile is not restored after a block.

## Testing

- `bash claude/hooks/tests/test-pre-push-lockfile.sh` → **Results: 12 passed, 0 failed** (exit 0).
- `bash -n` on the test → clean; `py -3 ast.parse claude/scripts/*.py` → OK (no Python changed).
- Suppression / test-integrity greps on the diff → **(none)**.

(During development the test initially reported 3 failures — traced to the stub `npm` bin being created *inside* the fixture repo, which dirtied `git status`; moving it to a separate mktemp dir resolved it. Not a hook defect.)

## Docs

- Wires the test into the `## Testing` section of `claude/CLAUDE.md`.
- Updates `docs/REFERENCE.md` pre-push section to document the lockfile-drift guard and draft-branch-block behaviors (which #307 added to `README.md` but not `REFERENCE.md`) plus the new self-test.

No new ADR — covered by [ADR-036](https://github.com/brownm09/dev-env/blob/main/docs/adr/036-lockfile-drift-prevention.md), whose Alternatives section named this self-test as deferred follow-up.

Closes #308