### PR TITLE
Make usage-snapshot surface expired/missing OAuth token instead of silent exit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,17 @@ before PR" rule in [`claude/CLAUDE.md`](claude/CLAUDE.md) defers to this section
    bash claude/scripts/tests/run-shellcheck.sh
    ```
 
+8. **usage-snapshot classifier test** — required when changing `claude/scripts/usage-snapshot.py`.
+   Exercises the pure `classify_token()` helper offline (no network, no credentials file): pins the
+   `no_expiry` / `ok` / `expiring` / `expired` states and the expiry boundary, asserting an expired
+   token now yields a user-facing advisory rather than the silent skip it did before
+   [#355](https://github.com/brownm09/dev-env/issues/355). The live usage API call is not covered
+   (the repo avoids urllib mocks).
+
+   ```bash
+   py -3 claude/scripts/tests/test_usage_snapshot.py
+   ```
+
 ## Observability
 
 dev-env has **no long-running runtime to instrument** — it is a configuration repo whose

--- a/claude/scripts/tests/test_usage_snapshot.py
+++ b/claude/scripts/tests/test_usage_snapshot.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Unit tests for usage-snapshot.py token classification.
+
+`usage-snapshot.py` is a PostToolUse hook that fires after `gh pr merge` and
+emits a usage snapshot. Before the fix in dev-env#355, an already-expired OAuth
+token made the hook `sys.exit(0)` silently — the feature went dead with no
+signal, even though an "expires within 1 hour" warning sat one branch below.
+
+The fix extracts the expiry decision into the pure `classify_token()` helper so
+it can be exercised offline (no network, no credentials file), matching the
+repo's fixture-only test convention. These tests pin the four states and assert
+the previously-silent `expired` path now yields a user-facing advisory.
+
+The live network call (`fetch_usage`) is intentionally not tested — the repo
+avoids urllib mocks, consistent with the other script tests.
+
+Usage:
+    py -3 claude/scripts/tests/test_usage_snapshot.py
+
+Exit 0 = all pass.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# tests/ -> scripts/ -> claude/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "claude" / "scripts" / "usage-snapshot.py"
+
+# The script filename is hyphenated, so import it by path rather than `import`.
+_spec = importlib.util.spec_from_file_location("usage_snapshot", SCRIPT)
+assert _spec and _spec.loader, f"cannot load module spec from {SCRIPT}"
+usage_snapshot = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(usage_snapshot)  # safe: main() is guarded by __main__
+classify_token = usage_snapshot.classify_token
+
+NOW_MS = 1_700_000_000_000  # fixed synthetic "now"; real time never consulted
+HOUR_MS = 3_600_000
+DAY_MS = 86_400_000
+
+
+def test_no_expiry_proceeds_silently() -> str:
+    state, advisory = classify_token(0, NOW_MS)
+    assert state == "no_expiry", f"expected no_expiry, got {state}"
+    assert advisory == "", f"expected empty advisory, got {advisory!r}"
+    return "expires_at_ms=0 -> no_expiry, no advisory (preserves prior behavior)"
+
+
+def test_valid_token_proceeds_silently() -> str:
+    state, advisory = classify_token(NOW_MS + 5 * HOUR_MS, NOW_MS)
+    assert state == "ok", f"expected ok, got {state}"
+    assert advisory == "", f"expected empty advisory, got {advisory!r}"
+    return "5h remaining -> ok, no advisory"
+
+
+def test_expiring_within_hour_warns() -> str:
+    state, advisory = classify_token(NOW_MS + 30 * 60_000, NOW_MS)
+    assert state == "expiring", f"expected expiring, got {state}"
+    assert "within 1 hour" in advisory, f"advisory missing warning text: {advisory!r}"
+    return "30m remaining -> expiring, within-1h advisory"
+
+
+def test_expired_token_now_visible() -> str:
+    state, advisory = classify_token(NOW_MS - 8 * DAY_MS, NOW_MS)
+    assert state == "expired", f"expected expired, got {state}"
+    assert "expired" in advisory, f"advisory missing 'expired': {advisory!r}"
+    assert "8.0 days ago" in advisory, f"advisory missing days-ago figure: {advisory!r}"
+    return "expired 8 days ago -> expired, advisory names the cause (was silent before #355)"
+
+
+def test_exact_expiry_boundary_counts_as_expired() -> str:
+    # expires_at_ms == now_ms must classify as expired (<=, not <).
+    state, _ = classify_token(NOW_MS, NOW_MS)
+    assert state == "expired", f"boundary should be expired, got {state}"
+    return "expires_at_ms == now_ms -> expired (boundary inclusive)"
+
+
+def main() -> int:
+    tests = [
+        ("no-expiry token proceeds silently", test_no_expiry_proceeds_silently),
+        ("valid token proceeds silently", test_valid_token_proceeds_silently),
+        ("token expiring within 1h warns", test_expiring_within_hour_warns),
+        ("expired token now yields advisory", test_expired_token_now_visible),
+        ("exact-expiry boundary is expired", test_exact_expiry_boundary_counts_as_expired),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            detail = fn()
+            print(f"PASS: {name}")
+            print(f"      {detail}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL: {name}")
+            for line in str(e).splitlines():
+                print(f"      {line}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR: {name}: {type(e).__name__}: {e}")
+    print()
+    print(f"Tests: {len(tests) - failed} passed, 0 skipped, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/scripts/usage-snapshot.py
+++ b/claude/scripts/usage-snapshot.py
@@ -221,6 +221,36 @@ def compute_cumulative_target(resets_at_str: str, config: dict) -> tuple[int, in
         return 0, 0, 7
 
 
+def classify_token(expires_at_ms: int, now_ms: float) -> tuple[str, str]:
+    """Classify the stored OAuth token by expiry, returning (state, advisory).
+
+    state is one of:
+      "no_expiry" — no expiry recorded (expires_at_ms falsy); proceed silently.
+      "ok"        — token valid with > 1h remaining; proceed silently.
+      "expiring"  — token valid but expires within 1 hour; advisory, do not proceed.
+      "expired"   — token already expired; advisory, do not proceed.
+
+    For "no_expiry"/"ok" the advisory is "". For "expiring"/"expired" the advisory
+    is a one-line message intended for stderr. Mirrors the visibility of the
+    expiring-within-1h path so an already-expired token no longer fails silently.
+    """
+    if not expires_at_ms:
+        return "no_expiry", ""
+    if expires_at_ms <= now_ms:
+        days_ago = (now_ms - expires_at_ms) / 86_400_000
+        return "expired", (
+            f"[usage-snapshot] Skipped: OAuth token in .credentials.json expired "
+            f"{days_ago:.1f} days ago. This client isn't refreshing that file — run "
+            f"`claude` interactively once to rewrite it."
+        )
+    if (expires_at_ms - now_ms) < 3_600_000:
+        return "expiring", (
+            "[usage-snapshot] OAuth token expires within 1 hour — open Claude Code "
+            "interactively to refresh before the next check."
+        )
+    return "ok", ""
+
+
 def status_emoji(util: float, target: int, margin: int) -> str:
     if target == 0:
         return ""
@@ -439,18 +469,20 @@ def main() -> None:
 
     token, expires_at_ms = get_access_token(creds)
     if not token:
-        sys.exit(0)
-
-    # Skip silently if token is already expired; warn if it expires within 1 hour
-    now_ms = time.time() * 1000
-    if expires_at_ms and expires_at_ms <= now_ms:
-        sys.exit(0)
-    if expires_at_ms and (expires_at_ms - now_ms) < 3_600_000:
+        # Creds file exists but holds no usable token — surface it rather than
+        # failing silently (creds-file-absent is handled silently above).
         print(
-            "[usage-snapshot] OAuth token expires within 1 hour — open Claude Code "
-            "interactively to refresh before the next check.",
+            "[usage-snapshot] Skipped: .credentials.json has no usable OAuth token "
+            "(missing or unparseable). Run `claude` interactively to rewrite it.",
             file=sys.stderr,
         )
+        sys.exit(2)
+
+    # Make an expired or about-to-expire token visible instead of silently skipping.
+    now_ms = time.time() * 1000
+    state, advisory = classify_token(expires_at_ms, now_ms)
+    if state in ("expired", "expiring"):
+        print(advisory, file=sys.stderr)
         sys.exit(2)
 
     util_data = fetch_usage(token)


### PR DESCRIPTION
Closes #355. Follow-up self-healing spec tracked in #356.

## Problem

The post-merge `### Usage Snapshot` block silently stopped appearing for ~8 days. `claude/scripts/usage-snapshot.py` reads the OAuth token from `C:/Users/brown/.claude/.credentials.json`, found it **expired**, and hit a silent `sys.exit(0)` (old line 446). The current client refreshes its token elsewhere and never writes back to that file, so the on-disk token the hook reads is frozen (~8.3 days stale, confirmed this session). Worse, the *expiring-within-1h* branch right below it printed a warning — so the moment the token actually lapsed, the warning meant to prompt a refresh also went quiet.

