### PR TITLE
Add execution-level verification for shell scripts (#337)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,37 @@ before PR" rule in [`claude/CLAUDE.md`](claude/CLAUDE.md) defers to this section
    `grep -n 'date -u' claude/CLAUDE.md` and confirm every match is in an internal operational
    artifact context (lock files, log timestamps) — not in stub filename or branch name descriptions.
 
+5. **Script path-hygiene lint** — required when adding or changing any `claude/scripts/*.sh` or
+   `claude/hooks/*` shell script. Flags the [dev-env#334](https://github.com/brownm09/dev-env/issues/334)
+   failure class: a `$HOME`-rooted scratch/temp path passed to `node` (Git Bash writes
+   `/c/Users/...` → `C:\Users\...`, but Node-on-Windows re-resolves the same string to
+   `C:\c\Users\...` → ENOENT). Scripts must use the literal `C:/Users/brown/.claude/scratch`
+   instead. Hermetic; comments mentioning `$HOME` are ignored.
+
+   ```bash
+   bash claude/scripts/tests/check-script-path-hygiene.sh
+   ```
+
+6. **`get-project-item.sh` smoke test** — required when changing `claude/scripts/get-project-item.sh`.
+   Actually *runs* the script (which `bash -n` cannot — #334 parsed cleanly yet failed at runtime):
+   asserts a known issue resolves to a `PVTI_` id, the no-match path exits 1, and the temp file is
+   cleaned up. Network-dependent — SKIPs (exit 0) when `gh` is unauthenticated/offline, so it is a
+   local pre-PR check, not a CI gate.
+
+   ```bash
+   bash claude/scripts/tests/test-get-project-item.sh
+   ```
+
+7. **shellcheck gate** — recommended when changing any shell script. Blocking at `--severity=error`
+   (the tree is error-clean as of 2026-06-07); pre-existing warnings/info are printed advisorily and
+   not gated. SKIPs (exit 0) with an install hint when `shellcheck` is absent — it is not installed by
+   default here and `choco install shellcheck` needs an elevated shell, so set `SHELLCHECK_BIN` to a
+   [portable binary](https://github.com/koalaman/shellcheck/releases) to run it locally.
+
+   ```bash
+   bash claude/scripts/tests/run-shellcheck.sh
+   ```
+
 ## Observability
 
 dev-env has **no long-running runtime to instrument** — it is a configuration repo whose

--- a/claude/scripts/tests/check-script-path-hygiene.sh
+++ b/claude/scripts/tests/check-script-path-hygiene.sh
@@ -33,14 +33,18 @@ mapfile -t FILES < <(
   } | sort -u
 )
 
+# grep the file for $1 with real line numbers, dropping full-line comments so a
+# script that merely *documents* the hazard (mentions node or $HOME in a comment)
+# is not flagged. Real file line numbers are preserved (grep -n on the file, then
+# filter out `N:   # ...` comment lines) so offender output points at the true line.
 OFFENDERS=0
 for f in "${FILES[@]}"; do
   [ -f "$f" ] || continue
-  # (a) does it call node?
-  grep -qE '\bnode\b' "$f" || continue
-  # (b) non-comment line assigning a $HOME-rooted path? Strip full-line comments
-  # first so a documentation mention of $HOME does not match.
-  hits=$(grep -vE '^[[:space:]]*#' "$f" | grep -nE '=[[:space:]]*"?'"'"'?\$\{?HOME\}?/' || true)
+  code_lines() { grep -nE "$1" "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true; }
+  # (a) does it actually call node (outside comments)?
+  [ -n "$(code_lines '\bnode\b')" ] || continue
+  # (b) does it assign a $HOME-rooted path (outside comments)?
+  hits=$(code_lines '=[[:space:]]*"?'"'"'?\$\{?HOME\}?/')
   if [ -n "$hits" ]; then
     OFFENDERS=$((OFFENDERS + 1))
     {

--- a/claude/scripts/tests/check-script-path-hygiene.sh
+++ b/claude/scripts/tests/check-script-path-hygiene.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# check-script-path-hygiene.sh — lint for the dev-env#334 failure class.
+#
+# Bug class: a scratch/temp path derived from $HOME is written by a Git Bash
+# redirect (which maps the MSYS `/c/Users/...` to `C:\Users\...`) but then read
+# back by Node-on-Windows, which resolves a leading `/c/...` against the current
+# drive (`C:\c\Users\...`). The write and the read target different files →
+# ENOENT on every invocation. See dev-env#334 and the fix in get-project-item.sh.
+#
+# Rule: a shell script that (a) invokes `node`, AND (b) assigns a path rooted at
+# $HOME / ${HOME} on a NON-comment line, is at risk. Such scripts must use the
+# literal Windows-style scratch path `C:/Users/brown/.claude/scratch` instead, so
+# Git Bash and Node resolve it identically (matches DEFAULT_LOG in
+# session-mode-report.py and the scratch-dir convention in CLAUDE.md).
+#
+# Comments are stripped before matching so a script may *document* the hazard
+# (as get-project-item.sh does) without tripping the lint.
+#
+# Exit 0 = clean; exit 1 = at least one offender (offending file + lines printed
+# to stderr). Run: bash claude/scripts/tests/check-script-path-hygiene.sh
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+cd "$REPO_ROOT"
+
+# Shell files to scan: *.sh under scripts/ (+ tests) plus shebang-#!sh hook files.
+mapfile -t FILES < <(
+  {
+    ls claude/scripts/*.sh claude/scripts/tests/*.sh claude/hooks/tests/*.sh 2>/dev/null
+    for f in claude/hooks/*; do
+      [ -f "$f" ] && head -1 "$f" | grep -qE '^#!.*\bsh\b' && echo "$f"
+    done
+  } | sort -u
+)
+
+OFFENDERS=0
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || continue
+  # (a) does it call node?
+  grep -qE '\bnode\b' "$f" || continue
+  # (b) non-comment line assigning a $HOME-rooted path? Strip full-line comments
+  # first so a documentation mention of $HOME does not match.
+  hits=$(grep -vE '^[[:space:]]*#' "$f" | grep -nE '=[[:space:]]*"?'"'"'?\$\{?HOME\}?/' || true)
+  if [ -n "$hits" ]; then
+    OFFENDERS=$((OFFENDERS + 1))
+    {
+      echo "OFFENDER: $f"
+      echo "  invokes node AND builds a \$HOME-rooted path (dev-env#334 class):"
+      echo "$hits" | sed 's/^/    /'
+      echo "  Fix: use the literal path C:/Users/brown/.claude/scratch so Git Bash and Node agree."
+    } >&2
+  fi
+done
+
+if [ "$OFFENDERS" -gt 0 ]; then
+  echo "path-hygiene: $OFFENDERS offending script(s) — see above." >&2
+  exit 1
+fi
+echo "path-hygiene: clean (${#FILES[@]} shell files scanned; no \$HOME-rooted path passed to node)."

--- a/claude/scripts/tests/run-shellcheck.sh
+++ b/claude/scripts/tests/run-shellcheck.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# run-shellcheck.sh — run shellcheck over the repo's shell scripts and hooks.
+#
+# Blocking gate at --severity=error: the current tree is error-clean (verified
+# 2026-06-07, shellcheck 0.10.0), so any newly introduced hard shell bug
+# (undefined-behaviour quoting, unreachable code, bad redirections) fails the
+# check. Warnings/info are pre-existing style/hygiene and are printed advisorily
+# (non-blocking) — they are tracked separately, not gated here.
+#
+# Skip-if-absent: shellcheck is not installed by default on this machine and
+# cannot be installed without elevation (choco needs admin). When it is missing
+# the check SKIPS (exit 0) with an install hint rather than failing, so it never
+# blocks a PR on a tool the environment lacks. To enable the gate locally:
+#   choco install shellcheck      # from an elevated shell, OR
+#   download the portable zip from https://github.com/koalaman/shellcheck/releases
+#     and put shellcheck(.exe) on PATH (or set SHELLCHECK_BIN to its path).
+#
+# Run: bash claude/scripts/tests/run-shellcheck.sh
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+cd "$REPO_ROOT" || exit 1
+
+SC="${SHELLCHECK_BIN:-shellcheck}"
+if ! command -v "$SC" >/dev/null 2>&1; then
+  echo "SKIP: shellcheck not found (set SHELLCHECK_BIN or install: choco install shellcheck)."
+  echo "      Portable: https://github.com/koalaman/shellcheck/releases"
+  exit 0
+fi
+
+# Enumerate shell files: *.sh under scripts/ (+ test dirs) plus #!sh hook files.
+mapfile -t FILES < <(
+  {
+    ls claude/scripts/*.sh claude/scripts/tests/*.sh claude/hooks/tests/*.sh 2>/dev/null
+    for f in claude/hooks/*; do
+      [ -f "$f" ] && head -1 "$f" | grep -qE '^#!.*\bsh\b' && echo "$f"
+    done
+  } | sort -u
+)
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "run-shellcheck: no shell files found." >&2
+  exit 1
+fi
+
+echo "run-shellcheck: scanning ${#FILES[@]} shell files with $("$SC" --version | awk '/version:/{print $2}')."
+
+# Advisory pass (warnings + info) — informational, never blocks.
+echo "--- advisory (warning/info, non-blocking) ---"
+"$SC" --severity=info "${FILES[@]}" || true
+
+# Blocking pass (errors only).
+echo "--- blocking (error severity) ---"
+if "$SC" --severity=error "${FILES[@]}"; then
+  echo "run-shellcheck: PASS (0 error-severity findings)."
+  exit 0
+else
+  echo "run-shellcheck: FAIL — error-severity shellcheck findings above must be fixed." >&2
+  exit 1
+fi

--- a/claude/scripts/tests/test-get-project-item.sh
+++ b/claude/scripts/tests/test-get-project-item.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# test-get-project-item.sh — execution smoke test for get-project-item.sh.
+#
+# This is the catch that bash -n (syntax only) misses: it actually RUNS the
+# script end-to-end and asserts behaviour, which is how dev-env#334 (a runtime
+# path-resolution bug that parsed cleanly) would have been caught.
+#
+# Network-dependent: it calls `gh project item-list`. When gh is unauthenticated
+# or offline it SKIPS (exit 0) rather than failing — so it is a local pre-PR
+# check, not a hermetic CI gate. Run: bash claude/scripts/tests/test-get-project-item.sh
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+SCRIPT="$REPO_ROOT/claude/scripts/get-project-item.sh"
+# Known, stable project #3 item used as the success fixture. If this issue is
+# ever removed from the board, the test fails loudly (assertion), which is the
+# correct signal — update KNOWN_ISSUE to any current project item number.
+KNOWN_ISSUE=334
+SCRATCH="C:/Users/brown/.claude/scratch"
+
+PASS=0; FAIL=0
+ok()  { echo "  ok: $*"; PASS=$((PASS + 1)); }
+bad() { echo "  FAIL: $*"; FAIL=$((FAIL + 1)); }
+skip() { echo "SKIP: $*"; exit 0; }
+
+[ -f "$SCRIPT" ] || { echo "FATAL: script not found at $SCRIPT" >&2; exit 1; }
+
+# Preflight: gh present, authenticated, and the project query reachable.
+command -v gh >/dev/null 2>&1 || skip "gh CLI not installed"
+gh auth status >/dev/null 2>&1 || skip "gh not authenticated (run: gh auth login)"
+if ! gh project item-list 3 --owner brownm09 --limit 1 >/dev/null 2>&1; then
+  skip "gh project query failed (offline, or missing 'project' scope: gh auth refresh -s project)"
+fi
+
+# Count via find (not `ls | wc`) so a non-alphanumeric name can't skew the count.
+count_temps() { find "$SCRATCH" -maxdepth 1 -name 'tmp_project_item_*.json' 2>/dev/null | wc -l; }
+before=$(count_temps)
+
+# Test 1 — success path: resolves a known item to a PVTI_ node id.
+if ITEM_ID=$(bash "$SCRIPT" "$KNOWN_ISSUE" 2>/dev/null); then
+  case "$ITEM_ID" in
+    PVTI_*) ok "resolved #$KNOWN_ISSUE -> $ITEM_ID" ;;
+    *)      bad "expected a PVTI_ id for #$KNOWN_ISSUE, got: '$ITEM_ID'" ;;
+  esac
+else
+  bad "script exited non-zero resolving known issue #$KNOWN_ISSUE (the #334 ENOENT regression)"
+fi
+
+# Test 2 — failure path: a non-existent issue exits 1 with the diagnostic.
+err=$(bash "$SCRIPT" 99999999 2>&1 >/dev/null); rc=$?
+if [ "$rc" -eq 1 ]; then ok "no-match exits 1"; else bad "no-match expected exit 1, got $rc"; fi
+case "$err" in
+  *"no item found"*) ok "no-match emits diagnostic to stderr" ;;
+  *)                 bad "no-match stderr missing 'no item found': '$err'" ;;
+esac
+
+# Test 3 — cleanup: the trap removes the temp file on every path.
+after=$(count_temps)
+if [ "$after" -le "$before" ]; then ok "no leftover temp files (count $before -> $after)"
+else bad "temp files leaked (count $before -> $after); trap cleanup failed"; fi
+
+echo "Tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -337,6 +337,19 @@ On-demand scripts — not wired to any event. Run manually or from other scripts
 | `get-project-item.sh` | `ITEM_ID=$(bash get-project-item.sh <issue-number> [project-number] [owner])` | Resolves a GitHub Project item node ID from an issue/PR number. Defaults to project 3, owner `brownm09`. Overridable via args or `PROJECT_NUMBER`/`PROJECT_OWNER` env vars. Requires `project` scope: `gh auth refresh -s project`. |
 | `session-mode-report.py` | `py -3 session-mode-report.py [--since YYYY-MM-DD] [--interactive-only] [--non-plan-only] [--log PATH]` | Reports the startup permission mode per session by parsing the `session-mode-prompt.py` hook log (`scratch/session-mode-prompt.log`). For each `session_id` it takes the earliest entry as the startup mode, classifies sessions as interactive vs. automated (scheduled-task / `<tag>` prompts), and flags (`!`) interactive sessions that started outside `plan`. Desktop/web and spawn-task sessions launch in `bypassPermissions` by design (overriding `defaultMode: plan`); this surfaces that. Read-only; report to stdout, diagnostics to stderr. |
 
+### Script verification suite
+
+Execution-level checks for the shell scripts themselves, run from the dev-env `## Testing`
+section (the canonical list of when to run each). `bash -n` catches only syntax — these catch
+runtime and environment bugs it misses, the motivating case being [dev-env#334](https://github.com/brownm09/dev-env/issues/334)
+(a path-resolution bug that parsed cleanly yet failed on every run).
+
+| Script | Invocation | What it does |
+|--------|-----------|-------------|
+| `tests/check-script-path-hygiene.sh` | `bash claude/scripts/tests/check-script-path-hygiene.sh` | Lints for the #334 class — a `$HOME`-rooted scratch/temp path passed to `node`, which Git Bash and Node-on-Windows resolve to different files. Scripts must use the literal `C:/Users/brown/.claude/scratch`. Hermetic; comment mentions of `$HOME` are ignored. Exit 1 on any offender. |
+| `tests/test-get-project-item.sh` | `bash claude/scripts/tests/test-get-project-item.sh` | Smoke-tests `get-project-item.sh` end-to-end: asserts a known issue resolves to a `PVTI_` id, the no-match path exits 1 with a diagnostic, and the temp file is cleaned up. Network-dependent — SKIPs (exit 0) when `gh` is unauthenticated/offline. |
+| `tests/run-shellcheck.sh` | `bash claude/scripts/tests/run-shellcheck.sh` | Runs shellcheck over all repo shell scripts/hooks. Blocking at `--severity=error` (tree is error-clean as of 2026-06-07); warnings/info printed advisorily. SKIPs (exit 0) with an install hint when shellcheck is absent — set `SHELLCHECK_BIN` to a [portable binary](https://github.com/koalaman/shellcheck/releases) to run it. |
+
 ---
 
 ## Model Selection


### PR DESCRIPTION
## Summary

Follow-up to #335 (the `get-project-item.sh` fix). That bug — a Windows + Git Bash path-resolution failure that broke the script on *every* invocation — went undetected because nothing **executes** the `.sh` utility scripts: `bash -n` checks syntax only, and the bug parsed cleanly. This PR adds three complementary, execution-level guards, wired into the dev-env `## Testing` section.

| Guard | File | Catches |
|---|---|---|
| **Path-class lint** (hermetic) | `tests/check-script-path-hygiene.sh` | The exact #334 class: a `$HOME`-rooted scratch/temp path passed to `node`. Recommends the literal `C:/Users/brown/.claude/scratch`. Comment mentions of `$HOME` are stripped so a script can *document* the hazard without tripping. |
| **Smoke test** | `tests/test-get-project-item.sh` | `get-project-item.sh` regressing — runs it end-to-end, asserts a known issue → `PVTI_` id, no-match → exit 1 + diagnostic, and temp-file cleanup. Network-dependent → SKIPs cleanly without `gh` auth. |
| **shellcheck gate** | `tests/run-shellcheck.sh` | The broader class of shell bugs. Blocking at `--severity=error` (tree is error-clean); warnings/info advisory. SKIPs with an install hint when shellcheck is absent. |

Why not just "add CI": dev-env has no CI, and GitHub's Linux runners would not reproduce a Windows + Git-Bash + Node path bug — so the path-class lint (hermetic) and the smoke test (local, network-gated) are the guards that actually catch this class.

All three new scripts are themselves shellcheck-clean at info severity, route diagnostics to stderr, and use deliberate exit codes (0 = pass/skip, non-zero = fail) per the dev-env `## Observability` contract.

## Testing

dev-env `## Testing` suite (run with `SHELLCHECK_BIN` pointed at a portable shellcheck 0.10.0):

- **Hook-script syntax check** (`ast.parse` on `claude/scripts/*.py`) → AST OK
- **`pyw -3` stdio test** → exit 0
- **Path-hygiene lint** → `clean (10 shell files scanned)`
- **Smoke test** → `Tests: 4 passed, 0 failed` (resolved #334 → `PVTI_...`; no-match exit 1 + diagnostic; no leftover temp files)
- **shellcheck gate** → `PASS (0 error-severity findings)`; 3 pre-existing warnings + info printed advisorily (all in pre-existing files, unrelated to this change)
- **Self-check:** ran the new shellcheck gate against the 3 new scripts at `--severity=info` → clean (no warnings/info introduced)

`Tests: dev-env has no JS/py unit suite for .sh utilities — these scripts ARE the verification layer; 5 suite checks + 4 smoke assertions passed, 0 skipped, 0 failed`

**Coverage gate:** This PR *is* test coverage — it adds execution verification for the `.sh` scripts that previously had none. The new scripts are verified by running them (above).

**Suppression / test-integrity greps:** Both clean. (No JS/TS test markers; the new files are shell.)

**shellcheck install note:** shellcheck is not installed on this machine and `choco install shellcheck` requires an elevated shell (fails with `UnauthorizedAccessException` non-elevated). I verified the gate by running a portable shellcheck 0.10.0 binary via `SHELLCHECK_BIN`. The gate SKIPs (exit 0) with an install hint when the binary is absent, so it never blocks a PR on a missing tool.

## Pre-existing shellcheck findings (advisory, out of scope)

The shellcheck advisory pass surfaced pre-existing **warnings** in files this PR does not touch — not gated, noted here for visibility:
- `merge-stale-pr.sh:53` — SC2010 (`ls | grep`)
- `hooks/tests/test-pre-push-lockfile.sh:19` — SC2034 (unused var), `:125` — SC2046 (word-splitting)
- plus several SC2015 (`A && B || C`) and SC2086/SC2012 info-level notes in existing test scripts.

These predate this branch and are unrelated to the #334 class. Filing them as a follow-up cleanup would be the right call rather than absorbing them here (scope guard). Let me know if you'd like that issue opened.

## ADR-warrant

N/A — adds verification *tooling* implementing the project's existing "`## Testing` is the canonical verification set" convention; not a new cross-cutting policy referenced by other CLAUDE.md files. Rationale captured in #337 + script headers + this PR.

## Doc-reconciliation

`claude/scripts/` changed → `docs/REFERENCE.md` updated (new "Script verification suite" subsection) and the dev-env `## Testing` section (steps 5–7). README Hooks table intentionally **not** touched — these are test helpers, not runtime hooks, matching the existing `test-merge-findings-gate.sh` / `test-pre-push-lockfile.sh` precedent (neither is in the README Hooks table).

Closes #337


## Review findings disposition

`/review` (claude-opus-4-8) → marker `blocking=0 non_blocking=0`. One correctness finding was self-caught during review and **fixed in-PR** (commit on this branch: path-hygiene lint now ignores comments in node-detection and reports real file line numbers; verified with a planted-offender positive test). Nothing left to file. `reviewed-by-claude` label applied. ([review comment](https://github.com/brownm09/dev-env/pull/338#issuecomment-4643356541))
