### PR TITLE
Clean up shellcheck warnings + fix two bugs the cleanup exposed (#339)

### DIFF
--- a/claude/hooks/pre-push
+++ b/claude/hooks/pre-push
@@ -8,7 +8,7 @@
 # This hook WARNS only (exit 0) — it does not block the push.
 # Install globally: git config --global core.hooksPath ~/.claude/hooks
 
-while read local_ref local_sha remote_ref remote_sha; do
+while read -r _ local_sha remote_ref remote_sha; do
   # skip deletes
   [ "$local_sha" = "0000000000000000000000000000000000000000" ] && continue
 

--- a/claude/hooks/tests/test-pre-push-lockfile.sh
+++ b/claude/hooks/tests/test-pre-push-lockfile.sh
@@ -16,7 +16,6 @@ set -u
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 HOOK="$SCRIPT_DIR/../pre-push"
-ZERO="0000000000000000000000000000000000000000"
 
 PASS=0
 FAIL=0
@@ -121,8 +120,17 @@ SHIM=""
 if [ -z "$NPM_PATH" ]; then
   FINALPATH="$PATH"   # npm already absent on this host
 else
-  NPM_DIR=$(dirname "$NPM_PATH")
-  FINALPATH=$(printf '%s\n' $(echo "$PATH" | tr ':' '\n') | grep -v -F -x "$NPM_DIR" | paste -sd: -)
+  # Drop EVERY PATH dir that holds an npm executable — npm can live in more than
+  # one (here: an nvm4w shim dir AND a system "Program Files/nodejs" dir), so
+  # removing only `dirname $(command -v npm)` leaves npm resolvable elsewhere and
+  # the coverage check below fails. Iterate ':'-split entries so dirs with spaces
+  # are matched exactly. (The previous `printf '%s\n' $(...)` form word-split on
+  # spaces — SC2046 — and only "worked" by corrupting the spaced npm entry.)
+  FINALPATH=$(echo "$PATH" | tr ':' '\n' | while IFS= read -r d; do
+    [ -n "$d" ] || continue
+    if [ -e "$d/npm" ] || [ -e "$d/npm.cmd" ] || [ -e "$d/npm.exe" ]; then continue; fi
+    printf '%s\n' "$d"
+  done | paste -sd: -)
   # If dropping npm's dir also dropped a tool the hook needs, shim that tool back in
   # (handles the pathological case where npm shares a directory with coreutils/git).
   SHIM=$(mktemp -d)

--- a/claude/scripts/merge-stale-pr.sh
+++ b/claude/scripts/merge-stale-pr.sh
@@ -50,7 +50,18 @@ git pull origin "$BRANCH"
 
 # ── Step 3: check for composed journal ────────────────────────────────────────
 DATE_PART="${BRANCH#draft/}"  # e.g. "2026-04-19"
-COMPOSED_FILE=$(ls sessions/**/"${DATE_PART}"*.md 2>/dev/null | grep -v '_draft\.md' | grep -v '\.stub\.md' | head -1 || true)
+# First sessions/**/<date>*.md that is not a _draft.md or .stub.md. A glob loop
+# (globstar enabled above) instead of `ls | grep` so the match is robust to
+# unusual filenames and the exclusions are exact suffix tests (SC2010).
+COMPOSED_FILE=""
+for _cand in sessions/**/"${DATE_PART}"*.md; do
+  [ -e "$_cand" ] || continue   # pattern with no match expands to itself — skip
+  case "$_cand" in
+    *_draft.md|*.stub.md) continue ;;
+  esac
+  COMPOSED_FILE="$_cand"
+  break
+done
 
 if [[ -z "$COMPOSED_FILE" ]]; then
   echo "WARNING: No composed journal file found for $DATE_PART." >&2

