### PR TITLE
fix(post-tool-use): read command output from stdout, not output (#377)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,17 @@ before PR" rule in [`claude/CLAUDE.md`](claude/CLAUDE.md) defers to this section
     py -3 claude/scripts/tests/test_memory_write_advisory.py
     ```
 
+12. **post-tool-use test** — required when changing `claude/scripts/post-tool-use.py`. Exercises the pure
+    `read_command_output()` and `extract_github_url()` helpers offline: pins that the real `stdout`-shaped
+    Bash payload yields a non-empty output (the pre-fix `output` read was `""` — the [#377](https://github.com/brownm09/dev-env/issues/377)
+    silent no-op), that the legacy `output` field still works, and that the de-silenced no-URL path
+    distinguishes a different-repo miss from a genuine empty ([ADR-049](docs/adr/049-hook-payload-output-field.md)).
+    The live `gh project item-add` call is not covered (the repo avoids subprocess mocks).
+
+    ```bash
+    py -3 claude/scripts/tests/test_post_tool_use.py
+    ```
+
 ## Observability
 
 dev-env has **no long-running runtime to instrument** — it is a configuration repo whose

--- a/claude/scripts/post-tool-use.py
+++ b/claude/scripts/post-tool-use.py
@@ -51,6 +51,23 @@ def load_config(cwd: str) -> dict | None:
         return None
 
 
+def read_command_output(data: dict) -> str:
+    """Return the Bash command's output from a PostToolUse hook payload.
+
+    Claude Code exposes a Bash command's output under ``tool_response.stdout``
+    (and ``stderr``), NOT ``output``. Reading ``output`` yields ``""`` and
+    silently breaks URL extraction (dev-env #377). Read stdout/stderr first and
+    fall back to the legacy ``output`` key for forward/backward compatibility.
+    """
+    tr = data.get("tool_response") or {}
+    if not isinstance(tr, dict):
+        return ""
+    parts = [p for p in (tr.get("stdout"), tr.get("stderr")) if p]
+    if parts:
+        return "\n".join(parts)
+    return str(tr.get("output", "") or "")
+
+
 def extract_github_url(output: str, repo: str | None = None) -> str | None:
     """Return the last GitHub URL found in command output, or None.
 
@@ -176,7 +193,7 @@ def main() -> None:
         sys.exit(0)
 
     command = data.get("tool_input", {}).get("command", "")
-    output = data.get("tool_response", {}).get("output", "")
+    output = read_command_output(data)
     exit_code = data.get("tool_response", {}).get("exitCode", 0)
     cwd = data.get("cwd", "")
 
@@ -200,9 +217,13 @@ def main() -> None:
 
     url = extract_github_url(output, repo)
     if not url:
-        # If a repo filter is configured, a missing URL most likely means the
-        # command targeted a different repo — exit silently rather than warning.
-        if repo:
+        # A configured repo filter can legitimately miss: the command may have
+        # created the item in a *different* repo than this cwd's project. Stay
+        # silent only in that case — some GitHub URL is present, just not ours.
+        # If a successful create produced no GitHub URL at all, that is the
+        # symptom of a real failure (e.g. reading the wrong payload field — the
+        # bug behind #377) and must surface rather than be swallowed silently.
+        if repo and extract_github_url(output, None):
             sys.exit(0)
         print(
             f"[project-hook] {item_type} created but no GitHub URL found in output.\n"

--- a/claude/scripts/tests/test_post_tool_use.py
+++ b/claude/scripts/tests/test_post_tool_use.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Unit tests for post-tool-use.py command-output reading and URL extraction.
+
+`post-tool-use.py` is a PostToolUse hook that fires after `gh issue create` /
+`gh pr create` and adds the new item to the configured GitHub Project. Before
+the fix in dev-env#377 it read `tool_response["output"]`, but Claude Code's Bash
+hook payload exposes a command's output under `stdout`/`stderr` (no `output`
+key). So `output` was always `""`, `extract_github_url` returned `None`, and —
+because the dev-env config sets `repo` — the hook hit a silent `sys.exit(0)`.
+The hook therefore never fired in any retained transcript; every project-add was
+done by hand via the documented fallback.
+
+The fix routes output through the pure `read_command_output()` helper (stdout +
+stderr, with a legacy `output` fallback) and de-silences the no-URL path so a
+successful create that yields no GitHub URL at all surfaces instead of vanishing.
+
+These tests exercise the pure helpers offline (no network, no gh subprocess),
+matching the repo's fixture-only test convention. `add_to_project` (the live gh
+call) is intentionally not tested.
+
+Usage:
+    py -3 claude/scripts/tests/test_post_tool_use.py
+
+Exit 0 = all pass.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# tests/ -> scripts/ -> claude/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "claude" / "scripts" / "post-tool-use.py"
+
+# The script imports _winsubp (a sibling in scripts/); make it resolvable when
+# exec_module runs the module body.
+sys.path.insert(0, str(SCRIPT.parent))
+
+# The script filename is hyphenated, so import it by path rather than `import`.
+_spec = importlib.util.spec_from_file_location("post_tool_use", SCRIPT)
+assert _spec and _spec.loader, f"cannot load module spec from {SCRIPT}"
+post_tool_use = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(post_tool_use)  # safe: main() is guarded by __main__
+read_command_output = post_tool_use.read_command_output
+extract_github_url = post_tool_use.extract_github_url
+
+URL = "https://github.com/brownm09/dev-env/issues/377"
+OTHER_REPO_URL = "https://github.com/someone/other-repo/issues/5"
+REPO = "brownm09/dev-env"
+
+
+def test_reads_stdout() -> str:
+    # The real Bash payload shape: output lives under `stdout`, not `output`.
+    payload = {"tool_response": {"stdout": URL, "stderr": "", "interrupted": False}}
+    got = read_command_output(payload)
+    assert got == URL, f"expected stdout URL, got {got!r}"
+    return "stdout-shaped payload -> output is the URL (the #377 regression)"
+
+
+def test_combines_stdout_and_stderr() -> str:
+    # `gh pr merge` prints its success line to stderr; both must be captured.
+    payload = {"tool_response": {"stdout": "done", "stderr": "warn"}}
+    got = read_command_output(payload)
+    assert got == "done\nwarn", f"expected stdout+stderr joined, got {got!r}"
+    return "stdout + stderr are both captured"
+
+
+def test_legacy_output_fallback() -> str:
+    # If a build ever sends the legacy `output` field, still read it.
+    payload = {"tool_response": {"output": URL}}
+    got = read_command_output(payload)
+    assert got == URL, f"expected legacy output fallback, got {got!r}"
+    return "legacy `output` field still works (forward/backward compatible)"
+
+
+def test_empty_and_malformed_payloads() -> str:
+    assert read_command_output({}) == "", "missing tool_response -> ''"
+    assert read_command_output({"tool_response": {}}) == "", "empty tool_response -> ''"
+    assert read_command_output({"tool_response": None}) == "", "None tool_response -> ''"
+    assert read_command_output({"tool_response": "x"}) == "", "non-dict tool_response -> ''"
+    return "missing/empty/None/non-dict tool_response all yield '' (no crash)"
+
+
+def test_old_output_read_would_have_been_empty() -> str:
+    # Pin the root cause: the pre-fix read (`.get("output")`) on the real shape
+    # is empty, which is exactly what silently broke the hook.
+    real_shape = {"stdout": URL, "stderr": "", "interrupted": False, "isImage": False}
+    assert real_shape.get("output", "") == "", "pre-fix read must be empty on real shape"
+    assert read_command_output({"tool_response": real_shape}) == URL, "fixed read recovers URL"
+    return "pre-fix `output` read was '' on the real payload; fixed read recovers the URL"
+
+
+def test_extract_url_matches_configured_repo() -> str:
+    assert extract_github_url(URL, REPO) == URL, "matching-repo URL should extract"
+    return "extract_github_url returns the URL for the configured repo"
+
+
+def test_extract_url_filters_other_repo() -> str:
+    assert extract_github_url(OTHER_REPO_URL, REPO) is None, "different-repo URL must not match"
+    return "repo filter rejects a URL for a different repo"
+
+
+def test_extract_url_empty_output_is_none() -> str:
+    assert extract_github_url("", REPO) is None, "empty output -> None"
+    assert extract_github_url("no url here", REPO) is None, "no URL -> None"
+    return "empty / URL-less output -> None"
+
+
+def test_desilence_predicate() -> str:
+    # The de-silenced branch stays silent only when SOME GitHub URL is present
+    # (a legitimate different-repo create); it surfaces when there is none.
+    different_repo = OTHER_REPO_URL
+    no_url = "=== merge exit: 0 ==="
+    assert extract_github_url(different_repo, None), "different-repo case has a URL -> stay silent"
+    assert not extract_github_url(no_url, None), "no-URL case is empty -> surface advisory"
+    return "different-repo output stays silent; no-URL output surfaces (de-silence behavior)"
+
+
+def main() -> int:
+    tests = [
+        ("reads command output from stdout", test_reads_stdout),
+        ("combines stdout and stderr", test_combines_stdout_and_stderr),
+        ("legacy output field still works", test_legacy_output_fallback),
+        ("empty/malformed payloads yield ''", test_empty_and_malformed_payloads),
+        ("pre-fix output read was empty (#377 root cause)", test_old_output_read_would_have_been_empty),
+        ("extract URL for configured repo", test_extract_url_matches_configured_repo),
+        ("repo filter rejects other repo", test_extract_url_filters_other_repo),
+        ("empty output extracts to None", test_extract_url_empty_output_is_none),
+        ("de-silence predicate distinguishes the two misses", test_desilence_predicate),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            detail = fn()
+            print(f"PASS: {name}")
+            print(f"      {detail}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL: {name}")
+            for line in str(e).splitlines():
+                print(f"      {line}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR: {name}: {type(e).__name__}: {e}")
+    print()
+    print(f"Tests: {len(tests) - failed} passed, 0 skipped, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/adr/049-hook-payload-output-field.md
+++ b/docs/adr/049-hook-payload-output-field.md
@@ -1,0 +1,42 @@
+# ADR-049 — PostToolUse Bash Hooks Read Output from `stdout`, Not `output`
+
+**Date:** 2026-06-21
+**Status:** Accepted
+**Tags:** hooks, post-tool-use, tool_response, payload, github-project, automation, reliability
+
+---
+
+## Context
+
+`post-tool-use.py` is documented (dev-env `CLAUDE.md` → GitHub Project; [ADR-023](023-generic-required-fields-issue-hook.md)) to fire after `gh issue create` / `gh pr create`, add the new item to the Dev Env GitHub Project (#3), and exit 2 with the `gh project item-edit` commands for Impact/Why.
+
+It never did. Investigating why issue #369 was not auto-added (dev-env #377) showed the hook **ran but silently `sys.exit(0)`'d** on every invocation:
+
+- The hook read the command output via `data["tool_response"]["output"]`.
+- Claude Code's Bash hook payload exposes a command's output under **`stdout`** (and `stderr`), **not** `output`. The observed Bash tool-result shape is `interrupted, isImage, noOutputExpected, stderr, stdout` — no `output` and no `exitCode` key — and it is identical across May and June 2026 transcripts.
+- So `output` was always `""`, `extract_github_url("", repo)` returned `None`, and because the dev-env `hook-config.json` sets `repo`, the hook took the *silent* `if repo: sys.exit(0)` branch — emitting nothing.
+
+The silent branch existed for a legitimate reason (a `gh` command run from a cwd whose project targets a *different* repo should not warn), but it also swallowed this genuine failure. Two compounding factors hid the bug for the hook's entire lifetime:
+
+1. **Silent failure** — no error, ever. Confirmed: across all retained transcripts (dev-env + lifting-logbook, months), there is not one real `[project-hook]` fire; every project-add was done by hand via the documented fallback.
+2. **A working manual fallback** — the `CLAUDE.md` workflow tells the operator to add the item manually, which papered over the dead automation. [ADR-014](014-auto-move-project-item-done-on-merge.md) even records the belief that this hook pattern "caused no incidents" — it failed invisibly.
+
+The wrong-field read was copied into several sibling hooks (`post-pr-merge-project.py`, `post-pr-merge-pull.py`, `post-pr-merge-reclaim.py`, `stub-push-archive-reminder.py`), so the same latent failure affects them too.
+
+## Decision
+
+1. **Read command output from `stdout`/`stderr`, not `output`.** `post-tool-use.py` routes output through a pure `read_command_output(data)` helper that joins `tool_response.stdout` and `tool_response.stderr`, falling back to the legacy `output` key for forward/backward compatibility. This is the canonical way for a PostToolUse Bash hook in this repo to read command output; new hooks must use it (or the same field precedence) rather than `tool_response["output"]`.
+
+2. **Do not let a silent branch swallow an unexpected empty.** The no-URL path now stays silent **only** when the output contains *some* GitHub URL (the legitimate different-repo case); a successful create that yields **no** URL at all emits an advisory (exit 2) instead of vanishing. A silent path that doubles as the failure mode of a config/payload bug is the reason this went undetected — diagnostics must survive the very breakage they would diagnose.
+
+3. **Cover it with an offline regression test.** `claude/scripts/tests/test_post_tool_use.py` pins that the real `stdout`-shaped payload yields a non-empty output (the pre-fix `output` read was `""`), that the legacy fallback still works, and that the de-silence predicate distinguishes a different-repo miss from a no-URL miss.
+
+The `exitCode` reads elsewhere default to `0` and are harmless because PostToolUse fires only after a successful tool call; they are left unchanged here.
+
+## Consequences
+
+- `post-tool-use.py` now fires on `gh issue create` / `gh pr create`, adds the item to the project, and prints the Impact/Why commands — eliminating the manual add step it was always meant to remove.
+- A real failure (no URL in a successful create's output) is now visible instead of silent.
+- The Bash-payload field constraint is recorded once here so the sibling-hook fixes and future hooks do not repeat it.
+- The sibling hooks remain affected and are tracked as a follow-up. `post-pr-merge-project.py` additionally needs to derive the PR number from the **command** (the `gh pr merge` output carries no `/pull/N` URL), so its fix is more than a field rename and is deliberately out of scope here.
+- General lesson for this repo's hooks: a guard's diagnostic must not depend on the same input path that the guard is meant to validate, or the failure is unobservable (compare the [ADR-034](034-error-message-diligence.md) error-message-diligence theme — believe verified signals, not assumed ones).

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -53,3 +53,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [046](046-post-merge-followup-tiles.md) | Post-Merge Follow-Up Tiles | 2026-06-20 | Accepted | git-workflow, post-merge, follow-ups, spawn-task, tiles |
 | [047](047-standardize-gh-credential-helper.md) | Standardize git's GitHub Credential Helper on `gh` for Agent Sessions | 2026-06-20 | Accepted | git, credential-manager, worktree, agent-session, windows, gh-cli, workflow, global-rule |
 | [048](048-memory-immortalization-issue-pairing.md) | Memory Writes Must Be Paired with an Immortalization Issue | 2026-06-20 | Accepted | workflow, memory, claude-behavior, documentation, global-rule, hooks, skill |
+| [049](049-hook-payload-output-field.md) | PostToolUse Bash Hooks Read Output from `stdout`, Not `output` | 2026-06-21 | Accepted | hooks, post-tool-use, tool_response, payload, github-project, automation, reliability |


### PR DESCRIPTION
## Summary

`post-tool-use.py` is documented to add new issues/PRs to the Dev Env GitHub Project (#3) after `gh issue create` / `gh pr create` and print the Impact/Why commands. **It never did** — it silently `sys.exit(0)`'d on every invocation, so every project-add was done manually via the fallback. This was surfaced by issue #369 not auto-adding in a worktree session, but the failure is **not** worktree/session-specific.

**Root cause:** the hook read `data["tool_response"]["output"]`, but Claude Code's Bash hook payload exposes a command's output under **`stdout`/`stderr`**, not `output`. So `output` was always `""` → `extract_github_url("", repo)` → `None` → and because the dev-env config sets `repo`, the hook took the **silent** `if repo: sys.exit(0)` branch. Confirmed: zero `[project-hook]` fires exist in months of transcripts (dev-env + lifting-logbook), and creating #377 itself did not auto-add (verified `PRESENT => NO`).

## Changes

- **`claude/scripts/post-tool-use.py`** — route output through a pure `read_command_output(data)` helper (reads `stdout`+`stderr`, legacy `output` fallback). De-silence the no-URL path: a successful create that yields **no** GitHub URL at all now emits an advisory (exit 2); the legitimate different-repo case still exits silently.
- **`claude/scripts/tests/test_post_tool_use.py`** — new offline regression test (9 cases): pins that the real `stdout`-shaped payload yields the URL (the pre-fix `output` read was `""`), the legacy fallback works, and the de-silence predicate distinguishes a different-repo miss from a genuine empty.
- **`docs/adr/049-hook-payload-output-field.md`** + INDEX — records the Bash-payload field constraint so sibling/future hooks don't repeat it.
- **`CLAUDE.md`** — register the new test as Testing item 12.

## Scope / follow-up

This PR fixes `post-tool-use.py` (verified: `gh issue create` prints the full issue URL to stdout). The same empty-`output` read also affects `post-pr-merge-project.py`, `post-pr-merge-pull.py`, `post-pr-merge-reclaim.py`, and `stub-push-archive-reminder.py`. `post-pr-merge-project.py` additionally needs to derive the PR number from the **command** (the `gh pr merge` output carries no `/pull/N` URL — verified in the #369 transcript), so its fix is more than a field rename. **Tracked as a follow-up** (so the move-to-Done hook the #369 stub believed had fired — it had not — gets a correct, verified fix).

## Testing

- `py -3 claude/scripts/tests/test_post_tool_use.py` → **Tests: 9 passed, 0 skipped, 0 failed**
- Hook-script syntax check (`ast.parse` all scripts) → **OK: 32 scripts parse**
- Coverage gate: new behavior (`read_command_output`, de-silence predicate, URL extraction) is covered by the new test.

## Suppression / test-integrity

- One suppression added: `except Exception as e:  # noqa: BLE001` in the test **runner** — a deliberate catch-all that reports an unexpected exception as a test ERROR rather than crashing the run. It mirrors the established convention in `test_usage_snapshot.py` (identical line) and applies only to the runner loop, not the assertions.
- Pre-PR greps: JS/TS suppression grep clean; test-integrity grep clean (no skip markers, no deleted tests, no lowered thresholds).

## ADR-warrant

Warranted — fixes a documented hook and records a durable platform constraint (Bash hook payload field names) → ADR-049 added.

## Review findings disposition

`/review` completed (comment [#issuecomment-4760889231](https://github.com/brownm09/dev-env/pull/379#issuecomment-4760889231)): **0 blocking, 0 non-blocking findings** — clean review, nothing to disposition. `reviewed-by-claude` applied.

Closes #377

