### PR TITLE
docs(CLAUDE.md): distinguish utility scripts from hook scripts in Documentation Maintenance table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,8 @@ When a PR modifies any of the paths below, update the listed reference docs **in
 | Change | Required updates |
 |---|---|
 | Add / remove / rename a skill in `claude/skills/` | Skills table in `README.md` + `docs/REFERENCE.md` Skills section |
-| Add / remove / rename a script in `claude/scripts/` or `claude/hooks/` | Hooks table in `README.md` + `docs/REFERENCE.md` Hooks section |
+| Add / remove / rename an event-driven hook script in `claude/hooks/` (or a script in `claude/scripts/` that fires on a Claude Code hook event) | Hooks table in `README.md` + `docs/REFERENCE.md` Hooks section |
+| Add / remove / rename a utility/on-demand script in `claude/scripts/` (no hook event — invoked manually or from a skill) | Utilities table (On-demand scripts) in `docs/REFERENCE.md` |
 | Add / remove / rename a routine in `claude/routines/` | Routines table in `README.md` + `docs/REFERENCE.md` Routines section |
 | Change `hook-config.json` schema (new field, removed field, type change) | Configuration subsection in `docs/REFERENCE.md` |
 | Change a skill's invocation syntax or options | Skill entry in `docs/REFERENCE.md` |


### PR DESCRIPTION
## Summary

- Splits the single "Add / remove / rename a script" row in the Documentation Maintenance table into two rows
- **Hook scripts row** now explicitly covers event-driven scripts in `claude/hooks/` (and `claude/scripts/` entries that fire on a hook event) → Hooks table in README.md + REFERENCE.md Hooks section
- **Utility scripts row** (new) covers on-demand/manual scripts with no hook event → Utilities table (On-demand scripts) in REFERENCE.md only

The impetus was `validate-manifest.py` (merged in #427), a utility invoked from `/journal-compose` with no hook event. The old catch-all rule would have directed it to the Hooks table, which is wrong.

Closes #428

## Testing

Docs-only change — ran:

1. Docs-only guard: `grep -n 'date -u' CLAUDE.md` — one match at line 47, inside the Testing section instruction text (not a stub filename or branch name description). ✅
2. Hook-script syntax check: `py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py` — `SYNTAX OK` ✅

Tests: N/A — docs-only change; no scripts added or modified.

## Suppression / test-integrity checks

No suppressions or test integrity violations introduced. Grep output clean.

## Risk dimensions

- **Testing** — docs-only guard + syntax check both pass (no script changed)
- **Observability** — N/A — no runtime
- **Security** — N/A — docs change
- **Resilience** — N/A — docs change
- **Performance** — N/A — docs change
- **Data integrity** — N/A — docs change

## ADR warrant

Clarifying an existing workflow rule (not adding a new architectural decision). No new ADR warranted.