--- a/claude/scripts/tests/check-script-path-hygiene.sh
+++ b/claude/scripts/tests/check-script-path-hygiene.sh
@@ -28,7 +28,10 @@ mapfile -t FILES < <(
   {
     ls claude/scripts/*.sh claude/scripts/tests/*.sh claude/hooks/tests/*.sh 2>/dev/null
     for f in claude/hooks/*; do
-      [ -f "$f" ] && head -1 "$f" | grep -qE '^#!.*\bsh\b' && echo "$f"
+      # `.*sh\b` (not `\bsh\b`): the interpreter basename ENDS in sh — matches
+      # `#!/bin/sh`, `#!/usr/bin/env bash`, `zsh`. A leading `\b` would miss
+      # `bash` (no word boundary inside "bash"), silently skipping bash hooks.
+      [ -f "$f" ] && head -1 "$f" | grep -qE '^#!.*sh\b' && echo "$f"
     done
   } | sort -u
 )

--- a/claude/scripts/tests/run-shellcheck.sh
+++ b/claude/scripts/tests/run-shellcheck.sh
@@ -33,7 +33,10 @@ mapfile -t FILES < <(
   {
     ls claude/scripts/*.sh claude/scripts/tests/*.sh claude/hooks/tests/*.sh 2>/dev/null
     for f in claude/hooks/*; do
-      [ -f "$f" ] && head -1 "$f" | grep -qE '^#!.*\bsh\b' && echo "$f"
+      # `.*sh\b` (not `\bsh\b`): the interpreter basename ENDS in sh — matches
+      # `#!/bin/sh`, `#!/usr/bin/env bash`, `zsh`. A leading `\b` would miss
+      # `bash` (no word boundary inside "bash"), silently skipping bash hooks.
+      [ -f "$f" ] && head -1 "$f" | grep -qE '^#!.*sh\b' && echo "$f"
     done
   } | sort -u
 )


### PR DESCRIPTION
## Summary

Gets the shellcheck gate (#338) clean at `--severity=warning`. Scoped to clean up three pre-existing warnings — but fixing them surfaced **two real bugs** (one a coverage hole in the gate I shipped in #338), which are fixed here too.

### Targeted warnings (the original #339 scope)
| Finding | File | Fix |
|---|---|---|
| SC2010 (`ls \| grep`) | `merge-stale-pr.sh:53` | globstar glob loop with exact-suffix exclusions |
| SC2034 (unused var) | `test-pre-push-lockfile.sh:19` | removed dead `ZERO` |
| SC2046 (word-split) | `test-pre-push-lockfile.sh:125` | rewrote the npm-dir PATH filter (see below) |

### Bugs exposed while fixing the above
1. **Enumeration coverage hole (in #338's own scripts).** The shell-file shebang filter `^#!.*\bsh\b` requires a word boundary *before* "sh", so it matched `#!/bin/sh` but **not** `#!/usr/bin/env bash` (no boundary inside "bash"). The bash-shebang `claude/hooks/pre-push` was therefore **silently excluded** from both the shellcheck gate and the path-hygiene lint — the gate reported "10 files" when there are 11. Fixed to `^#!.*sh\b` (interpreter basename *ends* in sh) in both `run-shellcheck.sh` and `check-script-path-hygiene.sh`. They now cover pre-push.
2. **`pre-push` SC2034.** With pre-push now in scope, its `read local_ref local_sha …` loop flagged the unused `local_ref`. Renamed to `_`, added `read -r`.
3. **Incomplete npm removal in the npm-absent test scenario.** Fixing SC2046 (the `printf '%s\n' $(...)` word-split) revealed the test only removed `dirname $(command -v npm)` — but on this machine npm lives in **two** dirs (`/c/nvm4w/nodejs` *and* `/c/Program Files/nodejs`). The old word-split had masked this by corrupting the spaced entry. The filter now drops **every** PATH dir containing an npm executable, handling spaces exactly.

## Testing

Full dev-env `## Testing` suite (portable shellcheck 0.10.0 via `SHELLCHECK_BIN`):

- **ast.parse** (py scripts) → OK
- **pyw -3 stdio** → OK
- **pre-push self-test** → `12 passed, 0 failed` (was `10 passed, 1 failed` before the npm-removal fix — the prior pass count didn't include the now-robust npm-absent assertions) — **required, since this PR edits both `pre-push` and its test**
- **path-hygiene lint** → clean (11 files — now includes pre-push)
- **smoke test** → `4 passed, 0 failed`
- **shellcheck gate** → scans **11** files (incl. pre-push), `PASS (0 error-severity)`; whole tree clean at `--severity=warning`

`Tests: dev-env has no JS/py unit suite for .sh utilities; 6 suite checks pass (pre-push self-test 12 passed / 0 failed; smoke 4/0), 0 skipped, 0 failed`

**Coverage gate:** The behavior changes are covered by the existing pre-push self-test (the npm-removal fix flips its scenario-4 assertions from failing to passing) and by the lint/gate self-runs. No new test files needed.

**Suppression / test-integrity greps:** both clean. No suppressions added (the SC2046 fix is a proper rewrite, not a `# shellcheck disable`).

## ADR-warrant
N/A — warning cleanup + bugfixes; no rule/hook-contract/settings change.

## Doc-reconciliation
N/A — `claude/scripts/` and `claude/hooks/` files changed, but all edits are bugfixes/cleanups with no interface or documented-behavior change. The verification suite's documented contract ("scan all repo shell scripts/hooks") is now met *more completely* (it previously missed bash-shebang hooks), not altered, so `README.md` / `docs/REFERENCE.md` need no update.

Closes #339


## Review findings disposition

`/review` (claude-opus-4-8) → marker `blocking=0 non_blocking=0`. Nothing to fix or file. Doc-reconciliation's mechanical 2b trigger was assessed and found not warranted (bugfixes, no interface/behavior change). `reviewed-by-claude` label applied. ([review comment](https://github.com/brownm09/dev-env/pull/340#issuecomment-4643386921))
