### PR TITLE
[docs] Document GitHub Actions silence when PR has merge conflict

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -105,6 +105,22 @@ Every project CLAUDE.md **must** also include a `## Observability` section descr
 - **PR branch state comes from the remote, not the local worktree.** Before judging whether a PR addressed findings or is mergeable: `git fetch origin <headRefName>`, then read via `git show origin/<headRefName>:<path>` — never the local tree, which may be stale or on another branch ([ADR-004](../docs/adr/004-pr-review-reads-from-remote.md)).
 - **Runbooks** for merging a PR from a worktree, separate clones for independent parallel work, deleting a remote branch in web sessions ([ADR-035](../docs/adr/035-git-push-delete-web-session-constraint.md)), and one-time `core.hooksPath` setup are in [`docs/REFERENCE.md` → Git Workflow Runbooks](../docs/REFERENCE.md#git-workflow-runbooks).
 
+### CI not firing — merge conflict silences GitHub Actions
+
+**Pattern:** A PR in `CONFLICTING` (merge conflict) state causes GitHub Actions `pull_request` events to never fire. GitHub cannot create the virtual merge commit at `refs/pull/N/merge`, so the event is silently dropped — no checks are queued, no runs appear.
+
+**Symptom:** `gh pr checks` returns "no checks reported" and `gh run list --branch <branch-name>` shows only stale runs from before the conflict.
+
+**Diagnosis:**
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus
+# mergeable: "CONFLICTING" — direct conflict indicator; mergeStateStatus will also be "DIRTY"
+```
+
+**Fix:** Rebase (or squash-rebase) the branch onto `origin/main` and force-push. Once the conflict is resolved, GitHub recreates the merge ref and CI fires normally on the next push.
+
+Motivating incident: [lifting-logbook PR #604](https://github.com/brownm09/lifting-logbook/pull/604).
+
 ---
 
 ## Dev-Env & Project Boards


### PR DESCRIPTION
## Summary

Adds a troubleshooting note to `## Git Workflow` in `claude/CLAUDE.md` documenting the GitHub Actions silence pattern discovered in lifting-logbook.

The pattern: a PR in `CONFLICTING` (merge conflict) state causes `pull_request` events to silently never fire — GitHub cannot create the virtual merge commit at `refs/pull/N/merge`, so no checks are queued. The symptom looks like a CI misconfiguration, not a merge conflict, which wastes debugging time.

The equivalent note was already added to lifting-logbook's project CLAUDE.md in [lifting-logbook PR #610](https://github.com/brownm09/lifting-logbook/pull/610). This PR promotes it to the global `claude/CLAUDE.md` so it applies across all projects.

Closes #421

## Changes

- `claude/CLAUDE.md` — new `### CI not firing — merge conflict silences GitHub Actions` subsection at the end of `## Git Workflow`, covering: pattern, symptom, `gh pr view --json mergeable,mergeStateStatus` diagnosis command, rebase fix, and motivating incident link

## Testing

Docs-only change. Ran all applicable dev-env verification steps:

1. **Hook-script syntax check** — `py -3 -c "import ast,sys; ..."` → all scripts pass
2. **`pyw -3` stdio verification** — N/A (no hook script changes)
3. **Pre-push hook self-test** — N/A (no hook changes)
4. **Docs-only guard** — `grep -n 'date -u' claude/CLAUDE.md` → no matches (passes)
5. **Script path-hygiene lint** — N/A (no shell script changes)
6. **`get-project-item.sh` smoke test** — N/A (no script changes)
7. **shellcheck gate** — N/A (no shell script changes)

Pre-PR greps:
- Suppression grep: clean (no hits)
- Test-integrity grep: clean (no hits)

Tests: N/A — docs-only change; no automated test suite to run.

## ADR warrant check

Change touches `claude/CLAUDE.md` but adds only a documentation/troubleshooting note (not a new rule or convention). Scanned `docs/adr/INDEX.md` for tags matching `ci-silence`, `merge-conflict`, `CONFLICTING`, `pull_request event`, `Actions silent` — no matches. ADR not warranted.

## Review findings disposition

*(to be filled after /review)*

## Suppression policy

No suppressions added.

## Test integrity

No test changes.