### PR TITLE
docs(reference): document the post-merge follow-up tile (chip) mechanism

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -541,6 +541,33 @@ owns the global value, coordinate rather than overwrite — two tools cannot sha
 Once clear: `git config --global core.hooksPath ~/.claude/hooks`. The hook chains to any per-repo
 `.git/hooks/pre-push`, so existing repo-level hooks are preserved.
 
+### Post-merge follow-up tiles (chips)
+
+The post-merge checklist ([`claude/CLAUDE.md`](../claude/CLAUDE.md) → Git Workflow) asks you to capture
+any out-of-scope follow-ups the work surfaced. The harness mechanism for this is the `spawn_task`
+background-task tool (full name `mcp__ccd_session__spawn_task`), which renders a clickable **tile**
+(chip) in the UI. One click spins the follow-up into its own Claude Code session and git worktree,
+seeded with the tile's prompt; otherwise the user dismisses it. The current turn continues
+uninterrupted either way.
+
+**When to use it.** At the post-merge follow-up checkpoint of
+[ADR-046](adr/046-post-merge-followup-tiles.md) — right after `gh pr merge`, one tile per genuine,
+actionable, out-of-scope item (a fix spotted in adjacent code, deferred work, tech debt, an idea worth
+pursuing). The bar is the file-and-link bar ([ADR-028](adr/028-all-findings-merge-gate.md)): real
+follow-ups, not speculative musings, so the tile surface stays signal-rich. (`spawn_task`'s own guidance
+names other good moments too — right after verification passes, right before summarizing completed
+work; ADR-046 formalizes the merge boundary specifically.)
+
+**Tiles capture; they do not track.** A tile is *ephemeral* — chip IDs are not persisted across app
+restarts, and a tile becomes real work only when the user clicks it. For a follow-up that must be
+durably tracked, still file a GitHub issue; the tile's spawned session is a natural place to do that.
+The tile and the issue are complementary, not redundant.
+
+**Fallback where `spawn_task` is unavailable.** The tool is not present in every session (e.g. some
+terminal CLI sessions). There, file a follow-up issue instead, so the capture still happens.
+
+Rationale, alternatives, and consequences: [ADR-046](adr/046-post-merge-followup-tiles.md).
+
 ---
 
 ## Disk-Full (ENOSPC) Recovery


### PR DESCRIPTION
## Summary

Adds a `### Post-merge follow-up tiles (chips)` subsection under **Git Workflow Runbooks** in `docs/REFERENCE.md`. ADR-046 and the post-merge `claude/CLAUDE.md` rule both reference the harness `spawn_task` background-task tool ("tile"/"chip"), but the reference doc — where a reader following the rule would look — did not describe it. The new entry covers, per the issue:

- **What a tile is** — the `mcp__ccd_session__spawn_task` tool renders a clickable chip; one click spins the follow-up into its own Claude Code session + git worktree, or the user dismisses it; tiles are ephemeral (IDs not persisted across app restarts).
- **When to use it** — the ADR-046 post-merge follow-up checkpoint; capture, not durable tracking.
- **Relation to filing issues** — durable follow-ups still get a GitHub issue (the tile's spawned session can do that); where `spawn_task` is unavailable (e.g. some terminal CLI sessions), file an issue instead.
- **Cross-links ADR-046** (and ADR-028 for the "genuine follow-ups" bar).

Closes #372

## Placement & scope decisions

- **Subsection under Git Workflow Runbooks**, not a new top-level section: that section explicitly exists to hold the in-repo details for `claude/CLAUDE.md` → Git Workflow rules, which is exactly where the post-merge tile rule lives. A `###` subsection keeps it short and out of the top-level Contents TOC (consistent with every other runbook subsection).
- **No README.md pointer.** README documents linked-config *artifacts* (Skills/Hooks/Routines tables) + setup; it has no Git-Workflow surface, and the tile is a harness mechanism, not a dev-env artifact. The project Documentation Maintenance table requires README/table updates only for skill/hook/script/routine changes — not for this prose addition.
- **No `claude/CLAUDE.md` edit.** Scoped to the reference doc as requested. The existing CLAUDE.md Git-Workflow "Runbooks" bullet already points readers to `docs/REFERENCE.md → Git Workflow Runbooks`, so the new entry is reachable without touching CLAUDE.md.

## Testing

dev-env has no runtime; the project `## Testing` suite (items 1–10) is hook/script self-tests — **N/A** for a prose-only `docs/REFERENCE.md` change (no `claude/scripts/*`, `claude/hooks/*`, or `*.py` touched). Docs verification performed instead:

- **Link integrity** — all three link targets resolve via `[ -f ]`: `../claude/CLAUDE.md`, `adr/046-post-merge-followup-tiles.md`, `adr/028-all-findings-merge-gate.md`.
- **Structure** — new `### Post-merge follow-up tiles (chips)` heading present exactly once; the following `## Disk-Full (ENOSPC) Recovery` heading shifted by exactly +27 lines, confirming the subsection is bounded inside Git Workflow Runbooks.
- **Diff scope** — 1 file changed, +27 insertions, 0 deletions (`docs/REFERENCE.md` only).

No automated test framework here, so no `Tests: N passed, N skipped, N failed` line applies.

## Pre-PR gates

- **Coverage gate** — N/A (docs-only; no testable behavior added).
- **Suppression grep** — CLEAN (no suppressions in diff).
- **Test-integrity grep** — CLEAN (no skip markers / threshold / bail changes).
- **Lockfile drift** — N/A (no `package.json` change).
- **ADR-warrant** — N/A: documents an already-accepted decision (ADR-046); sets no new rule, restructures no directory, changes no hook/skill/setting.
- **Doc-reconciliation** — only `docs/REFERENCE.md` touched; no skill/hook/script/routine added/removed/renamed, so the Documentation Maintenance table imposes no further updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
