### PR TITLE
docs(claude): add User-Actionable References rule to global CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -371,8 +371,6 @@ Whenever directing the user to view, test, run, or consume any resource, include
 
 No "see the file" without the path. No "check the PR" without the URL.
 
-See [dev-env#407](https://github.com/brownm09/dev-env/issues/407).
-
 ---
 
 ## Engineering Journal

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -362,6 +362,19 @@ When writing or updating any architectural documentation (ADRs, design docs, REA
 
 ---
 
+## User-Actionable References
+
+Whenever directing the user to view, test, run, or consume any resource, include the exact reference inline — never make the user ask for it:
+
+- **Local files, scripts, and logs** — provide the absolute path or the exact invocation string. Never say "run the script" without the full path, or "see the log" without the file path.
+- **Remote resources (PRs, issues, deployed URLs)** — provide the full URL. Never say "check the PR" without the link, or "see the issue" without the URL.
+
+No "see the file" without the path. No "check the PR" without the URL.
+
+See [dev-env#407](https://github.com/brownm09/dev-env/issues/407).
+
+---
+
 ## Engineering Journal
 
 After each session (or at natural breakpoints for long sessions), create or update a session


### PR DESCRIPTION
## Summary

- Adds a new `## User-Actionable References` section to the global `claude/CLAUDE.md`
- Rule: always include the absolute path/invocation string for local resources and the full URL for remote resources (PRs, issues) whenever directing the user to act on something
- No "see the file" without the path; no "check the PR" without the URL

## Why

Every reference without a path or link creates a follow-up question — the user can't act on "run the script" without knowing which script. This rule eliminates that friction class entirely.

## Testing

N/A — documentation-only change. No automated tests. Verified the new section renders correctly in the Markdown source.

Tests: N/A (docs-only change, 0 failed)

## Suppression / test-integrity checks

N/A — no code changed.

## Review findings disposition

Style note (from review comment [#408#issuecomment-4782066123](https://github.com/brownm09/dev-env/pull/408#issuecomment-4782066123)): trailing `See [dev-env#407]` issue link inconsistent with document's ADR-link convention — fixed in `b0feb05` (dropped the line; git history captures the motivation).

<!-- review-findings: blocking=0 non_blocking=0 -->

Closes #407