## Change

- Extract a pure `classify_token(expires_at_ms, now_ms) -> (state, advisory)` helper (`no_expiry` / `ok` / `expiring` / `expired`).
- Rewire `main()`: `expired` and `expiring` print a one-line stderr advisory + `exit 2` (this hook's existing output contract); `ok` / `no_expiry` proceed to `fetch_usage` as before.
- Surface the missing-token-when-creds-present case (was a silent `exit 0`); `creds is None` (file absent/corrupt) stays silent — legitimate in unconfigured environments.
- New offline test `claude/scripts/tests/test_usage_snapshot.py` + registered as command 8 in the dev-env `## Testing` section.

## Testing

Ran from the worktree root:

- Syntax check (`ast.parse` over `claude/scripts/*.py`): **OK**
- `py -3 claude/scripts/tests/test_usage_snapshot.py` — **Tests: 5 passed, 0 skipped, 0 failed**
- `py -3 claude/scripts/tests/test_pyw_stdio.py` (unchanged invariant; also confirms the modified hook still parses and resolves) — **Tests: 6 passed, 0 skipped, 0 failed**

Pre-PR greps: suppression grep clean; test-integrity grep clean (the `sys.exit(` hits are the known `exit(` ⊃ `xit(` false positive, not skip markers). No `package.json` touched — lockfile policy N/A.

## Coverage

New behavior (the four classifier states + expiry boundary) is covered by the new offline test. The live `fetch_usage` network call is intentionally not covered — the repo avoids urllib mocks, consistent with existing script tests.

## Risk-dimension audit

- **Testing** — covered (above).
- **Observability** — the change *is* an observability fix: routes the expired/missing-token diagnostic to stderr with a deliberate `exit 2`, per the dev-env `## Observability` contract.
- **Security** — no token values logged; the advisory names the file, never its contents. No new credential reads/writes (self-healing write-back is deferred to #356).
- **Resilience** — strictly widens visibility; `ok`/`no_expiry` paths and the outer `except: sys.exit(0)` guard are unchanged, so a malformed payload still fails safe.
- **Performance** — N/A, pure local branch logic.
- **Data integrity** — N/A, no persisted state changed.
- **ADR warrant** — consistency fix within the existing hook-output contract (ADR-027); no new ADR. The deferred self-healing work (#356) introduces a credential-writing convention and will warrant an ADR when implemented.
- **Doc reconciliation** — no script added/removed, so README/REFERENCE Hooks tables are unchanged; only the new `## Testing` command line was added.