### PR TITLE
fix(hooks): pr-merge-reminder fires on worktree merges

### DIFF
--- a/claude/scripts/pr-merge-reminder.py
+++ b/claude/scripts/pr-merge-reminder.py
@@ -30,7 +30,7 @@ import subprocess
 import sys
 from collections.abc import Callable
 
-from _hookio import read_command_output
+from _hookio import output_has_merge_marker, read_command_output
 
 # Matches the start of a statement token against `gh pr merge`, `gh pr create`,
 # or `git push`.
@@ -262,6 +262,16 @@ def _create_shard_step(output: str) -> str:
     )
 
 
+def _is_successful_merge_call(exit_code: int, output: str) -> bool:
+    """Return True iff a gh pr merge call completed the remote merge.
+
+    Worktree merges exit non-zero on local cleanup (e.g. 'main is already
+    checked out') even when the remote merge succeeded — check the success
+    marker too (issue #275 behaviour, mirrors post-merge-tile-checkpoint.py).
+    """
+    return exit_code == 0 or output_has_merge_marker(output)
+
+
 def main() -> None:
     raw = sys.stdin.read().strip()
     if not raw:
@@ -275,12 +285,9 @@ def main() -> None:
     if data.get("tool_name") != "Bash":
         sys.exit(0)
 
-    exit_code = data.get("tool_response", {}).get("exitCode", 0)
-    if exit_code != 0:
-        sys.exit(0)
-
     command = data.get("tool_input", {}).get("command", "")
     cwd = data.get("cwd", "<unknown>")
+    exit_code = data.get("tool_response", {}).get("exitCode", 0)
 
     is_create = is_pr_create_command(command)
     is_merge = is_pr_merge_command(command)
@@ -289,10 +296,20 @@ def main() -> None:
     if not (is_create or is_merge or is_push):
         sys.exit(0)
 
+    # gh pr merge in a worktree exits non-zero on local cleanup even when the
+    # remote merge succeeded; check the output marker too.
+    # gh pr create and git push are only acted on when they exit cleanly.
+    output = read_command_output(data)
+    if is_merge:
+        if not _is_successful_merge_call(exit_code, output):
+            sys.exit(0)
+    elif exit_code != 0:
+        sys.exit(0)
+
     messages = []
 
     if is_create:
-        shard_step = _create_shard_step(read_command_output(data))
+        shard_step = _create_shard_step(output)
         messages.append(
             "[journal-reminder] gh pr create detected — write the journal stub AND"
             " open-PR shard NOW:\n"

--- a/claude/scripts/tests/test_pr_merge_reminder.py
+++ b/claude/scripts/tests/test_pr_merge_reminder.py
@@ -30,6 +30,7 @@ is_pr_create_command = pmr.is_pr_create_command
 is_pr_merge_command = pmr.is_pr_merge_command
 is_git_push_command = pmr.is_git_push_command
 _create_shard_step = pmr._create_shard_step
+_is_successful_merge_call = pmr._is_successful_merge_call
 
 # read_command_output lives in _hookio (a sibling of pr-merge-reminder.py).
 # SCRIPT.parent already on sys.path, so import it directly.
@@ -185,6 +186,38 @@ def test_shard_step_merge_url_not_matched() -> str:
 
 
 # ---------------------------------------------------------------------------
+# _is_successful_merge_call
+# ---------------------------------------------------------------------------
+
+def test_merge_call_clean_exit() -> str:
+    assert _is_successful_merge_call(0, "")
+    return "exit 0 + empty output -> fires"
+
+
+def test_merge_call_worktree_nonzero_with_marker() -> str:
+    # Worktree merges exit non-zero on local cleanup; the stdout success marker
+    # confirms the remote merge actually completed (issue #275 behaviour).
+    assert _is_successful_merge_call(
+        1, "Squashed and merged pull request #419"
+    )
+    return "exit 1 + 'Squashed and merged' marker -> fires"
+
+
+def test_merge_call_failed_no_marker() -> str:
+    # A genuine merge failure (non-zero, no success marker) must not fire.
+    assert not _is_successful_merge_call(
+        1, "X Pull request #419 is not mergeable"
+    )
+    return "exit 1 + no success marker -> no-op"
+
+
+def test_merge_call_exit_zero_trumps_no_marker() -> str:
+    # exit 0 is sufficient even when no success text appears (dry-run / quiet mode).
+    assert _is_successful_merge_call(0, "some other output with no merge line")
+    return "exit 0 + no marker -> fires (exit code is authoritative)"
+
+
+# ---------------------------------------------------------------------------
 # runner
 # ---------------------------------------------------------------------------
 
@@ -206,6 +239,10 @@ def main() -> int:
         ("shard step: issue URL not matched", test_shard_step_merge_url_not_matched),
         ("shard step: URL found via stdout field", test_shard_step_via_stdout_field),
         ("shard step: legacy .output fallback", test_shard_step_legacy_output_field_empty_gives_fallback),
+        ("merge call: exit 0 fires", test_merge_call_clean_exit),
+        ("merge call: exit 1 + marker fires (worktree case)", test_merge_call_worktree_nonzero_with_marker),
+        ("merge call: exit 1 no marker -> no-op", test_merge_call_failed_no_marker),
+        ("merge call: exit 0 trumps no marker", test_merge_call_exit_zero_trumps_no_marker),
     ]
     failed = 0
     for name, fn in tests:


### PR DESCRIPTION
## Problem

`pr-merge-reminder.py` had a global early-exit guard:

```python
exit_code = data.get("tool_response", {}).get("exitCode", 0)
if exit_code != 0:
    sys.exit(0)
```

When `gh pr merge` runs from a worktree, the remote GitHub merge succeeds but the local checkout cleanup fails with `fatal: 'main' is already checked out at ...`. This exits non-zero, and the global guard silently dropped the event — the journal-update reminder never fired.

## Fix

Applies the same pattern as `post-merge-tile-checkpoint.py` (ADR-060, PR #416):

- Removed the global `exit_code != 0` bail
- Added per-command guards after command detection:
  - `gh pr merge`: `exit_code == 0 or output_has_merge_marker(output)` — imports `output_has_merge_marker` from `_hookio`
  - `gh pr create` / `git push`: strict `exit_code == 0` (unchanged semantics)
- Extracted `_is_successful_merge_call(exit_code, output)` as a named pure predicate for testability

## Testing

**Hook-script syntax check:**
```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/pr-merge-reminder.py claude/scripts/tests/test_pr_merge_reminder.py
```
→ `Syntax OK`

**pr-merge-reminder test suite** (4 new cases covering `_is_successful_merge_call`, 16 existing cases unchanged):
```
py -3 claude/scripts/tests/test_pr_merge_reminder.py
```
→ `Tests: 20 passed, 0 skipped, 0 failed`

## ADR-warrant check

No new ADR needed. This is a bug fix extending the pattern already established in ADR-060 (`output_has_merge_marker` for worktree-merge detection). Rationale is recoverable from ADR-060 and issue #275.

## Suppression / test-integrity greps

No suppressions, skip markers, deleted tests, or lowered thresholds.

Closes #419