### PR TITLE
Pair durable memory writes with an immortalization issue (+ advisory hook + /memory-audit skill)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,17 @@ before PR" rule in [`claude/CLAUDE.md`](claude/CLAUDE.md) defers to this section
     py -3 claude/scripts/tests/test_post_pr_merge_reclaim.py
     ```
 
+11. **memory-write-advisory test** — required when changing `claude/scripts/memory-write-advisory.py`.
+    Exercises the pure `should_advise_memory_write()` predicate offline (no stdin, no Claude session):
+    pins that a durable memory write with no immortalization link advises, while a write that already
+    cites an issue/ADR/`CLAUDE.md`, the `MEMORY.md` index, a non-`memory/` path, a non-`.md` file, or the
+    `Edit` tool stays silent ([ADR-048](docs/adr/048-memory-immortalization-issue-pairing.md)). The stdin
+    plumbing and exit-2 emission are not covered (pure-helper convention).
+
+    ```bash
+    py -3 claude/scripts/tests/test_memory_write_advisory.py
+    ```
+
 ## Observability
 
 dev-env has **no long-running runtime to instrument** — it is a configuration repo whose

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Custom slash commands loaded from `claude/skills/`. Invoke with `/skill-name [ar
 | [`/research [tag:] <decision> [--compare <alt>]`](claude/skills/research/SKILL.md) | Finds 1–3 primary sources. Greps shared source library first; spawns a subagent only on cache miss. |
 | [`/review <PR-URL> [flags]`](claude/skills/review/SKILL.md) | Reviews a PR for correctness, security, reliability, maintainability, documentation reconciliation, test coverage (ADR-022), and test integrity (ADR-029). Posts report as PR comment by default. |
 | [`/journal-onboard [slug]`](claude/skills/journal-onboard/SKILL.md) | Scaffolds `sessions/<project>/` in engineering-journal and optionally creates `.claude/CLAUDE.md` in the project repo. |
+| [`/memory-audit`](claude/skills/memory-audit/SKILL.md) | Reconciles agent memory against the version-controlled instructions and emits a table (per entry: durable? instruction-home? disposition). Catches never-ported durables, stale notes, and index drift. |
 
 ## Hooks
 
@@ -67,6 +68,7 @@ Hooks that spawn subprocesses (`git`, `gh`, `bash`, …) must `import _winsubp` 
 | PostToolUse (Bash) | `post-pr-merge-project.py` | Auto-moves linked issue to Done on configured GitHub Project after `gh pr merge` |
 | PostToolUse (Bash) | `usage-snapshot.py` | Emits weekly/5-hour utilisation vs. daily soft targets and top-5 session exchanges after `gh pr merge` |
 | PostToolUse (Bash) | `stub-push-archive-reminder.py` | Writes a sentinel flag after a stub is pushed to engineering-journal; Stop hook consumes it to remind Claude to archive |
+| PostToolUse (Write) | `memory-write-advisory.py` | Reminds Claude to pair a durable memory write with an immortalization issue when a memory file is written without an issue/ADR/`CLAUDE.md` link; non-blocking advisory (see [ADR-048](docs/adr/048-memory-immortalization-issue-pairing.md)) |
 | Stop | `token-tracker.py` | Aggregates session token usage to `scratch/token-sessions.jsonl` |
 | Stop | `journal-stop-check.py` | Checks sentinel flag and stale open journal stubs at session end; emits closing reminder if stub was pushed this session |
 | PostCompact | `post-compact.py` | Emits compaction status line (trigger type + remaining tokens) |

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -13,13 +13,14 @@ Project-specific CLAUDE.md files extend these conventions — they do not repeat
 
 ## Durable Preferences & Memory
 
-Agent memory (`~/.claude/projects/.../memory/`) is a private cache, not the source of truth. It is invisible to the user and to everyone else who works in these repos and processes, and it is not reliably consulted at the moments it matters.
+Agent memory (`~/.claude/projects/.../memory/`) is a private cache, not the source of truth. It is invisible to the user and to everyone else who works in these repos and processes, and it is not reliably consulted at the moments it matters. The instructions (`CLAUDE.md` and project docs) are loaded every session and visible to everyone — that is where durable rules must live.
 
-- **Any durable user preference or workflow rule committed to memory must also be documented in the version-controlled repo** — in the appropriate `CLAUDE.md` (global or project) or project docs — **or, at minimum, captured in a GitHub issue.** Never let a standing instruction live *exclusively* in memory.
-- Do this **in the same session** the preference is stated. When you write the memory entry, link it back to where it is recorded in the repo so the two stay connected.
-- Memory may still hold session-local or fast-changing context; this rule governs durable, cross-session preferences and rules — the things a human collaborator would need to know to work the way the user expects.
+- **Never let a durable preference or workflow rule live only in memory.** Whenever you commit one to a `user`/`feedback`/`project` memory file, **pair it — in the same session — with a GitHub issue whose explicit job is to immortalize it into the instructions** (the appropriate `CLAUDE.md`, global or project, or project docs). Link that issue from **both** the memory body and its `MEMORY.md` pointer so the two never drift apart.
+- **Filing the issue is the floor, not the finish.** The issue exists to drive the rule *into* the instructions — not to substitute for doing so. Prefer to make the instruction edit immediately and close the issue in the same session; a deferred issue is the backstop that keeps the rule from being forgotten, not a place to park it indefinitely.
+- **Transient context is exempt.** Session-local or fast-changing notes (open-PR lists, in-flight working state) may live in memory and expire there — no issue required. This rule governs only durable, cross-session rules: the things a human collaborator would need to know to work the way the user expects.
+- A non-blocking write-time hook (`memory-write-advisory.py`) reminds you when a memory file is written without such a link, and the `/memory-audit` skill reconciles memory against the instructions on demand.
 
-See [ADR-038](../docs/adr/038-durable-preferences-documented-in-repo.md).
+See [ADR-038](../docs/adr/038-durable-preferences-documented-in-repo.md), [ADR-048](../docs/adr/048-memory-immortalization-issue-pairing.md).
 
 ---
 

--- a/claude/scripts/memory-write-advisory.py
+++ b/claude/scripts/memory-write-advisory.py
@@ -18,6 +18,11 @@ MEMORY.md pointer. Transient/session-local notes are exempt — the link-absence
 heuristic keeps this nudge quiet on writes that already carry a link, and the
 agent (not this hook) judges whether a given note is durable.
 
+The link check is an intentionally permissive proxy (plain substring / loose
+regex), so it errs toward staying silent — the safe direction for a non-blocking
+nudge. Do not "tighten" it into a stricter check: a missed nudge is harmless (the
+agent still follows the rule), whereas a noisier one trains the reader to ignore it.
+
 Stdin JSON shape (PostToolUse):
   {"tool_name": "Write", "tool_input": {"file_path": "...", "content": "..."}, ...}
 
@@ -29,6 +34,8 @@ import re
 import sys
 
 # An immortalization link anywhere in the written body suppresses the nudge.
+# Intentionally permissive (substring / loose regex): over-suppression is the safe
+# direction for a non-blocking advisory — see the module docstring before tightening.
 _LINK_PATTERNS = (
     re.compile(r"#\d+"),            # GitHub issue / PR reference
     re.compile(r"ADR-\d+", re.I),  # ADR reference

--- a/claude/scripts/memory-write-advisory.py
+++ b/claude/scripts/memory-write-advisory.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Claude Code PostToolUse hook — advisory reminder when a durable memory file
+is written without a link that immortalizes it into the repo instructions.
+
+Fires only for the Write tool, only for a `.md` file inside a `.../memory/`
+directory (excluding the MEMORY.md index), and only when the written body lacks
+any immortalization link — a GitHub issue/PR ref (`#123`), an ADR ref
+(`ADR-048`), the string `CLAUDE.md`, or the phrase "Documented in repo". When
+all of those hold it emits a one-line stderr reminder and exits 2 so Claude sees
+it and files the issue. The tool has already run, so exit 2 here *surfaces* the
+reminder — it does not block the write (same convention as post-tool-use.py and
+pr-merge-reminder.py). Every other case exits 0 silently.
+
+Per ADR-048 (extends ADR-038): a durable user/feedback/project memory must be
+paired, in the same session, with a GitHub issue that drives it into the
+instructions (CLAUDE.md / project docs), linked from the memory body and the
+MEMORY.md pointer. Transient/session-local notes are exempt — the link-absence
+heuristic keeps this nudge quiet on writes that already carry a link, and the
+agent (not this hook) judges whether a given note is durable.
+
+Stdin JSON shape (PostToolUse):
+  {"tool_name": "Write", "tool_input": {"file_path": "...", "content": "..."}, ...}
+
+Exit 0 — not a relevant write, or the memory body already carries a link; silent.
+Exit 2 — durable memory written with no immortalization link; reminder on stderr.
+"""
+import json
+import re
+import sys
+
+# An immortalization link anywhere in the written body suppresses the nudge.
+_LINK_PATTERNS = (
+    re.compile(r"#\d+"),            # GitHub issue / PR reference
+    re.compile(r"ADR-\d+", re.I),  # ADR reference
+)
+_LINK_SUBSTRINGS = ("CLAUDE.md", "Documented in repo")
+
+
+def should_advise_memory_write(tool_name: str, file_path: str, content: str) -> bool:
+    """True when a durable memory file is written with no immortalization link.
+
+    Pure and offline so it can be unit-tested without a Claude Code session.
+    The hook never decides whether a note is *durable* — it only flags the
+    absence of any link, leaving the durability judgment to the agent.
+    """
+    if tool_name != "Write":
+        return False
+    norm = (file_path or "").replace("\\", "/")
+    if "/memory/" not in norm:
+        return False
+    base = norm.rsplit("/", 1)[-1]
+    if base == "MEMORY.md" or not base.endswith(".md"):
+        return False
+    body = content or ""
+    if any(p.search(body) for p in _LINK_PATTERNS):
+        return False
+    if any(s in body for s in _LINK_SUBSTRINGS):
+        return False
+    return True
+
+
+ADVISORY = (
+    "[memory-hook] A memory file was written with no link that immortalizes it "
+    "into the instructions.\n"
+    "  If this is a durable user/feedback/project rule, in this same session:\n"
+    "    1. file a GitHub issue whose job is to port it into the instructions "
+    "(CLAUDE.md / project docs),\n"
+    "    2. link that issue from both the memory body and the MEMORY.md pointer,\n"
+    "    3. prefer to make the instruction edit now and close the issue.\n"
+    "  Transient/session-local notes are exempt. See ADR-048 (extends ADR-038)."
+)
+
+
+def main() -> None:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        sys.exit(0)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {}) or {}
+    if should_advise_memory_write(
+        data.get("tool_name", ""),
+        tool_input.get("file_path", ""),
+        tool_input.get("content", ""),
+    ):
+        print(ADVISORY, file=sys.stderr)
+        sys.exit(2)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:  # safe-exit guard: never block or crash a Write
+        sys.exit(0)

--- a/claude/scripts/tests/test_memory_write_advisory.py
+++ b/claude/scripts/tests/test_memory_write_advisory.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Unit tests for memory-write-advisory.py's should_advise_memory_write predicate.
+
+memory-write-advisory.py is a PostToolUse(Write) hook that nudges Claude to pair a
+durable memory write with an immortalization issue (ADR-048, extends ADR-038). The
+"should this nudge fire?" decision is extracted into the pure
+should_advise_memory_write() predicate so it can be exercised offline (no Claude
+session, no stdin plumbing), matching the repo's fixture-only test convention.
+
+Usage:
+    py -3 claude/scripts/tests/test_memory_write_advisory.py
+
+Exit 0 = all pass.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# tests/ -> scripts/ -> claude/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "claude" / "scripts" / "memory-write-advisory.py"
+sys.path.insert(0, str(SCRIPT.parent))
+
+# Hyphenated filename — import by path rather than `import`.
+_spec = importlib.util.spec_from_file_location("memory_write_advisory", SCRIPT)
+assert _spec and _spec.loader, f"cannot load module spec from {SCRIPT}"
+mwa = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mwa)  # safe: main() is guarded by __main__
+should = mwa.should_advise_memory_write
+
+# A representative durable-memory path (forward and back slashes both exercised).
+MEM = "C:/Users/brown/.claude/projects/C--Users-brown-Git-dev-env/memory/feedback_new_rule.md"
+
+
+def test_durable_write_no_link_advises() -> str:
+    assert should("Write", MEM, "User wants X. Why: ... How to apply: ...")
+    return "durable memory, no link -> advise"
+
+
+def test_backslash_path_advises() -> str:
+    # Windows-style path separators must normalize so the memory dir is detected.
+    win = r"C:\Users\brown\.claude\projects\proj\memory\feedback_x.md"
+    assert should("Write", win, "durable rule with no link")
+    return "backslash memory path, no link -> advise"
+
+
+def test_write_with_issue_ref_silent() -> str:
+    assert not should("Write", MEM, "User wants X. Tracked in #373.")
+    return "memory body cites #373 -> silent"
+
+
+def test_write_with_adr_ref_silent() -> str:
+    assert not should("Write", MEM, "See ADR-048 for the rule.")
+    return "memory body cites ADR-048 -> silent"
+
+
+def test_write_with_claudemd_ref_silent() -> str:
+    assert not should("Write", MEM, "Documented in repo: claude/CLAUDE.md.")
+    return "memory body cites CLAUDE.md / 'Documented in repo' -> silent"
+
+
+def test_memory_index_silent() -> str:
+    idx = "C:/Users/brown/.claude/projects/x/memory/MEMORY.md"
+    assert not should("Write", idx, "- [Foo](foo.md) - bar")
+    return "MEMORY.md index -> silent"
+
+
+def test_non_memory_path_silent() -> str:
+    assert not should("Write", "C:/Users/brown/Git/dev-env/claude/CLAUDE.md", "anything")
+    return "write outside a memory dir -> silent"
+
+
+def test_non_md_in_memory_silent() -> str:
+    assert not should("Write", "C:/Users/brown/.claude/projects/x/memory/notes.txt", "x")
+    return "non-.md file in memory dir -> silent"
+
+
+def test_edit_tool_silent() -> str:
+    assert not should("Edit", MEM, "durable rule, no link")
+    return "Edit tool (not Write) -> silent"
+
+
+def test_empty_inputs_silent() -> str:
+    assert not should("Write", "", "")
+    assert not should("", MEM, "durable rule, no link")
+    return "empty path / empty tool_name -> silent (no crash)"
+
+
+def main() -> int:
+    tests = [
+        ("durable write, no link advises", test_durable_write_no_link_advises),
+        ("backslash memory path advises", test_backslash_path_advises),
+        ("write with issue ref silent", test_write_with_issue_ref_silent),
+        ("write with ADR ref silent", test_write_with_adr_ref_silent),
+        ("write with CLAUDE.md ref silent", test_write_with_claudemd_ref_silent),
+        ("MEMORY.md index silent", test_memory_index_silent),
+        ("non-memory path silent", test_non_memory_path_silent),
+        ("non-.md in memory silent", test_non_md_in_memory_silent),
+        ("Edit tool silent", test_edit_tool_silent),
+        ("empty inputs silent", test_empty_inputs_silent),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            detail = fn()
+            print(f"PASS: {name}")
+            print(f"      {detail}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL: {name}")
+            for line in str(e).splitlines():
+                print(f"      {line}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR: {name}: {type(e).__name__}: {e}")
+    print()
+    print(f"Tests: {len(tests) - failed} passed, 0 skipped, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/scripts/tests/test_memory_write_advisory.py
+++ b/claude/scripts/tests/test_memory_write_advisory.py
@@ -56,8 +56,15 @@ def test_write_with_adr_ref_silent() -> str:
 
 
 def test_write_with_claudemd_ref_silent() -> str:
-    assert not should("Write", MEM, "Documented in repo: claude/CLAUDE.md.")
-    return "memory body cites CLAUDE.md / 'Documented in repo' -> silent"
+    # The 'CLAUDE.md' substring alone (no other link token) must suppress.
+    assert not should("Write", MEM, "see claude/CLAUDE.md for the rule")
+    return "memory body cites CLAUDE.md -> silent"
+
+
+def test_write_with_documented_in_repo_silent() -> str:
+    # The 'Documented in repo' substring alone (no other link token) must suppress.
+    assert not should("Write", MEM, "Documented in repo under docs/")
+    return "memory body says 'Documented in repo' -> silent"
 
 
 def test_memory_index_silent() -> str:
@@ -94,6 +101,7 @@ def main() -> int:
         ("write with issue ref silent", test_write_with_issue_ref_silent),
         ("write with ADR ref silent", test_write_with_adr_ref_silent),
         ("write with CLAUDE.md ref silent", test_write_with_claudemd_ref_silent),
+        ("write with 'Documented in repo' silent", test_write_with_documented_in_repo_silent),
         ("MEMORY.md index silent", test_memory_index_silent),
         ("non-memory path silent", test_non_memory_path_silent),
         ("non-.md in memory silent", test_non_md_in_memory_silent),

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -190,6 +190,15 @@
             "command": "pyw -3 C:/Users/brown/.claude/scripts/usage-snapshot.py"
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pyw -3 C:/Users/brown/.claude/scripts/memory-write-advisory.py"
+          }
+        ]
       }
     ]
   },

--- a/claude/skills/memory-audit/SKILL.md
+++ b/claude/skills/memory-audit/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: memory-audit
+description: Reconcile agent memory against the version-controlled instructions and emit a table — per entry type, durable?, instruction home?, and a disposition (remain / promote / delete). Catches never-ported durables, stale notes, and index drift. Invoke as /memory-audit.
+argument-hint: "(no arguments)"
+allowed-tools: Read Grep Glob Bash AskUserQuestion Edit
+---
+
+You are auditing the active project's agent memory against the version-controlled
+instructions, to surface what should **remain** as a cache, be **promoted** into the
+instructions, or be **deleted** as stale. This is the audit-time complement to the
+write-time rule in `claude/CLAUDE.md` § Durable Preferences & Memory and
+[ADR-048](../../../docs/adr/048-memory-immortalization-issue-pairing.md) /
+[ADR-038](../../../docs/adr/038-durable-preferences-documented-in-repo.md). It realizes
+the reconciliation direction of [dev-env#363](https://github.com/brownm09/dev-env/issues/363).
+
+The output is a **table for the user to review** — do not delete or promote anything
+without confirmation (Step 5). Read-only by default.
+
+## Step 0 — Locate the memory store
+
+The active project's memory lives at
+`~/.claude/projects/<project-dir>/memory/` with an index at `MEMORY.md`.
+List the directory and read `MEMORY.md`:
+
+```bash
+ls -1 "C:/Users/brown/.claude/projects/<project-dir>/memory/"
+```
+
+(`<project-dir>` is the slugified project path Claude Code already uses for this
+session — it is the directory whose `memory/` you were given at session start.)
+
+## Step 1 — Read every memory file
+
+For each `*.md` file other than `MEMORY.md`, read its frontmatter (`type:` —
+`user` / `feedback` / `project` / `reference`) and body. Note any
+"**Documented in repo (source of truth):**" line — the instruction home the
+memory *claims*.
+
+## Step 2 — Verify against CURRENT instructions, not a stale tree
+
+> A memory is a point-in-time snapshot, and a worktree can be cut from an older
+> `main`. Before trusting *or* doubting any claim, verify against current `origin/main`.
+
+For the dev-env repo specifically:
+
+```bash
+git -C C:/Users/brown/Git/dev-env fetch origin --quiet
+git -C C:/Users/brown/Git/dev-env log --oneline -1 origin/main
+```
+
+When a memory claims an instruction home (a `CLAUDE.md` section, an `ADR-NNN`,
+a doc path), **confirm the cited file/section actually exists on `origin/main`**
+(`git show origin/main:<path>` or grep the working tree only if it is on
+`origin/main`). A claim that points at a non-existent ADR or section is **drift**,
+not proof of immortalization. (This guard exists because the audit that created this
+skill first produced a false "drift" finding from a stale worktree base.)
+
+## Step 3 — Classify each entry
+
+For each memory, determine three things:
+
+1. **Durable?** A `user`/`feedback` rule, or a `project` entry encoding a
+   cross-session rule/decision, is **durable**. Open-PR lists, in-flight working
+   state, and other fast-changing notes are **transient** (exempt from the rule).
+2. **Instruction home?** Does a real, current instruction (a `CLAUDE.md` section,
+   project doc, or ADR) capture this durable rule? Confirm per Step 2.
+3. **Drift / staleness signals:**
+   - **Stale note** — cites PRs/issues now merged/closed, or a "next step" that has
+     since shipped, or facts contradicted by current code.
+   - **Never-ported durable** — durable, no instruction home, no tracking issue (or
+     a *closed* issue whose work never landed). This is the forbidden memory-only
+     state.
+   - **Index drift** — the entry is missing from `MEMORY.md`, or its `MEMORY.md`
+     line disagrees with the file it indexes.
+
+## Step 4 — Emit the reconciliation table
+
+Print one row per memory file:
+
+```
+| Memory file | Type | Durable? | Instruction home (verified) | Drift | Disposition |
+|---|---|---|---|---|---|
+```
+
+Disposition is one of:
+
+- **remain-as-cache** — durable and already immortalized in a current instruction;
+  keep the memory as a recall aid. (Fix index drift if any.)
+- **promote-to-instructions** — durable, no current instruction home → file an
+  immortalization issue and port it into the appropriate `CLAUDE.md`/docs (per the
+  write-time rule).
+- **delete-stale** — transient-and-expired, or resolved/superseded; the repo (or
+  engineering-journal `open-prs.jsonl`) is the authoritative source.
+
+Also report any `MEMORY.md` index drift (missing entries, inconsistent lines).
+
+## Step 5 — Confirm before acting
+
+Present the table and ask the user which dispositions to apply (use
+`AskUserQuestion` if there is more than one promote/delete decision). Then, only for
+the confirmed items:
+
+- **promote** → file the GitHub issue, port the rule into `CLAUDE.md`/docs, link the
+  issue from the memory body and `MEMORY.md` (follow the write-time rule in
+  `claude/CLAUDE.md`).
+- **delete** → remove the memory file and its `MEMORY.md` line.
+- **remain** → leave the file; only repair `MEMORY.md` index drift.
+
+Memory files are machine-local (never committed); instruction edits and issues
+follow the normal dev-env branch/PR workflow.
+
+## Notes
+
+- The write-time hook `memory-write-advisory.py` (ADR-048) catches *new* memory-only
+  rules at the moment of writing; this skill catches the *backlog* and *drift* that
+  accrue over time. They are complements.
+- Keep the bar for **promote** at genuinely durable cross-session rules — the same
+  bar the write-time rule uses. Do not promote transient context.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -113,6 +113,18 @@ Scaffolds a new project's journal home (`sessions/<slug>/`) in engineering-journ
 
 ---
 
+### /memory-audit
+
+```
+/memory-audit
+```
+
+Reconciles the active project's agent memory against the version-controlled instructions and emits a table — per entry: `type`, durable?, instruction home?, and a disposition (`remain-as-cache` / `promote-to-instructions` / `delete-stale`). Catches the three rot modes ADR-038's write-time rule does not: never-ported durables, stale notes (cited PRs/issues merged, "next steps" shipped), and `MEMORY.md` index drift.
+
+**How it works:** reads every memory file and `MEMORY.md`, verifies any *claimed* instruction home actually exists on current `origin/main` (so a stale worktree base can't produce a false "drift" finding), classifies each entry, and prints the reconciliation table. Read-only by default — promotions and deletions are confirmed with the user before acting. Audit-time complement to the write-time rule and hook ([ADR-048](adr/048-memory-immortalization-issue-pairing.md), [ADR-038](adr/038-durable-preferences-documented-in-repo.md)).
+
+---
+
 
 ## Hooks
 
@@ -174,9 +186,13 @@ Fires before matched tool calls. Matcher values are set per entry in `settings.j
 
 ---
 
-### PostToolUse (Bash only)
+### PostToolUse
 
-Fires after each Bash tool call completes. Matched with `"matcher": "Bash"`.
+Fires after a matched tool call completes. Matcher values are set per entry in `settings.json`.
+
+#### Bash hooks
+
+Matched with `"matcher": "Bash"`.
 
 | Script | Trigger condition | What it does |
 |--------|------------------|-------------|
@@ -187,6 +203,14 @@ Fires after each Bash tool call completes. Matched with `"matcher": "Bash"`.
 | `post-pr-merge-project.py` | Command contains `gh pr merge` | Auto-moves the linked issue (`Closes/Fixes/Resolves #N` in PR body) to Done on the configured GitHub Project. Opt-in via `status_field_id` and `done_option_id` in `hook-config.json`. [ADR-014](adr/014-auto-move-project-item-done-on-merge.md) |
 | `usage-snapshot.py` | Command contains `gh pr merge` | Queries `https://api.anthropic.com/api/oauth/usage` (via OAuth Bearer token from `~/.claude/.credentials.json`) and parses the session JSONL for the top-5 costliest exchanges. Emits a `### Usage Snapshot (post-merge)` markdown block showing weekly/5-hour utilisation vs. day-of-week soft targets (configured in `claude/usage-config.json`). Global — fires for all repos without opt-in. Include the emitted block verbatim in the post-merge journal stub. A still-valid "expiring" token is used (not skipped); an **expired** token is **refreshed on demand** at merge via the CLI (`keep-token-warm.ps1`) before fetching, so the snapshot only falls back to the stderr advisory ([#357](https://github.com/brownm09/dev-env/pull/357)) when the refresh token itself is dead ([ADR-044](adr/044-eliminate-usage-snapshot-gap-on-demand-refresh.md)). The `ClaudeKeepTokenWarm` scheduled task (see Utilities) keeps the token usually-fresh so on-demand refresh rarely fires ([ADR-043](adr/043-keep-warm-scheduled-task-for-token-freshness.md)). |
 | `stub-push-archive-reminder.py` | `git push` to `engineering-journal` with a stub commit | Writes a sentinel file (`~/.claude/scratch/stub-pushed.flag`) and exits 0. Verifies the most-recent commit in the journal repo touches a `.stub.md` file before writing the flag. The Stop hook (`journal-stop-check.py`) consumes the sentinel and issues the archive reminder via exit 2. |
+
+#### Write hooks
+
+Matched with `"matcher": "Write"`.
+
+| Script | Trigger condition | What it does |
+|--------|------------------|-------------|
+| `memory-write-advisory.py` | The `Write` tool targets a `.md` file inside a `…/memory/` directory (not the `MEMORY.md` index) **and** the written body carries no immortalization link — no `#\d+` issue/PR ref, no `ADR-\d+`, no `CLAUDE.md`, no "Documented in repo" | Emits a one-line stderr reminder and exits 2 (the `Write` already ran — exit 2 *surfaces* the reminder, it does not block) telling Claude to pair the durable memory with an immortalization issue and link it from the memory body + `MEMORY.md`. The link-absence heuristic keeps it quiet on writes that already carry a link; the agent (not the hook) judges durability. Spawns no subprocess; fails open (exit 0). The pure `should_advise_memory_write()` helper is unit-tested by `tests/test_memory_write_advisory.py`. [ADR-048](adr/048-memory-immortalization-issue-pairing.md) |
 
 ---
 

--- a/docs/adr/038-durable-preferences-documented-in-repo.md
+++ b/docs/adr/038-durable-preferences-documented-in-repo.md
@@ -1,7 +1,7 @@
 # ADR-038 — Durable Preferences Must Be Documented in the Repo, Not Only in Memory
 
 **Date:** 2026-06-04
-**Status:** Accepted
+**Status:** Accepted — extended by [ADR-048](048-memory-immortalization-issue-pairing.md)
 **Closes:** [dev-env#311](https://github.com/brownm09/dev-env/issues/311)
 **Tags:** workflow, memory, claude-behavior, documentation, global-rule, code-quality
 **Related:** [ADR-003](003-config-in-version-control.md), [ADR-008](008-plan-then-optimize-forcing-function.md)

--- a/docs/adr/048-memory-immortalization-issue-pairing.md
+++ b/docs/adr/048-memory-immortalization-issue-pairing.md
@@ -1,0 +1,75 @@
+# ADR-048 — Memory Writes Must Be Paired with an Immortalization Issue
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Closes:** [dev-env#373](https://github.com/brownm09/dev-env/issues/373)
+**Tags:** workflow, memory, claude-behavior, documentation, global-rule, hooks, skill
+**Extends:** [ADR-038](038-durable-preferences-documented-in-repo.md)
+**Related:** [ADR-027](027-userpromptsubmit-blocking-hook-conventions.md), [ADR-024](024-worktree-path-guard-hook.md), [ADR-039](039-merge-gate-findings-enforcement.md)
+
+---
+
+## Context
+
+[ADR-038](038-durable-preferences-documented-in-repo.md) established the rule that a durable preference committed to agent memory must *also* be documented in the repo "**or, at minimum, captured in a GitHub issue.**" In practice that "minimum" became a terminal state: an issue is filed (or nothing is) and the durable rule still rots in memory-only form. The user named the failure directly — "a lot of things in memory are often ignored or forgotten when needed" — and asked that no durable memory be written without *also* committing it to an issue that immortalizes the memory **into the instructions**.
+
+A one-time audit of the current memory store (2026-06-20) confirmed three rot modes ADR-038's behavioral rule did not prevent:
+
+1. **Stale notes.** `project_open_prs.md` cited PRs from 2026-05-10, all long merged; its `MEMORY.md` index line was *itself* inconsistent with the file it indexed.
+2. **Resolved-but-lingering research.** `project_usage_alerting.md` had shipped as the post-merge usage snapshot, but the memo lingered with an unbuilt "next step."
+3. **Index drift.** `feedback_post_merge_followup_tiles.md` was **missing from the `MEMORY.md` index** even though the rule itself was correctly ported (ADR-046).
+
+The instructions (`CLAUDE.md` + project docs) are loaded every session and visible to every collaborator; memory is neither. The fix is to make the *path from memory to instructions* mandatory and observable, not optional.
+
+This ADR deliberately revisits ADR-038's rejected alternative — "a hook that blocks on memory writes lacking a repo counterpart." ADR-038 rejected it because reliably auto-detecting whether a preference is *durable* (vs. session-local) is a behavioral judgment, not a grep. That objection holds for a **blocking** hook. It does **not** hold for a **non-blocking advisory** that fires only on a cheap, false-positive-tolerant signal and leaves the durability judgment to the agent.
+
+## Decision
+
+Three coordinated changes, extending — not superseding — ADR-038.
+
+### 1. Strengthen `claude/CLAUDE.md` § Durable Preferences & Memory
+
+A durable (`user`/`feedback`/`project`) memory write must, **in the same session**, be paired with a GitHub issue whose explicit job is to **immortalize it into the instructions** (the appropriate `CLAUDE.md` or project docs), linked from **both** the memory body and its `MEMORY.md` pointer. Filing the issue is the floor, not the finish — it exists to drive the rule into the instructions, not to substitute for doing so; prefer to make the instruction edit immediately and close the issue same-session. Transient/session-local context (open-PR lists, in-flight state) stays exempt.
+
+### 2. Advisory write-time hook — `memory-write-advisory.py` (PostToolUse, `Write`)
+
+A new hook, wired on a `PostToolUse` `Write` matcher, fires **only** when the pure `should_advise_memory_write(tool_name, file_path, content)` predicate holds: the tool is `Write`, the path is a `.md` file inside a `…/memory/` directory other than the `MEMORY.md` index, **and** the written body carries **no** immortalization link — no issue/PR ref (`#\d+`), no `ADR-\d+`, no `CLAUDE.md`, no "Documented in repo". On a match it emits a one-line reminder on **stderr** and exits **2** so Claude sees it and acts; every other case exits **0** silently. The tool has already run, so exit 2 here *surfaces* the reminder — it does not block the write (the same `PostToolUse`-exit-2 convention `post-tool-use.py` and `pr-merge-reminder.py` already use). The hook spawns no subprocess and fails open (top-level guard → exit 0).
+
+The **link-absence heuristic** is what makes the advisory variant defensible where ADR-038 rejected a blocking one: the hook never decides whether a memory is durable — it only nudges when *no link of any kind* is present, and stays silent the moment one is. A transient note that genuinely needs no issue simply gets a one-line reminder it can ignore; a durable rule that already cites its issue/ADR is never nagged.
+
+### 3. `/memory-audit` skill — `claude/skills/memory-audit/SKILL.md`
+
+A report-first skill that reconciles the active project's memory against the repo and emits a table (per entry: type, durable?, instruction home?, disposition — `remain-as-cache` / `promote-to-instructions` / `delete-stale`), covering the three rot modes above (never-ported durables, stale notes, drift). It verifies that any instruction home a memory *claims* actually exists on current `origin/main` before trusting it — the audit that motivated this ADR initially produced a false "drift" finding from a stale worktree base, so freshness verification is built into the skill. This makes the one-time reconciliation repeatable and is the audit-time complement to the write-time rule ([dev-env#363](https://github.com/brownm09/dev-env/issues/363)).
+
+## Rationale
+
+- **Why mandatory issue, not "or at minimum an issue."** The optional framing is exactly the loophole that let durable rules sit in memory. Re-framing the issue as a *tracker toward the instructions* (not a terminal record) closes it without abolishing the low-friction fallback for mid-task captures.
+- **Why advisory, not blocking.** ADR-038's objection (can't auto-detect durability) is real for a gate but not for a nudge. The link-absence signal is intentionally permissive: it tolerates false positives (a transient note gets a harmless reminder) and never produces a false *negative* that blocks a legitimate write.
+- **Why exit 2.** For `PostToolUse`, the tool has already executed; exit 2 feeds stderr back to Claude as actionable feedback without undoing anything — the established convention in this repo. Exit 0 would route the text to the transcript only, where the model is less likely to act ([ADR-027](027-userpromptsubmit-blocking-hook-conventions.md)).
+- **Why a skill for the audit.** The write-time rule prevents *new* memory-only rules; it does nothing about the backlog or about drift that accrues as the repo moves. A repeatable reconciliation pass is the only thing that catches stale notes and index drift after the fact.
+
+## Alternatives considered
+
+- **Keep ADR-038 as-is.** Rejected — the optional-issue loophole is the reported problem.
+- **A blocking hook on memory writes.** Rejected for the same reason ADR-038 gave (durability is a judgment), and because blocking a machine-local cache write is hostile to legitimate transient notes.
+- **A hook that greps the repo / GitHub to confirm the issue exists.** Rejected — a network/`gh` round-trip on *every* `Write` is too costly and failure-prone for a global matcher; the link-presence proxy is good enough and fails safe.
+- **Skill only, no hook.** Rejected — an on-demand audit never catches the write *at the moment it happens*, which is the "forgotten in the moment" failure the user named.
+
+## Consequences
+
+**Positive:**
+- Durable rules reliably reach the instructions everyone reads; the memory→issue→instructions path is now both required and observable.
+- The nudge is low-noise (gated on link-absence) and fail-safe (never blocks a write).
+- `/memory-audit` makes reconciliation repeatable, catching the stale-note and index-drift modes the write-time rule cannot.
+
+**Negative:**
+- A `PostToolUse` `Write` matcher now runs `memory-write-advisory.py` on **every** `Write` globally. The cost is a single JSON parse + string check that exits 0 immediately for non-memory paths, and it fails open — but it is one more per-write hook.
+- Adds an ADR, a hook + test, a skill, and ~6 lines to the global `CLAUDE.md`. Enforcement of the *issue-pairing* itself remains behavioral; the hook only reminds.
+
+## References
+
+- [ADR-038](038-durable-preferences-documented-in-repo.md) — the durable-preferences rule this extends, including the rejected blocking-hook alternative revisited here.
+- [ADR-027](027-userpromptsubmit-blocking-hook-conventions.md) — hook exit-code / safe-exit conventions (`PostToolUse` exit 2 surfaces stderr to Claude; advisory hooks fail open).
+- [dev-env#373](https://github.com/brownm09/dev-env/issues/373) — issue tracking this change; [dev-env#363](https://github.com/brownm09/dev-env/issues/363) — the audit-time reconciliation direction the `/memory-audit` skill realizes.
+- [Anthropic — Claude Code hooks reference](https://docs.anthropic.com/en/docs/claude-code/hooks) — primary source for the `PostToolUse` event payload and exit-code semantics the hook relies on.
+- [Anthropic — Claude Code memory](https://docs.anthropic.com/en/docs/claude-code/memory) — primary source for why `CLAUDE.md` is loaded every session, which is why it is the right home for durable rules.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -52,3 +52,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [045](045-pre-install-freespace-gate.md) | Pre-Install Free-Space Gate + Prompt Post-Merge Reclamation | 2026-06-18 | Accepted | disk, worktrees, node_modules, hooks, ENOSPC, npm-install, post-merge, runbook |
 | [046](046-post-merge-followup-tiles.md) | Post-Merge Follow-Up Tiles | 2026-06-20 | Accepted | git-workflow, post-merge, follow-ups, spawn-task, tiles |
 | [047](047-standardize-gh-credential-helper.md) | Standardize git's GitHub Credential Helper on `gh` for Agent Sessions | 2026-06-20 | Accepted | git, credential-manager, worktree, agent-session, windows, gh-cli, workflow, global-rule |
+| [048](048-memory-immortalization-issue-pairing.md) | Memory Writes Must Be Paired with an Immortalization Issue | 2026-06-20 | Accepted | workflow, memory, claude-behavior, documentation, global-rule, hooks, skill |


### PR DESCRIPTION
Closes #373. Addresses #363 (the `/memory-audit` skill realizes its on-demand reconciliation).

## Why

Agent memory is a private, machine-local cache — invisible and unreliably consulted. [ADR-038](docs/adr/038-durable-preferences-documented-in-repo.md) required durable preferences to reach the repo *"or, at minimum, an issue,"* and that "minimum" became a terminal loophole: durable rules still rot in memory-only form. This makes the **memory → issue → instructions** path mandatory and observable, and runs a one-time audit of the current store.

## What

- **Strengthened rule** (`claude/CLAUDE.md` § Durable Preferences & Memory): a durable (`user`/`feedback`/`project`) memory must be paired, same session, with a GitHub issue whose job is to immortalize it into the instructions — linked from **both** the memory body and the `MEMORY.md` pointer. Filing the issue is the floor, not the finish. Transient/session-local context stays exempt.
- **[ADR-048](docs/adr/048-memory-immortalization-issue-pairing.md)** (extends ADR-038); INDEX + ADR-038 status note updated. *(Renumbered 047→048 mid-flight: #375 landed ADR-047 (gh-credential) while this branch was open; rebased onto current `main`.)*
- **`memory-write-advisory.py`** — non-blocking `PostToolUse` (`Write`) hook. Fires only when a memory `.md` (not `MEMORY.md`) is written with **no** immortalization link (`#\d+` / `ADR-\d+` / `CLAUDE.md` / "Documented in repo"). Exit 2 *surfaces* the reminder to Claude (the `Write` already ran — it does not block); silent exit 0 otherwise. The link-absence heuristic is what makes the advisory variant defensible where ADR-038 rejected a *blocking* hook — it never judges durability, it only nudges when no link exists.
- **`/memory-audit` skill** — reconciles memory vs. instructions and emits a disposition table; verifies any *claimed* instruction home against current `origin/main` (a stale worktree base produced a false "drift" finding during this very session).
- **Docs:** `settings.json` (Write matcher), README + REFERENCE (Skills + Hooks), project `CLAUDE.md` § Testing (item 11).

## One-time memory audit (the table)

| Memory file | Type | Durable? | Instruction home | Disposition |
|---|---|---|---|---|
| `feedback_durable_preferences_in_repo.md` | feedback | yes | CLAUDE.md §Durable + ADR-038/048 | remain (updated for strengthened rule) |
| `feedback_plan_then_optimize.md` | feedback | yes | CLAUDE.md §Plan-then-optimize + ADR-008/042 | remain |
| `feedback_fix_errors_encountered.md` | feedback | yes | CLAUDE.md §Fix errors on encounter + ADR-038 | remain |
| `feedback_post_merge_followup_tiles.md` | feedback | yes | CLAUDE.md Git Workflow + ADR-046 | remain (was **missing from `MEMORY.md` index** → added) |
| `project_open_prs.md` | project | no (transient) | N/A | **delete** — stale (2026-05-10 PRs, merged); authoritative source is engineering-journal `open-prs.jsonl` |
| `project_usage_alerting.md` | project | partial | snapshot shipped | **delete** as resolved |

Memory files are machine-local (never committed); the cleanup happens outside this PR.

## Testing

dev-env has no app runtime — verification is the `## Testing` suite. Run:

- **Hook-script syntax check** (`ast.parse` all `claude/scripts/*.py`) — PASS.
- **`pyw -3` stdio + `_winsubp` static check** (`test_pyw_stdio.py`) — `Tests: 6 passed, 0 skipped, 0 failed`. Confirms the new (subprocess-free) hook is correctly *not* required to import `_winsubp`.
- **New unit test** (`test_memory_write_advisory.py`, added per the coverage gate) — `Tests: 11 passed, 0 skipped, 0 failed`. Covers: durable-write-no-link advises; issue/ADR link → silent; `CLAUDE.md` substring → silent; `Documented in repo` substring → silent; `MEMORY.md` index → silent; non-`memory/` path → silent; non-`.md` → silent; `Edit` tool → silent; backslash path normalization; empty inputs.
- **Behavioral smokes:** memory write w/ no link → exit 2 + stderr advisory; with `#373` → exit 0; non-memory write → exit 0; empty stdin → exit 0 (atomic-commit smoke).
- **`settings.json`** — valid JSON.

**Suppression check** (`git diff origin/main | grep …`): clean.

**Test-integrity check:** the official grep's `xit\(` sub-pattern matches `sys.exit(` in the new Python hook/test — these are **false positives** (process exits, not test-skip markers). No skip markers, deleted tests, or lowered thresholds were introduced; the new test only adds coverage.

**Lockfile / baseline:** N/A — no `package.json` change; dev-env is not under Jest baseline tracking.

## Review findings disposition

`/review` (claude-opus-4-8, two parallel passes) — **0 blocking, 3 non-blocking**; `reviewed-by-claude` applied.

- **[maintainability] link heuristic looser than prose** — **fixed in `78fe2bc`**: docstring + comment now state the link check is an intentionally permissive proxy (over-suppression is the safe direction for a non-blocking nudge) and warn against tightening it.
- **[maintainability] combined-substring test** — **fixed in `78fe2bc`**: split `test_write_with_claudemd_ref_silent` into two assertions pinning `CLAUDE.md` and `Documented in repo` independently (11 tests).
- **[maintainability] language-scope (Python vs JS scanners)** — **verified**: the new test is the only `*.py`; it uses the repo's custom PASS/FAIL runner with no `@pytest.mark.skip` / `pytest.skip(` / `unittest.skip` idioms. No integrity violation.

<!-- findings-disposed -->
