### PR TITLE
Correct overstated worktree node_modules figure in ADR-045 + ENOSPC runbook (#366)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -580,7 +580,7 @@ and the disk has ample free space, it is the tarball issue, not ENOSPC.
 
 | Consumer | Typical size | Reclaim with |
 |---|---|---|
-| `lifting-logbook/.claude/worktrees/*/node_modules` | **dominant** — dozens of worktrees × ~1–2 GB each (≈30–60+ GB) | `reclaim-worktree-disk.py` (idle) → `prune-stale-worktrees` (merged) |
+| `lifting-logbook/.claude/worktrees/*/node_modules` | **dominant** — ~14 GB aggregate across ~60 worktrees (measured `du`; avg ~230 MB — a full install is ~1–2 GB, but idle trees get reclaimed so most are partial) | `reclaim-worktree-disk.py` (idle) → `prune-stale-worktrees` (merged) |
 | Docker Desktop (Testcontainers images/volumes) | ~5–6 GB | `docker system prune` (destructive — see below) |
 | Playwright browser bundles | ~700 MB | `npx playwright uninstall` (reinstalled on next test run) |
 | npm cache | ~700 MB | `npm cache clean --force` |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -580,7 +580,7 @@ and the disk has ample free space, it is the tarball issue, not ENOSPC.
 
 | Consumer | Typical size | Reclaim with |
 |---|---|---|
-| `lifting-logbook/.claude/worktrees/*/node_modules` | **dominant** — ~14 GB aggregate across ~60 worktrees (measured `du`; avg ~230 MB — a full install is ~1–2 GB, but idle trees get reclaimed so most are partial) | `reclaim-worktree-disk.py` (idle) → `prune-stale-worktrees` (merged) |
+| `lifting-logbook/.claude/worktrees/*/node_modules` | **dominant** — ~14 GB aggregate across ~60 worktrees (measured `du`; avg ~240 MB — a full install is ~1–2 GB, but idle trees get reclaimed so most are partial) | `reclaim-worktree-disk.py` (idle) → `prune-stale-worktrees` (merged) |
 | Docker Desktop (Testcontainers images/volumes) | ~5–6 GB | `docker system prune` (destructive — see below) |
 | Playwright browser bundles | ~700 MB | `npx playwright uninstall` (reinstalled on next test run) |
 | npm cache | ~700 MB | `npm cache clean --force` |

--- a/docs/adr/045-pre-install-freespace-gate.md
+++ b/docs/adr/045-pre-install-freespace-gate.md
@@ -37,10 +37,16 @@ and the 6-hourly `reclaim-worktree-disk` routine. Yet the disk still saturated t
    already critical, a detached reclaim *races* an install already in flight rather than preventing it.
 
 **Dominant consumer (acceptance criterion 1), measured 2026-06-18.** `lifting-logbook/.claude/worktrees/`
-held **60 worktrees**, each carrying a full monorepo `node_modules` (~1–2 GB ⇒ ~30–60+ GB) — the project
-mandates a per-worktree install for its Husky `turbo` binary. Secondary: Docker (~5.9 GB), Playwright
-(~685 MB), npm cache (~684 MB). The dev-env worktrees themselves were negligible (~17 MB, no
-`node_modules`). This matches ADR-037's diagnosis and confirms idle worktree `node_modules` is the lever.
+held **60 worktrees** totalling **~14 GB** of `node_modules` (a direct `du`), averaging ~230 MB each —
+*not* every worktree carries a full install, because ADR-037's routine reclaims idle ones; a
+freshly-installed monorepo tree is ~1–2 GB, which is the per-worktree *upper* bound, not the typical
+footprint. The project mandates a per-worktree install for its Husky `turbo` binary. Secondary:
+lifting-logbook's own `node_modules` (~858 MB), Docker (~5.9 GB), Playwright (~685 MB), npm cache
+(~684 MB). The dev-env worktrees themselves were negligible (~17 MB, no `node_modules`). At ~14 GB the
+worktree bucket is still the largest single consumer — more than twice Docker's ~5.9 GB — confirming
+ADR-037's diagnosis that idle worktree `node_modules` is the lever. (An earlier draft of this ADR cited
+the ~1–2 GB-per-worktree upper bound as a ~30–60 GB aggregate; that was an extrapolation, not the
+measured total — corrected to the measured ~14 GB per dev-env#366.)
 
 ## Decision
 

--- a/docs/adr/045-pre-install-freespace-gate.md
+++ b/docs/adr/045-pre-install-freespace-gate.md
@@ -37,7 +37,7 @@ and the 6-hourly `reclaim-worktree-disk` routine. Yet the disk still saturated t
    already critical, a detached reclaim *races* an install already in flight rather than preventing it.
 
 **Dominant consumer (acceptance criterion 1), measured 2026-06-18.** `lifting-logbook/.claude/worktrees/`
-held **60 worktrees** totalling **~14 GB** of `node_modules` (a direct `du`), averaging ~230 MB each —
+held **60 worktrees** totalling **~14 GB** of `node_modules` (a direct `du`), averaging ~240 MB each —
 *not* every worktree carries a full install, because ADR-037's routine reclaims idle ones; a
 freshly-installed monorepo tree is ~1–2 GB, which is the per-worktree *upper* bound, not the typical
 footprint. The project mandates a per-worktree install for its Husky `turbo` binary. Secondary:


### PR DESCRIPTION
Closes #366.

## Problem

[ADR-045](docs/adr/045-pre-install-freespace-gate.md) and the `docs/REFERENCE.md` → Disk-Full (ENOSPC) Recovery runbook (both merged in #365) cited the dominant `C:` consumer — `lifting-logbook/.claude/worktrees/*/node_modules` — as **"~30–60+ GB"**, and ADR-045 framed it as a figure *"measured 2026-06-18."* A same-day direct `du` shows otherwise:

```
worktree count:                 60
.claude/worktrees total (du):   14 GB
main node_modules:              858 MB
```

The "~1–2 GB × 60" was an upper-bound extrapolation (a *full* install), not the measured total — idle trees are reclaimed by ADR-037's routine, so most worktrees are partial (avg ~230 MB).

## Changes (docs-only)

- **ADR-045 dominant-consumer paragraph:** corrected to the measured ~14 GB aggregate; reframed ~1–2 GB as the per-worktree *upper bound*; added the lifting-logbook main `node_modules` (858 MB) to the secondary list; added a one-line note that the earlier ~30–60 GB was an extrapolation corrected per #366. The qualitative conclusion is preserved and now better supported: at ~14 GB the worktree bucket is still the largest single consumer (>2× Docker's ~5.9 GB).
- **REFERENCE consumer table:** the dominant row now reads "~14 GB aggregate across ~60 worktrees (avg ~230 MB)".

**Left intentionally unchanged:** [ADR-037](docs/adr/037-worktree-disk-reclamation.md) line 18 ("estimated 30–60 GB") — it is honestly labeled an *estimate* and is a contemporaneous 2026-06-03 record from before the reclaim routine existed (when worktrees were not being reclaimed and plausibly larger). Rewriting a prior ADR's date-stamped estimate would be revisionist.

## Testing

dev-env has a `## Testing` section; this change is **docs-only** (one ADR + one REFERENCE table row) — no skill/hook/script/routine touched, so the script test suite (ast syntax, `pyw -3` stdio, helper tests) is N/A.

Manual verification:
- `grep -rn "30.60" docs/ claude/ README.md` → only two matches remain, both intended: ADR-037's correctly-labeled contemporaneous estimate (left as-is) and ADR-045's new correction note.
- New `~14 GB` figures present and internally consistent across ADR-045 and the REFERENCE table.
- No doc-reconciliation needed (Documentation Maintenance table covers skill/hook/script/routine adds/removes/renames — none here; ADR-045 already in INDEX).

`No automated tests (docs-only change).`

## Review findings disposition

`/review` (claude-opus-4-8) returned **0 blocking, 0 non-blocking**. One precision nit was self-caught during review (average rounds to ~240 MB, not the ~230 MB first written) and fixed in `f920b84` before the review posted. Nothing outstanding.
