### PR TITLE
docs: correct worktree-merge runbook on remote branch delete

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -401,9 +401,13 @@ the GitHub REST API via `gh`, which goes over authenticated HTTPS and bypasses s
 gh api -X DELETE "repos/{owner}/{repo}/git/refs/heads/<branch>"
 ```
 
-For the merge case, prefer `gh pr merge --squash --delete-branch` — its branch delete already uses
-the API path and is unaffected. Alternatively, defer deletion to GitHub's "automatically delete
-head branches" repo setting or the weekly `prune-stale-worktrees` routine.
+For the merge case, prefer `gh pr merge --squash --delete-branch` — its remote branch delete already
+uses the API path, so it is unaffected by *this* send-pack proxy issue. Note the separate worktree
+caveat: when the merge is run *from a worktree*, gh aborts at its local-checkout step before reaching
+that API delete, so the remote branch is left in place regardless — see
+[Merging a PR developed in a worktree](#merging-a-pr-developed-in-a-worktree) below. Alternatively,
+defer deletion to GitHub's "automatically delete head branches" repo setting or the weekly
+`prune-stale-worktrees` routine.
 
 **Upstream fix (Claude Code sandbox).** Proxy the send-pack sideband for delete-only ref updates
 — relay the full `git-receive-pack` response before closing the POST. (A full-clone fallback would

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -422,10 +422,32 @@ behavioral *rules* stay in CLAUDE.md; these are the step-by-step details.
 ### Merging a PR developed in a worktree
 
 Run `gh pr merge --squash --delete-branch` directly from the worktree. Do **not** call `ExitWorktree`
-first — it is session-bound and becomes a no-op after `/compact` (the common case). `gh` will fail to
-check out main locally and fail to delete the local branch (the worktree holds it checked out), but
-the remote merge and remote branch delete complete successfully — those errors are benign. The local
-worktree directory and branch are cleaned up by the weekly `prune-merged-worktrees.py` run.
+first — it is session-bound and becomes a no-op after `/compact` (the common case).
+
+**The merge itself succeeds, but `--delete-branch` does not delete the remote branch from a worktree.**
+`gh pr merge` performs the squash-merge first (a server-side API call that completes), then runs its
+`--delete-branch` cleanup in *local-then-remote* order: it checks out the default branch and deletes
+the **local** branch, *then* deletes the **remote** branch. From a worktree the local checkout step
+fails — `gh` prints `failed to run git: fatal: 'main' is already checked out at C:/Users/brown/Git/dev-env`
+(the canonical clone holds `main`, and the worktree holds the PR branch) — and `gh` aborts at that
+point. Because the abort happens *before* the remote-delete step, **both the local branch delete and
+the remote branch delete are skipped.** Confirmed on dev-env PRs #327 and #329 (2026-06-06): each
+left the remote ref in place, requiring a manual delete that reported `[deleted]`.
+
+After the merge, delete the remote ref manually:
+
+```bash
+git push origin --delete <branch>
+# or, in a web/cloud session where send-pack is blocked (see the web-session runbook below):
+gh api -X DELETE "repos/{owner}/{repo}/git/refs/heads/<branch>"
+```
+
+The local worktree directory and branch are cleaned up by the weekly `prune-merged-worktrees.py` run.
+
+**Secondary effect — no post-merge usage snapshot.** Because the `gh pr merge` invocation exits
+non-zero on the failed local-checkout tail, the `PostToolUse` post-merge hook does **not** emit its
+`### Usage Snapshot (post-merge)` block — it keys off a clean `gh pr merge`. When merging from a
+worktree, expect the snapshot to be absent and capture usage by other means for the journal stub.
 
 ### Separate clones for fully independent parallel work
 


### PR DESCRIPTION
## Summary

Corrects an inaccuracy in the **"Merging a PR developed in a worktree"** runbook (`docs/REFERENCE.md`). The runbook claimed that when `gh pr merge --squash --delete-branch` is run from a Claude-managed worktree, "the remote merge **and remote branch delete** complete successfully — those errors are benign." The remote branch delete does **not** complete.

### Root cause (verified)

`gh pr merge --delete-branch` runs branch cleanup in *local-then-remote* order: it checks out the default branch and deletes the local branch, *then* deletes the remote branch. The merge itself is a prior server-side API call that has already completed. From a worktree the local checkout step fails (`fatal: 'main' is already checked out at C:/Users/brown/Git/dev-env`), `gh` aborts at that point, and the remote-delete step never runs. Net: **merge succeeds, but both the local and remote branch deletes are skipped.**

Observed twice on 2026-06-06 (PRs #327 and #329): each merge left the remote ref in place; it had to be removed manually with `git push origin --delete <branch>`, which reported `[deleted]` — proving the ref still existed post-merge. Re-verified this session: both refs are now absent only because they were deleted by hand afterward.

### Changes

- Rewrite the runbook to state both deletes are skipped and give the manual remote-ref delete recipe (`git push origin --delete <branch>`, or `gh api -X DELETE repos/{owner}/{repo}/git/refs/heads/<branch>` for web/cloud sessions).
- Add a **secondary effect** note: the `PostToolUse` post-merge usage-snapshot hook does not emit its `### Usage Snapshot (post-merge)` block in this failure case, because it keys off a clean (zero-exit) `gh pr merge`.

## Testing

Docs-only change to `docs/REFERENCE.md` — no runtime, scripts, or hooks touched, so the `## Testing` hook-script self-tests do not apply (the docs-only guard #4 targets `claude/CLAUDE.md`, which is unchanged). Verification performed:

- **Error Message Diligence trace** — confirmed via `gh pr view 327/329` (both MERGED) and `git ls-remote --heads origin <branch>` (both refs absent only after the manual delete) that the remote branch survived `gh pr merge --delete-branch`. Root cause traced to gh's local-then-remote cleanup ordering, not restated from the error text.
- **Link integrity** — the new "see the web-session runbook below" reference resolves to the existing `### Deleting a remote branch in Claude Code web sessions` section (line 443).
- **Suppression grep** — clean (no matches on the diff).
- **Test-integrity grep** — clean (no matches on the diff).

No automated test suite applies. Tests: N/A (docs-only, no runtime).

## ADR-warrant / doc-reconciliation

- **ADR-warrant: not warranted** — factual correction to an operational runbook; no rule/hook/skill/settings change, and the rationale (gh local-then-remote ordering) lives in the corrected text.
- **Doc-reconciliation: not warranted** — no skill/hook/script/routine added, removed, renamed, or behavior-changed; no README/Documentation-Maintenance updates required.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review findings disposition

`/review` (claude-opus-4-8) found **0 blocking, 1 non-blocking**:

- **[non-blocking, documentation] ADR-035 merge-case line could mislead worktree readers** — the web-session section said `gh pr merge --delete-branch`'s remote delete "is unaffected" (scoped to the send-pack proxy issue), which could read as "remote branch is cleaned up" to someone merging from a worktree. **Fixed in `97f0987`** — added a worktree caveat + cross-reference to the "Merging a PR developed in a worktree" runbook so the two sections agree.
