### PR TITLE
Block writes from orphaned Claude-managed worktrees (ADR-024 addendum) (#328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Custom slash commands loaded from `claude/skills/`. Invoke with `/skill-name [ar
 ## Hooks
 
 Hook scripts run automatically via Claude Code's `hooks` configuration in `claude/settings.json`.
-Most hooks are advisory — they emit reminders but do not block tool execution. The exception is `pre-tool-use-worktree-path-check.py`, which blocks `Write`, `Edit`, and `NotebookEdit` calls that target the canonical repo root instead of the active worktree.
+Most hooks are advisory — they emit reminders but do not block tool execution. The exception is `pre-tool-use-worktree-path-check.py`, which blocks `Write`, `Edit`, and `NotebookEdit` calls that target the canonical repo root instead of the active worktree, **and** blocks any such call issued from an orphaned/disconnected worktree (one whose `.git` link is gone, so git silently resolves to the canonical repo).
 
 Hooks that spawn subprocesses (`git`, `gh`, `bash`, …) must `import _winsubp` — a helper module at `claude/scripts/_winsubp.py` that patches `subprocess.Popen.__init__` to set `CREATE_NO_WINDOW` so children don't flash a console window under `pythonw.exe`. See [ADR-007](docs/adr/007-hook-command-invocation.md).
 
@@ -58,7 +58,7 @@ Hooks that spawn subprocesses (`git`, `gh`, `bash`, …) must `import _winsubp` 
 | PreToolUse (Bash) | `pre-commit-branch-check.py` | Emits current branch as a checkpoint before `git commit` |
 | PreToolUse (Bash) | `pre-pr-create-check.py` | Emits test-verification checklist, documentation-gap warning, and pre-existing-failure baseline advisory before `gh pr create` |
 | PreToolUse (Bash) | `pre-merge-findings-gate.py` | Blocks `gh pr merge` when a `/review` comment reports open findings and the PR body records no disposition — mechanical enforcement of the all-findings merge gate (see [ADR-039](docs/adr/039-merge-gate-findings-enforcement.md)) |
-| PreToolUse (Write/Edit/NotebookEdit) | `pre-tool-use-worktree-path-check.py` | Blocks file writes whose absolute path targets the canonical repo root instead of the active worktree |
+| PreToolUse (Write/Edit/NotebookEdit) | `pre-tool-use-worktree-path-check.py` | Blocks file writes whose absolute path targets the canonical repo root instead of the active worktree, and blocks all writes from an orphaned worktree whose `.git` link no longer resolves (see [ADR-024](docs/adr/024-worktree-path-guard-hook.md)) |
 | PostToolUse (Bash) | `pr-merge-reminder.py` | Reminds to write a journal stub after `gh pr create`, `gh pr merge`, or `git push` (when the pushed branch has an open PR) |
 | PostToolUse (Bash) | `post-tool-use.py` | Auto-adds issues/PRs to configured GitHub Project; exits 2 with `required_fields` reminders |
 | PostToolUse (Bash) | `post-pr-merge-pull.py` | Fast-forwards local `main` after `gh pr merge` |

--- a/claude/scripts/pre-tool-use-worktree-path-check.py
+++ b/claude/scripts/pre-tool-use-worktree-path-check.py
@@ -10,11 +10,18 @@ silently. This hook intercepts those calls before the write happens.
 Logic:
   1. If cwd does not contain `/.claude/worktrees/<name>/`, pass immediately.
   2. Extract canonical_root (repo root) and worktree_root from cwd.
-  3. Read file_path (Write/Edit) or notebook_path (NotebookEdit) from tool input.
-  4. If the path is absolute and starts with canonical_root but NOT with
+  3. Liveness guard (ADR-024 addendum, dev-env#328): assert the worktree is a
+     *live* registered worktree, not an orphan whose `.git` link is gone. An
+     orphaned worktree dir silently resolves every git command up the tree to
+     the canonical repo's `.git`, so writes land on the wrong tree or in a
+     disconnected directory invisible to git. If `<worktree_root>/.git` is
+     missing, or `git -C <cwd> rev-parse --show-toplevel` resolves to anything
+     other than worktree_root → exit 2 with the recovery recipe.
+  4. Read file_path (Write/Edit) or notebook_path (NotebookEdit) from tool input.
+  5. If the path is absolute and starts with canonical_root but NOT with
      worktree_root → exit 2 with a blocking message naming both paths and the
      corrected worktree-relative path.
-  5. Otherwise pass (exit 0).
+  6. Otherwise pass (exit 0).
 
 Blocking: exits 2 with JSON {"reason": "..."} — the harness refuses the tool
 call and shows the reason to Claude so it can re-issue with the correct path.
@@ -28,9 +35,11 @@ Stdin JSON shape (PreToolUse):
     "cwd": "..."
   }
 """
+import _winsubp  # noqa: F401  -- suppress console windows on Windows
 import json
 import os
 import re
+import subprocess
 import sys
 
 # Matches `.claude/worktrees/<name>` anywhere in a path, capturing the repo
@@ -50,6 +59,57 @@ _PATH_FIELD = {
 
 def _normalize(path: str) -> str:
     return os.path.normcase(os.path.normpath(path))
+
+
+def _resolve_git_toplevel(cwd: str):
+    """Return git's worktree top-level for `cwd`, or None if git can't resolve it.
+
+    For a live worktree this is the worktree root. For an *orphaned* worktree dir
+    (no `.git` link file), git walks up the tree and returns the canonical repo
+    root instead — that mismatch is the orphan signature the liveness guard keys
+    on. Any execution failure (git missing, timeout, non-zero exit) returns None.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    top = result.stdout.strip()
+    return top or None
+
+
+def _worktree_is_live(
+    worktree_root: str,
+    cwd: str,
+    *,
+    path_exists=os.path.exists,
+    git_toplevel=_resolve_git_toplevel,
+) -> bool:
+    """True if `worktree_root` is a live registered worktree, not an orphan.
+
+    Two signals, cheapest first:
+      1. The `.git` link file must exist at the worktree root. An orphaned dir
+         has lost it — this is the documented incident (dev-env#328), caught
+         without spawning git.
+      2. git's resolved top-level for `cwd` must equal `worktree_root`. This
+         catches the subtle case where git mis-resolves up to the canonical repo.
+
+    If git cannot run (returns None) but the `.git` link is present, treat the
+    worktree as live — a transient git failure must not block every write when
+    the link file clearly exists.
+    """
+    if not path_exists(os.path.join(worktree_root, ".git")):
+        return False
+    top = git_toplevel(cwd)
+    if top is None:
+        return True
+    return _normalize(top) == _normalize(worktree_root)
 
 
 def main() -> None:
@@ -73,6 +133,29 @@ def main() -> None:
 
     canonical_root = m.group(1)   # e.g. C:/Users/brown/Git/dev-env
     worktree_root = m.group(0)    # e.g. C:/Users/brown/Git/dev-env/.claude/worktrees/dreamy-feistel-e004d7
+
+    # Liveness guard (dev-env#328): an orphaned worktree dir silently resolves
+    # git up to the canonical repo, so *any* write from here — relative paths and
+    # in-worktree absolute paths included — risks landing on the wrong tree or in
+    # a disconnected directory. Check before the path-scoping below so it covers
+    # all three cases, not just canonical-root absolute paths.
+    if not _worktree_is_live(worktree_root, cwd):
+        reason = (
+            f"[worktree-path-guard] BLOCKED: {tool_name} issued from an orphaned / "
+            f"disconnected worktree. The worktree directory exists but is not a live "
+            f"registered worktree (its `.git` link is missing or git resolves to the "
+            f"canonical repo), so git silently operates on the CANONICAL repo and writes "
+            f"land on the wrong tree or in a directory invisible to git.\n"
+            f"\n"
+            f"  Worktree : {worktree_root}\n"
+            f"  cwd      : {cwd}\n"
+            f"\n"
+            f"Recover by re-creating the path as a real worktree, then retry:\n"
+            f"  git worktree add --force {worktree_root} <branch>\n"
+            f"(<branch> is typically claude/<worktree-name>; confirm with `git branch -a`.)"
+        )
+        print(json.dumps({"reason": reason}))
+        sys.exit(2)
 
     file_path = data.get("tool_input", {}).get(_PATH_FIELD[tool_name], "")
     if not file_path or not os.path.isabs(file_path):

--- a/claude/scripts/tests/test_worktree_path_check.py
+++ b/claude/scripts/tests/test_worktree_path_check.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Unit + integration tests for pre-tool-use-worktree-path-check.py.
+
+Two layers, both hermetic (no real git repos, no real worktrees):
+
+  1. _worktree_is_live() decision table — the orphaned-worktree liveness guard
+     (dev-env#328). Driven with stubbed `path_exists` / `git_toplevel` so every
+     branch is exercised deterministically.
+  2. End-to-end main() via subprocess — drives the real hook over stdin and
+     asserts exit codes for:
+       - an Edit from an orphaned `.claude/worktrees/<name>` cwd (no `.git`) is
+         BLOCKED (exit 2) with the orphan recovery message;
+       - a call from a non-worktree cwd is a no-op (exit 0).
+
+Usage:
+    py -3 claude/scripts/tests/test_worktree_path_check.py
+
+Exit 0 = all pass.
+"""
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# tests/ -> scripts/ -> claude/ -> repo root
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = SCRIPTS_DIR / "pre-tool-use-worktree-path-check.py"
+
+# The module's first line is `import _winsubp`; ensure scripts/ is importable.
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("worktree_path_check", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+wpc = _load_module()
+
+_WT = "C:/Users/brown/Git/dev-env/.claude/worktrees/hardcore-williams-9df32f"
+_CANON = "C:/Users/brown/Git/dev-env"
+
+
+def test_worktree_is_live_decision_table() -> str:
+    cases = [
+        # (label, git_link_present, git_toplevel_return, expected_live)
+        ("live: .git present, toplevel == worktree_root", True, _WT, True),
+        ("orphan: .git link missing", False, _WT, False),
+        ("orphan: git resolves up to canonical root", True, _CANON, False),
+        ("orphan: git returns unrelated path", True, "C:/somewhere/else", False),
+        (".git present but git exec failed (None) → don't false-block", True, None, True),
+        ("live: toplevel differs only by case/sep", True, _WT.replace("/", "\\").upper(), True),
+    ]
+    for label, link_present, top, expected in cases:
+        live = wpc._worktree_is_live(
+            _WT,
+            _WT,
+            path_exists=lambda _p, _present=link_present: _present,
+            git_toplevel=lambda _c, _top=top: _top,
+        )
+        if live != expected:
+            raise AssertionError(f"{label}: _worktree_is_live = {live}, expected {expected}")
+    return f"{len(cases)} liveness combinations classified correctly"
+
+
+def test_git_link_check_short_circuits_before_git() -> str:
+    """When the .git link is missing, git_toplevel must not even be consulted."""
+    called = {"n": 0}
+
+    def _spy(_cwd):
+        called["n"] += 1
+        return _WT
+
+    live = wpc._worktree_is_live(
+        _WT, _WT, path_exists=lambda _p: False, git_toplevel=_spy
+    )
+    if live is not False:
+        raise AssertionError("missing .git link should yield not-live")
+    if called["n"] != 0:
+        raise AssertionError("git_toplevel was called despite missing .git link (no short-circuit)")
+    return "missing .git link blocks without spawning git"
+
+
+def _run_hook(payload: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(MODULE_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_main_blocks_edit_from_orphaned_worktree() -> str:
+    """Acceptance: an Edit from an orphaned worktree cwd (no .git) is blocked."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # Build <tmp>/.claude/worktrees/<name> with NO .git link — an orphan.
+        orphan = Path(tmp) / ".claude" / "worktrees" / "orphan-name"
+        orphan.mkdir(parents=True)
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": str(orphan / "some_file.py")},
+            "cwd": str(orphan),
+        }
+        proc = _run_hook(payload)
+        if proc.returncode != 2:
+            raise AssertionError(
+                f"expected exit 2 (block), got {proc.returncode}. stderr={proc.stderr!r}"
+            )
+        try:
+            reason = json.loads(proc.stdout).get("reason", "")
+        except json.JSONDecodeError:
+            raise AssertionError(f"stdout was not JSON: {proc.stdout!r}")
+        if "orphaned" not in reason or "git worktree add --force" not in reason:
+            raise AssertionError(f"block reason missing orphan/recovery text: {reason!r}")
+    return "Edit from orphaned worktree cwd blocked (exit 2) with recovery recipe"
+
+
+def test_main_noop_outside_worktree() -> str:
+    """A call whose cwd is not a Claude-managed worktree is a no-op (exit 0)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(Path(tmp) / "x.py")},
+            "cwd": tmp,
+        }
+        proc = _run_hook(payload)
+        if proc.returncode != 0:
+            raise AssertionError(
+                f"expected exit 0 (no-op) outside worktree, got {proc.returncode}. "
+                f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+            )
+    return "non-worktree cwd is a no-op (exit 0)"
+
+
+def main() -> int:
+    tests = [
+        ("_worktree_is_live decision table", test_worktree_is_live_decision_table),
+        ("missing .git short-circuits before git", test_git_link_check_short_circuits_before_git),
+        ("main() blocks Edit from orphaned worktree", test_main_blocks_edit_from_orphaned_worktree),
+        ("main() no-op outside worktree", test_main_noop_outside_worktree),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            detail = fn()
+            print(f"PASS: {name}")
+            print(f"      {detail}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL: {name}")
+            for line in str(e).splitlines():
+                print(f"      {line}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR: {name}: {type(e).__name__}: {e}")
+    print()
+    print(f"Tests: {len(tests) - failed} passed, 0 skipped, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -116,7 +116,7 @@ Scaffolds a new project's journal home (`sessions/<slug>/`) in engineering-journ
 
 ## Hooks
 
-Most hooks are **advisory** — they emit `systemMessage` reminders but do not block tool execution. The exception is `pre-tool-use-worktree-path-check.py` (a `PreToolUse` hook), which exits 2 with a `{"reason": "..."}` payload to block `Write`, `Edit`, and `NotebookEdit` calls that target the canonical repo root instead of the active worktree.
+Most hooks are **advisory** — they emit `systemMessage` reminders but do not block tool execution. The exception is `pre-tool-use-worktree-path-check.py` (a `PreToolUse` hook), which exits 2 with a `{"reason": "..."}` payload to block `Write`, `Edit`, and `NotebookEdit` calls that target the canonical repo root instead of the active worktree, or that are issued from an orphaned worktree whose `.git` link no longer resolves (so git silently operates on the canonical repo).
 
 Configuration is in `claude/settings.json` (symlinked to `~/.claude/settings.json`).
 See [ADR-007](adr/007-hook-command-invocation.md) for why hooks invoke scripts via `pyw -3` (the windowless variant of the Windows Python Launcher) rather than `python3` directly, wrapped in `bash -c`, or via `py -3` (which flashes a console window per spawn). Shell-invoked Python (the `## Testing` command, skill `py -3` examples, and the `pre-push` hook) continues to use `py -3`.
@@ -169,7 +169,7 @@ Fires before matched tool calls. Matcher values are set per entry in `settings.j
 
 | Script | Trigger condition | What it does |
 |--------|------------------|-------------|
-| `pre-tool-use-worktree-path-check.py` | Session `cwd` is inside a Claude-managed worktree and `file_path` (or `notebook_path`) is absolute and starts with the canonical repo root | **Blocks** the tool call (exit 2) with a message naming the attempted path, the active worktree root, and the corrected path. No-op when the session is not in a worktree or when the path already targets the worktree root. **Bypass for intentional canonical edits:** use `Bash` with `node -e`, `sed`, or `python3` — the hook only covers the three file tools, not `Bash`. [ADR-024](adr/024-worktree-path-guard-hook.md) |
+| `pre-tool-use-worktree-path-check.py` | Session `cwd` is inside a Claude-managed worktree and either (a) the worktree is **orphaned** — its `.git` link is missing or `git rev-parse --show-toplevel` does not resolve to the worktree root — or (b) `file_path`/`notebook_path` is absolute and starts with the canonical repo root | **Blocks** the tool call (exit 2). For an orphaned worktree, the message names the worktree + cwd and gives the recovery recipe `git worktree add --force <worktree_root> <branch>` (covers all writes from the orphan, not just canonical-root paths). Otherwise the message names the attempted path, the active worktree root, and the corrected path. No-op when the session is not in a worktree, or (for case b) when the path already targets the worktree root. The liveness check runs one `git rev-parse` per file write in a worktree, short-circuited when the `.git` link is already missing. **Bypass for intentional canonical edits:** use `Bash` with `node -e`, `sed`, or `python3` — the hook only covers the three file tools, not `Bash`. [ADR-024](adr/024-worktree-path-guard-hook.md) |
 
 ---
 

--- a/docs/adr/024-worktree-path-guard-hook.md
+++ b/docs/adr/024-worktree-path-guard-hook.md
@@ -119,6 +119,17 @@ and giving the recovery recipe `git worktree add --force <worktree_root> <branch
   block is recoverable (clear message + recipe); a silent wrong-tree write is
   not. But blocking every write when git is momentarily unavailable yet the
   `.git` link plainly exists would be a worse failure mode, so step 3 fails open.
+- **Both signals retained despite the per-write git spawn.** The `.git`-existence
+  check (signal 1) catches the documented incident — an orphan whose link file is
+  gone — with no subprocess. Signal 2 (`git rev-parse --show-toplevel`) is *not*
+  merely belt-and-suspenders: it catches a distinct, real orphan mode where the
+  `.git` file still exists but its `gitdir:` target was removed (e.g. a later
+  `git worktree prune` deleted `<canonical>/.git/worktrees/<name>` while the
+  checkout dir remained), so git silently resolves up to the canonical repo even
+  though signal 1 passes. The cost — one fast, windowless `git rev-parse` per
+  file write *in a worktree only* (~10–30 ms, `CREATE_NO_WINDOW`) — is acceptable
+  for closing that second mode; memoizing liveness per session was considered and
+  rejected to keep the hook stateless.
 - **Extend the hook, not a new SessionStart guard.** Option A (this) converts the
   silent failure into a hard block at the moment of risk and is testable in the
   same hermetic style; Options B/C (issue #328) were not pursued.

--- a/docs/adr/024-worktree-path-guard-hook.md
+++ b/docs/adr/024-worktree-path-guard-hook.md
@@ -1,8 +1,8 @@
 # ADR-024: PreToolUse Hook to Block Canonical-Root Writes from Worktrees
 
-**Date:** 2026-05-23
+**Date:** 2026-05-23 (amended 2026-06-06)
 **Status:** Accepted
-**Tags:** hooks, worktrees, pre-tool-use, file-safety, write, edit
+**Tags:** hooks, worktrees, pre-tool-use, file-safety, write, edit, orphaned-worktree
 
 ---
 
@@ -64,10 +64,86 @@ On Windows, `os.path.relpath` raises `ValueError` when source and target are on 
 
 ---
 
+## Addendum (2026-06-06): orphaned-worktree liveness guard (dev-env#328)
+
+### Problem the original decision missed
+
+The original logic keys entirely on the cwd **path string**. It extracts
+`worktree_root` from the path and checks whether `file_path` is lexically inside
+it — but never verifies the worktree directory is a *live, registered* git
+worktree.
+
+An **orphaned worktree** — a `.claude/worktrees/<name>/` directory that still
+exists on disk but has lost its `.git` link file and is no longer in
+`git worktree list` — defeats this. Git, finding no `.git` at the directory,
+walks **up** the tree and resolves every command to the **canonical** repo's
+`.git`. The harness still treats the directory as the session's worktree (sets
+cwd there, force-resets cwd to it after each command), so the failure is silent:
+
+- `git status`/`branch`/`stash`/`checkout` operate on the canonical checkout —
+  `git stash -u` stashed an unrelated branch's WIP; `git checkout -b` moved the
+  canonical checkout onto a new branch.
+- `Write`/`Edit` (absolute paths) landed files in the disconnected directory,
+  invisible to git.
+
+For this case the original hook computes `worktree_root` from the path, sees the
+target is "inside" it, and **passes** — missing the exact case it most needs to
+catch. Observed in a career-playbook session on 2026-06-06; recovery took several
+careful steps (restore canonical branch, `git stash pop`, `git worktree add
+--force`, move stranded files back).
+
+### Extended decision
+
+Before the path-scoping check, `main()` now asserts the worktree is **live** via
+`_worktree_is_live(worktree_root, cwd)`:
+
+1. `<worktree_root>/.git` must exist (the worktree link file). Missing → **not
+   live** (the documented orphan signature; caught without spawning git).
+2. `git -C <cwd> rev-parse --show-toplevel` must equal `worktree_root`. A
+   resolution to the canonical root (or anywhere else) → **not live** (subtle
+   mis-resolution).
+3. If git cannot run at all (returns `None`) but the `.git` link is present →
+   treated as **live** — a transient git failure must not block every write when
+   the link file clearly exists.
+
+Not-live → exit 2 with a `{"reason": ...}` message naming the worktree and cwd
+and giving the recovery recipe `git worktree add --force <worktree_root> <branch>`.
+
+### Judgment calls (addendum)
+
+- **Check placed before path-scoping.** The orphan risk applies to *any* write
+  from the dead cwd — relative paths and in-worktree absolute paths included, not
+  just canonical-root absolute paths — so the liveness gate runs first and covers
+  all three.
+- **Fail-closed on a genuine orphan, fail-open on transient git failure.** A
+  block is recoverable (clear message + recipe); a silent wrong-tree write is
+  not. But blocking every write when git is momentarily unavailable yet the
+  `.git` link plainly exists would be a worse failure mode, so step 3 fails open.
+- **Extend the hook, not a new SessionStart guard.** Option A (this) converts the
+  silent failure into a hard block at the moment of risk and is testable in the
+  same hermetic style; Options B/C (issue #328) were not pursued.
+- **`import _winsubp`.** The hook now spawns `git` under `pythonw`, so it adopts
+  the console-flash-suppression module per ADR-007.
+
+### Consequences (addendum)
+
+- **Performance:** one `git rev-parse --show-toplevel` per file write *in a
+  worktree only*, short-circuited (no subprocess) when the `.git` link is already
+  missing. No-op outside worktrees is unchanged.
+- **Coverage:** still limited to `Write`/`Edit`/`NotebookEdit`; Bash writes from
+  an orphan remain uncovered (same deferral as the original decision).
+- Covered by `claude/scripts/tests/test_worktree_path_check.py` (hermetic unit +
+  subprocess integration tests).
+
+---
+
 ## References
 
 - `claude/scripts/pre-tool-use-worktree-path-check.py` — implementation
+- `claude/scripts/tests/test_worktree_path_check.py` — self-test (addendum)
 - `claude/settings.json` — hook wiring
-- `brownm09/career-playbook#276` — downstream symptom tracker
+- `brownm09/career-playbook#276` — downstream symptom tracker (original)
+- `brownm09/dev-env#328` — orphaned-worktree hardening (addendum)
 - Engineering-journal `sessions/career-playbook/2026-05-22_140307.stub.md` — third occurrence
+- Engineering-journal `sessions/career-playbook/2026-06-06_105718.stub.md` — orphaned-worktree incident
 - [Claude Code Hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks) — hook exit codes and JSON output format

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -28,7 +28,7 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [021](021-auto-stub-on-pr-push.md) | Auto-Write Journal Stub on git push to Open PR Branch | 2026-05-11 | Accepted | journal, stubs, hooks, post-tool-use, git-push, automation |
 | [022](022-test-coverage-gate-before-pr.md) | Test Coverage Gate: Require Declaration of New Testable Behavior Before PR | 2026-05-16 | Accepted | testing, coverage, workflow, git, pr, blocking-rule |
 | [023](023-generic-required-fields-issue-hook.md) | Generic `required_fields` Config for Issue/PR Project-Board Hook | 2026-05-16 | Accepted | hooks, github-project, post-tool-use, hook-config, automation, workflow |
-| [024](024-worktree-path-guard-hook.md) | PreToolUse Hook to Block Canonical-Root Writes from Worktrees | 2026-05-23 | Accepted | hooks, worktrees, pre-tool-use, file-safety, write, edit |
+| [024](024-worktree-path-guard-hook.md) | PreToolUse Hook to Block Canonical-Root Writes from Worktrees | 2026-05-23 (amended 2026-06-06) | Accepted | hooks, worktrees, pre-tool-use, file-safety, write, edit, orphaned-worktree |
 | [025](025-default-plan-mode.md) | Default Plan Mode | 2026-05-23 | Accepted | config, settings, plan-mode, workflow, defaults |
 | [026](026-suppression-policy.md) | Suppression Policy: No Silent Workarounds for Type and Lint Errors | 2026-05-24 | Accepted | code-quality, typescript, eslint, workflow, suppression, pre-pr |
 | [027](027-userpromptsubmit-blocking-hook-conventions.md) | UserPromptSubmit Hook Output: stderr for Blocking, Per-Session Marker Files | 2026-05-27 | Accepted | hooks, UserPromptSubmit, stderr, per-session-state, claude-code-contract |


### PR DESCRIPTION
## Summary

Hardens the worktree-path guard against **orphaned Claude-managed worktrees** — a `<repo>/.claude/worktrees/<name>/` directory that still exists on disk but is no longer a registered git worktree (its `.git` link is gone). Git then resolves every command *up the tree* to the canonical repo, so writes silently land on the wrong tree or in a directory invisible to git, while the harness keeps treating the dead dir as the active worktree.

The existing `pre-tool-use-worktree-path-check.py` keyed only on the cwd path *string*, computed the worktree root from it, saw the target was "inside" it, and **passed** — missing the exact case it most needed to catch.

Closes #328.

## Changes

- **`claude/scripts/pre-tool-use-worktree-path-check.py`** — adds a liveness guard that runs *before* the existing path-scoping (so it covers relative and in-worktree absolute paths, not just canonical-root paths):
  - `_worktree_is_live()` — (1) `<worktree_root>/.git` must exist (orphan signature, caught without spawning git); (2) `git -C <cwd> rev-parse --show-toplevel` must equal the worktree root (catches mis-resolution to canonical); (3) if git can't run but `.git` is present → treated as live (no false-block on transient git failure).
  - Not-live → exit 2 with `{"reason"}` naming the worktree + cwd and the recovery recipe `git worktree add --force <worktree_root> <branch>`.
  - Adds `import _winsubp` (now spawns `git` under `pythonw` — ADR-007 console-flash suppression).
- **`claude/scripts/tests/test_worktree_path_check.py`** — new hermetic self-test (unit decision table + subprocess integration).
- **Docs:** README hooks table/intro, `docs/REFERENCE.md` hook entry, **ADR-024 addendum (2026-06-06)**, `docs/adr/INDEX.md` row.

## Testing

Per dev-env `## Testing`:

- **Hook-script syntax check** (`ast.parse` over `claude/scripts/*.py`) — OK.
- **New self-test** `py -3 claude/scripts/tests/test_worktree_path_check.py` — `Tests: 4 passed, 0 skipped, 0 failed`. Covers the liveness decision table (6 combinations), `.git`-missing short-circuit, end-to-end block of an Edit from an orphaned worktree cwd (exit 2 + recovery text — the acceptance criterion), and non-worktree no-op (exit 0).
- **`pyw -3` stdio test** `py -3 claude/scripts/tests/test_pyw_stdio.py` — `Tests: 6 passed, 0 skipped, 0 failed` (confirms the new `_winsubp` import keeps every hook on the `pyw -3` contract; "every subprocess-using hook imports `_winsubp`" now counts this script).

The live-worktree path is also exercised implicitly: this PR was authored from a live worktree and all Edit/Write calls succeeded.

**Outcome:** all green.

## Coverage / integrity gates

- **Coverage gate:** new behavior covered by the new self-test (above).
- **Suppression grep:** clean (no suppressions added).
- **Test-integrity grep:** the only matches are the `xit(` false-positive class matching `e**xit(**` in the hook's normal `sys.exit(...)` calls — no skip markers, no deleted tests, no lowered thresholds.
- **Lockfile / baseline:** N/A — no `package.json` change; dev-env is not a Jest repo.

## Risk audit

- **Resilience:** fail-closed (block, recoverable with recipe) on a genuine orphan; fail-open only on transient git failure when the `.git` link is present.
- **Performance:** one `git rev-parse` per file write *in a worktree only*, short-circuited (no subprocess) when `.git` is already missing; no-op outside worktrees unchanged.
- **Security:** `git` invoked with list args (no shell); cwd from the harness; no new input surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review findings disposition

`/review` run in-session (0 blocking, 1 non-blocking, 1 question) — [comment](https://github.com/brownm09/dev-env/pull/329#issuecomment-4641279583), `reviewed-by-claude` applied. All findings dispositioned:

- **[non-blocking, maintainability] Python language-scope scanner gap** — verified, no change. The new `.py` test was manually confirmed to contain no skip idioms (`@pytest.mark.skip`, `pytest.skip(`, etc.); ADR-029's JS/TS-only scanners simply can't inspect it.
- **[question] per-write `git rev-parse` cost** — fixed in `9925b41`. Added an ADR-024 judgment-call bullet documenting that signal 2 is not redundant with the `.git`-existence check: it catches a distinct orphan mode (the `.git` file exists but its `gitdir:` target was pruned), so the per-edit windowless git spawn is a deliberate, justified cost; per-session memoization was considered and rejected to keep the hook stateless.
