### PR TITLE
Document GCM remote-git-op hang + gh auth setup-git fix (ADR-047)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -532,6 +532,58 @@ gh api -X DELETE "repos/{owner}/{repo}/git/refs/heads/<branch>"
 Root cause and upstream fix: [ADR-035](adr/035-git-push-delete-web-session-constraint.md) /
 [Platform Constraints](#platform-constraints).
 
+### Remote git ops hang on the Git Credential Manager GUI (agent / worktree sessions)
+
+**Symptom.** In Claude-managed worktree / non-interactive agent sessions on Windows, every *remote*
+git operation — `git push`, `git fetch`, `git ls-remote` — hangs indefinitely. Git for Windows ships
+**Git Credential Manager (GCM)** as the default `credential.helper`; on a credential lookup it launches
+the `GitHub.UI.exe` GUI OAuth dialog, which never resolves in a session with no interactive desktop
+driving it, so the command blocks until timeout. Stuck dialogs accumulate (~15 in one session) and
+must be force-killed:
+
+```bash
+taskkill //F //IM GitHub.UI.exe
+```
+
+`gh` itself stays authenticated the whole time — its OAuth token lives in the OS keyring, not behind
+the GUI — so only raw git-over-HTTPS is affected, never gh-mediated operations.
+
+**Per-command workaround (fail-fast, no global change).** Point the single op at gh's token and
+disable the prompt so it errors instead of hanging:
+
+```bash
+GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c 'credential.helper=!gh auth git-credential' <push|fetch|ls-remote|...>
+```
+
+The empty `-c credential.helper=` clears any inherited helper (so GCM does not run); the second `-c`
+uses gh's credential helper; `GIT_TERMINAL_PROMPT=0` makes it fail fast if no credential is available.
+
+**Persistent fix (standardized 2026-06-20).** Run once to point git's `github.com` credential helper
+at gh's token globally, so *all* remote ops resolve credentials over authenticated HTTPS and never
+invoke the GCM GUI:
+
+```bash
+gh auth setup-git
+```
+
+This sets the global config `credential.https://github.com.helper` to `!gh auth git-credential`
+([gh manual](https://cli.github.com/manual/gh_auth_setup-git)). Verify with a no-hang smoke test —
+it should return immediately instead of blocking:
+
+```bash
+git ls-remote --heads origin >/dev/null && echo OK
+```
+
+A fresh machine or a wiped git config must re-run `gh auth setup-git` (or use the per-command fallback
+above). Revert if ever undesired — this restores GCM as the `github.com` helper, and the hang in agent
+sessions:
+
+```bash
+git config --global --unset-all credential.https://github.com.helper
+```
+
+Root cause, decision, and alternatives: [ADR-047](adr/047-standardize-gh-credential-helper.md).
+
 ### Pre-push hook wiring (one-time setup)
 
 Before setting, check for an existing value: `git config --system core.hooksPath` and

--- a/docs/adr/047-standardize-gh-credential-helper.md
+++ b/docs/adr/047-standardize-gh-credential-helper.md
@@ -1,0 +1,106 @@
+# ADR-047 — Standardize git's GitHub Credential Helper on `gh` to Prevent Credential-Manager GUI Hangs in Agent Sessions
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Closes:** [dev-env#371](https://github.com/brownm09/dev-env/issues/371)
+**Tags:** git, credential-manager, worktree, agent-session, windows, gh-cli, workflow, global-rule
+**Related:** [ADR-035](035-git-push-delete-web-session-constraint.md) (sibling remote-git-op platform constraint), [ADR-005](005-global-core-hooks-path.md) (global git-config standardization for a workflow invariant)
+
+---
+
+## Context
+
+Git for Windows ships **Git Credential Manager (GCM)** as the default `credential.helper` for HTTPS
+remotes. When git needs a credential for `github.com` and GCM has none cached (or must refresh one),
+GCM launches the `GitHub.UI.exe` GUI OAuth dialog to authenticate interactively.
+
+In Claude-managed worktree / non-interactive **agent sessions** on Windows there is no interactive
+desktop session driving that dialog, so it never resolves. The consequence: **every remote git
+operation over HTTPS — `git push`, `git fetch`, `git ls-remote` — hangs until timeout.** In the
+originating incident (2026-06-20) ~15 stuck `GitHub.UI.exe` processes accumulated across one session
+and had to be force-killed (`taskkill //F //IM GitHub.UI.exe`), burning tokens on recovery.
+
+Crucially, `gh` itself stays authenticated the entire time — its OAuth token lives in the OS keyring,
+not behind the GUI — so gh-mediated operations never hang. The two credential paths are independent:
+**git → GCM (GUI)**, **gh → keyring token**. Only raw git-over-HTTPS is affected.
+
+This is the git-credential analogue of [ADR-035](035-git-push-delete-web-session-constraint.md): a
+remote git operation that works in an ordinary interactive local session fails opaquely in an agent
+session and costs tokens to recover. There the failure was a sandbox proxy; here it is the local
+credential helper. The fix follows the same shape — route the operation through `gh`, which is already
+authenticated.
+
+---
+
+## Decision
+
+Standardize git's GitHub credential helper on `gh`'s token, machine-wide, by running once:
+
+```bash
+gh auth setup-git
+```
+
+This sets the global config key `credential.https://github.com.helper` to `!gh auth git-credential`
+([gh manual](https://cli.github.com/manual/gh_auth_setup-git)). git then resolves `github.com`
+credentials from gh's keyring-stored OAuth token over authenticated HTTPS and **never invokes the GCM
+GUI**, so remote operations complete non-interactively instead of hanging. Applied 2026-06-20 and
+verified by a no-hang `git ls-remote` smoke test (and confirmed again by the merge-base `git fetch`
+in the session that authored this ADR, which returned immediately).
+
+Two further commitments:
+
+1. **Per-command fallback** for any environment where the global helper is absent (a fresh machine, a
+   wiped config) — point a single op at gh's token and fail fast instead of hanging:
+   ```bash
+   GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c 'credential.helper=!gh auth git-credential' <push|fetch|...>
+   ```
+   The empty `-c credential.helper=` clears any inherited helper so GCM does not run; the second `-c`
+   uses gh's helper; `GIT_TERMINAL_PROMPT=0` makes it error rather than block if no credential is
+   available.
+2. **Document** the symptom, the per-command fallback, the standardization, the verification smoke
+   test, and the revert in `docs/REFERENCE.md` →
+   [Git Workflow Runbooks](../REFERENCE.md#remote-git-ops-hang-on-the-git-credential-manager-gui-agent--worktree-sessions),
+   so the global-config change is explained in-repo rather than living only as an unexplained machine
+   state ([ADR-038](038-durable-preferences-documented-in-repo.md)).
+
+**Revert** (restores GCM as the github.com helper — and the hang in agent sessions):
+
+```bash
+git config --global --unset-all credential.https://github.com.helper
+```
+
+---
+
+## Consequences
+
+- Remote git ops in agent/worktree sessions no longer hang on the GCM GUI; the failure class (stuck
+  `GitHub.UI.exe` dialogs → `taskkill` recovery → token waste) is removed.
+- The change is **global git config, machine-wide** — it affects all repos and every session on this
+  machine, not only agent sessions. Interactive local sessions also route `github.com` credentials
+  through gh's token, which is fine (gh is the authenticated CLI here) and yields a single credential
+  path regardless of session type.
+- It depends on `gh` staying authenticated. If gh's token lapses, git ops fail with a **fast
+  credential error**, not a GUI hang — still strictly better than the original failure mode.
+- New machines / fresh environments must re-run `gh auth setup-git` (or use the per-command fallback)
+  — captured in the runbook.
+- Fully reversible with a single `--unset-all`. The change is recorded here precisely because
+  `git log` over the docs would not explain *why* a global credential helper was standardized.
+
+---
+
+## Alternatives Considered
+
+- **Per-command workaround only** (`GIT_TERMINAL_PROMPT=0 git -c credential.helper=… <op>` on every
+  remote op). Rejected as the *primary* fix: it must be remembered and prepended to every push/fetch,
+  and a single forgotten prefix reintroduces the hang. Kept as the documented fallback for
+  environments without the global helper.
+- **Set `GIT_TERMINAL_PROMPT=0` globally without changing the helper.** Rejected: it converts the
+  hang into a hard failure (git can no longer prompt) but does not authenticate — git still has no
+  working `github.com` credential in the agent session, so pushes/fetches fail outright. It removes
+  the hang but not the inability to reach the remote.
+- **Uninstall or disable Git Credential Manager.** Rejected: heavier-handed, affects all hosts (not
+  just `github.com`), and removes a tool the user may want in interactive sessions. Pointing only the
+  `github.com` helper at gh is the minimal, reversible change.
+- **Switch remotes to SSH.** Rejected: would require re-keying remotes and changing clone URLs across
+  many repos and worktrees; the HTTPS + gh-token path is already the authenticated path here (gh is
+  set up) and needs no per-repo change.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -51,3 +51,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [044](044-eliminate-usage-snapshot-gap-on-demand-refresh.md) | Eliminate the Usage-Snapshot Gap via On-Demand CLI Refresh | 2026-06-16 | Accepted | hooks, oauth, token-refresh, usage-snapshot, post-tool-use, lazy-refresh |
 | [045](045-pre-install-freespace-gate.md) | Pre-Install Free-Space Gate + Prompt Post-Merge Reclamation | 2026-06-18 | Accepted | disk, worktrees, node_modules, hooks, ENOSPC, npm-install, post-merge, runbook |
 | [046](046-post-merge-followup-tiles.md) | Post-Merge Follow-Up Tiles | 2026-06-20 | Accepted | git-workflow, post-merge, follow-ups, spawn-task, tiles |
+| [047](047-standardize-gh-credential-helper.md) | Standardize git's GitHub Credential Helper on `gh` for Agent Sessions | 2026-06-20 | Accepted | git, credential-manager, worktree, agent-session, windows, gh-cli, workflow, global-rule |


### PR DESCRIPTION
## Summary

Documents a recurring Windows platform constraint and the fix applied for it on 2026-06-20.

**Constraint:** In Claude-managed worktree / non-interactive agent sessions on Windows, every *remote* git operation (`git push`, `git fetch`, `git ls-remote`) hangs. Git for Windows ships Git Credential Manager (GCM) as the default `credential.helper`; on a credential lookup it launches the `GitHub.UI.exe` GUI OAuth dialog, which never resolves with no interactive desktop driving it, so the command blocks until timeout (~15 stuck dialogs accumulated in one session and were force-killed). `gh` stays authenticated via the keyring throughout — only raw git-over-HTTPS is affected.

**Fix (standardized this session):** `gh auth setup-git` points git's `github.com` credential helper at gh's token globally, so remote ops resolve over authenticated HTTPS and never invoke the GCM GUI. Verified by a no-hang `ls-remote` / `fetch` smoke test (the fetch + push in *this* PR confirm it).

## Changes

- `docs/REFERENCE.md` → **Git Workflow Runbooks**: new entry covering the symptom, the per-command fallback (`GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c 'credential.helper=!gh auth git-credential' …`), the `gh auth setup-git` standardization, a verification smoke test, and the revert command.
- `docs/adr/047-standardize-gh-credential-helper.md`: new ADR (Context / Decision / Consequences / Alternatives). Related ADR-035 (sibling remote-git-op constraint), ADR-005 (global git-config standardization precedent), ADR-038 (document durable decisions in-repo).
- `docs/adr/INDEX.md`: ADR-047 row.

**ADR decision:** Yes — a machine-wide git-config standardization is a workflow decision `git log` would not explain, the same class as ADR-035. ADR authored.

Closes #371

## Testing

dev-env's verification suite is script/hook self-tests; this PR touches **only** `docs/REFERENCE.md` and `docs/adr/` (no scripts, hooks, skills, routines, or `claude/CLAUDE.md`), so checks #1–#3 and #5–#10 are **N/A — no code touched**, and the #4 docs-only guard (which targets `claude/CLAUDE.md`) is **N/A — that file is not modified**. No automated test suite applies to a docs-only change; verification was the doc checks below:

- **Suppression grep** (`git diff --cached | grep -E '…'`): **clean** (the `!gh auth git-credential` strings are git config helper syntax, not TS non-null assertions).
- **Test-integrity grep:** **clean**; no deleted test files.
- **Cross-reference link integrity:** all four referenced ADR files (047/035/005/038) exist; REFERENCE→ADR-047 target resolves; the ADR→REFERENCE anchor (`…-gui-agent--worktree-sessions`) matches GitHub's computed heading slug exactly (verified with the slugger algorithm).
- **Live fix verification:** `git fetch` and `git push` in this PR completed without hanging, confirming the documented `gh auth setup-git` fix.

**Coverage gate:** N/A — docs-only change, no new testable runtime behavior.

## Risk-dimension audit

- **Security:** the fix points git's helper at gh's keyring-stored OAuth token; the docs record config keys/commands only — no secret/token text, no PII.
- **Resilience:** the runbook documents both the rollback (`git config --global --unset-all credential.https://github.com.helper`) and the fail-fast per-command fallback for environments lacking the global helper.
- **Observability / Testing(runtime) / Performance / Data-integrity:** N/A — docs-only, no runtime.

## Doc reconciliation

No skill/hook/script/routine added, removed, or renamed → README Documentation Maintenance table not triggered. ADR INDEX.md updated (required for the new ADR). README references to ADR-045 are unrelated hook-row citations and do not go stale.

## Review findings disposition

`/review` (claude-opus-4-8) returned **0 blocking / 0 non-blocking** findings — clean review, `reviewed-by-claude` applied ([review comment](https://github.com/brownm09/dev-env/pull/375#issuecomment-4760603152)). No findings to disposition.