### PR TITLE
[test] Guarantee absent-npm coverage in pre-push lockfile self-test

### DIFF
--- a/claude/hooks/tests/test-pre-push-lockfile.sh
+++ b/claude/hooks/tests/test-pre-push-lockfile.sh
@@ -20,7 +20,6 @@ ZERO="0000000000000000000000000000000000000000"
 
 PASS=0
 FAIL=0
-note() { echo "  NOTE: $*"; }
 ok()   { echo "  ok: $*"; PASS=$((PASS + 1)); }
 bad()  { echo "  FAIL: $*"; FAIL=$((FAIL + 1)); }
 
@@ -117,16 +116,33 @@ rm -rf "$REPO" "$(dirname "$BIN")"
 # --- Scenario 4: npm absent -> SKIP (exit 0) ---
 echo "[4] npm absent -> SKIP"
 read -r REPO C1 C2 <<<"$(make_fixture)"
-NPM_DIR=$(dirname "$(command -v npm 2>/dev/null || echo /nonexistent/npm)")
-MINPATH=$(printf '%s\n' $(echo "$PATH" | tr ':' '\n') | grep -v -F -x "$NPM_DIR" | paste -sd: -)
-if PATH="$MINPATH" command -v npm >/dev/null 2>&1; then
-  note "could not isolate npm from PATH on this host; skipping absent-npm assertion"
+NPM_PATH=$(command -v npm 2>/dev/null || true)
+SHIM=""
+if [ -z "$NPM_PATH" ]; then
+  FINALPATH="$PATH"   # npm already absent on this host
 else
-  RC=$(run_hook "$REPO" "$C1" "$C2" "$MINPATH" pass)
-  [ "$RC" = "0" ] && ok "exit 0 (guard skipped cleanly)" || bad "expected exit 0, got $RC"
+  NPM_DIR=$(dirname "$NPM_PATH")
+  FINALPATH=$(printf '%s\n' $(echo "$PATH" | tr ':' '\n') | grep -v -F -x "$NPM_DIR" | paste -sd: -)
+  # If dropping npm's dir also dropped a tool the hook needs, shim that tool back in
+  # (handles the pathological case where npm shares a directory with coreutils/git).
+  SHIM=$(mktemp -d)
+  for t in git grep cp rm diff mktemp date bash sed; do
+    if ! PATH="$FINALPATH" command -v "$t" >/dev/null 2>&1; then
+      src=$(command -v "$t" 2>/dev/null) && [ -n "$src" ] && ln -s "$src" "$SHIM/$t" 2>/dev/null
+    fi
+  done
+  FINALPATH="$SHIM:$FINALPATH"
+fi
+# Coverage is only meaningful if npm is genuinely gone AND the hook's tools resolve.
+# A construction failure is a loud FAIL, never a silent skip (dev-env#313).
+if PATH="$FINALPATH" command -v npm >/dev/null 2>&1 || ! PATH="$FINALPATH" command -v git >/dev/null 2>&1; then
+  bad "could not construct an npm-absent environment (npm still on PATH or git missing)"
+else
+  RC=$(run_hook "$REPO" "$C1" "$C2" "$FINALPATH" pass)
+  [ "$RC" = "0" ] && ok "exit 0 (guard skipped cleanly, npm absent)" || bad "expected exit 0, got $RC"
   tree_clean "$REPO" && ok "working tree clean" || bad "working tree dirty"
 fi
-rm -rf "$REPO"
+rm -rf "$REPO" "${SHIM:-/nonexistent}"
 
 # --- Scenario 5: repo-level pre-push chaining fires on pass ---
 echo "[5] chaining to repo-level .git/hooks/pre-push"


### PR DESCRIPTION
## Summary

Retro-fix bringing #310 into ADR-028 compliance — addresses the two non-blocking findings the #310 review left 'as-is' (which it should not have, per the all-findings merge gate):

- **[reliability] absent-npm isolation** — *fixed here.* Scenario 4 of `claude/hooks/tests/test-pre-push-lockfile.sh` previously skipped with a NOTE when it couldn't isolate npm from PATH, silently becoming a no-op. It now constructs an npm-absent PATH (drops npm's dir; shims any tool that lived only there) and **fails loudly** if it can't, rather than skipping. Coverage is guaranteed on normal hosts (Windows dev + Linux CI). Removed the now-unused `note()` helper.
- **[maintainability] hook-test discoverability** — *filed as #314* (deferred by design: its own recommendation is to act 'when a second hook test appears').

## Testing

- `bash claude/hooks/tests/test-pre-push-lockfile.sh` → **Results: 12 passed, 0 failed**. Scenario 4 now reports `exit 0 (guard skipped cleanly, npm absent)` — the assertion runs instead of skipping.
- `bash -n` clean; suppression/integrity greps → (none).

## Review findings disposition
This PR's own review findings will each be dispositioned (fixed-in-PR or filed) before merge — no 'as-is'.

Closes #313