### PR TITLE
Fix get-project-item.sh scratch-path resolution on Windows + Git Bash (#334)

### DIFF
--- a/claude/scripts/get-project-item.sh
+++ b/claude/scripts/get-project-item.sh
@@ -23,25 +23,28 @@ fi
 PROJECT_NUMBER="${2:-${PROJECT_NUMBER:-3}}"
 OWNER="${3:-${PROJECT_OWNER:-brownm09}}"
 
-SCRATCH="${HOME}/.claude/scratch"
+# Literal Windows-style path (not "${HOME}/...") so Git Bash and Node resolve it
+# identically. Under Git Bash $HOME is the MSYS path /c/Users/brown; Node on Windows
+# resolves a leading /c/... against the current drive (-> C:\c\Users\...), so the
+# redirect-write and the node-read would target different files (dev-env#334). This
+# matches the repo convention (DEFAULT_LOG in session-mode-report.py).
+SCRATCH="C:/Users/brown/.claude/scratch"
 TMPFILE="${SCRATCH}/tmp_project_item_$$.json"
+trap 'rm -f "$TMPFILE"' EXIT
 
 gh project item-list "$PROJECT_NUMBER" \
   --owner "$OWNER" \
   --format json \
   --limit 1000 > "$TMPFILE"
 
+# Under `set -e` a non-zero exit from node (e.g. no matching item) aborts the script
+# with that status; the EXIT trap above removes the temp file either way. (The former
+# `EXIT_CODE=$?` guard here was dead code — set -e aborted before it could run.)
 ITEM_ID=$(node -e "
   const d = JSON.parse(require('fs').readFileSync('$TMPFILE', 'utf8'));
   const item = d.items.find(i => i.content && i.content.number === $ISSUE_NUMBER);
   if (!item) { process.stderr.write('get-project-item: no item found for #$ISSUE_NUMBER\n'); process.exit(1); }
   console.log(item.id);
 ")
-EXIT_CODE=$?
-rm -f "$TMPFILE"
-
-if [[ $EXIT_CODE -ne 0 ]]; then
-  exit 1
-fi
 
 echo "$ITEM_ID"


### PR DESCRIPTION
## Summary

Fixes `claude/scripts/get-project-item.sh`, which exited 1 with `ENOENT … C:\c\Users\brown\.claude\scratch\…` on every invocation on Windows + Git Bash.

**Root cause.** Line 26 set `SCRATCH="${HOME}/.claude/scratch"`. Under Git Bash `$HOME` is the MSYS path `/c/Users/brown`. The `gh … > "$TMPFILE"` redirect is performed by Git Bash, which maps `/c/Users/…` → `C:\Users\…` correctly. But the `node -e` read of the same `$TMPFILE` string ran under Node-on-Windows, which resolves a leading `/c/…` against the *current drive* → `C:\c\Users\…`. Write and read targeted different files → ENOENT.

**Fix.** Hardcode the literal Windows-style path `C:/Users/brown/.claude/scratch`, which Git Bash and Node resolve identically. This matches the existing repo convention — `DEFAULT_LOG` in `claude/scripts/session-mode-report.py` and the scratch-dir guidance in global + project `CLAUDE.md`.

**Secondary fix.** The old `EXIT_CODE=$?` guard (line 40) was dead code: under `set -e`, a non-zero `node -e` exit aborts the script before the assignment, so the `if [[ $EXIT_CODE -ne 0 ]]` block never ran. Replaced it with a `trap 'rm -f "$TMPFILE"' EXIT` so the temp file is cleaned up on *every* exit path, and a no-match case still exits 1 via `set -e` propagating node's exit code.

Closes #334

## Testing

Per dev-env `## Testing`. This is a `.sh` utility with no unit-test harness; verification is the syntax checks plus the live repro (success + failure paths).

- **`bash -n claude/scripts/get-project-item.sh`** → PARSE OK
- **`py -3 -c "import ast … ast.parse …" claude/scripts/*.py`** (hook-script syntax check) → AST OK (unaffected; .py scripts untouched)
- **Live repro — success:** `bash claude/scripts/get-project-item.sh 330` → `PVTI_lAHOAjEKvM4BWKFezgu8RAQ` (previously ENOENT exit 1) ✅
- **Live repro — failure path:** `bash claude/scripts/get-project-item.sh 99999999` → stderr `get-project-item: no item found for #99999999`, **exit 1** ✅
- **Temp-file cleanup:** scratch-dir temp-file count held steady across both success and failure runs (the `trap` removes the file on every exit). Removed two stale orphan temp files left by the *original* broken script (08:02 today), which are exactly the bug's symptom — set -e aborted before the old `rm`.

`Tests: no automated test suite for .sh utilities — manual verification above; 4 checks passed, 0 skipped, 0 failed`

**Coverage gate:** No JS/TS/py test framework covers these standalone `.sh` utilities; behavior verified via the live repro above (success + failure + cleanup). Deferring an automated harness for shell utilities as out of scope for a one-line path fix.

**Suppression / test-integrity greps:** Suppression grep clean. Test-integrity grep produced one match — `process.exit(1)` inside the unchanged `node -e` snippet matched the `xit\(` Jest-marker pattern as a substring of "e**xit(**". This is a documented false-positive class (substring over-match), not a `xit(` pending-test marker. No real violation.

## ADR-warrant

N/A — bug fix to an existing utility script. No rule/hook contract/skill/settings change; rationale is captured in the issue, code comments, and commit message.

## Doc-reconciliation

N/A — invocation syntax unchanged, so the `docs/REFERENCE.md` Utilities row and `README.md` need no update.


## Review findings disposition

`/review` (claude-opus-4-8) returned **0 blocking, 0 non-blocking** findings — nothing to fix or file. The `reviewed-by-claude` label is applied. ([review comment](https://github.com/brownm09/dev-env/pull/335#issuecomment-4643304139))
