### PR TITLE
[fix] Worktree prune/reclaim safety (#350, #383, #399, #400)

### DIFF
--- a/claude/scripts/_worktree_topology.py
+++ b/claude/scripts/_worktree_topology.py
@@ -36,8 +36,8 @@ def parse_worktree_porcelain(text: str) -> "list[dict]":
     """Parse ``git worktree list --porcelain`` into ``[{path, branch}, ...]``.
 
     ``branch`` is the short name, ``"<detached>"`` for a detached HEAD, or ``""`` when
-    unspecified. Used by ``dev-env-sync.py`` and ``prune-merged-worktrees.py``;
-    ``reclaim-worktree-disk.py`` keeps an equivalent local copy (not in this fix's scope).
+    unspecified. Used by ``dev-env-sync.py``, ``prune-merged-worktrees.py``, and
+    ``reclaim-worktree-disk.py``.
     """
     worktrees: "list[dict]" = []
     current: "dict | None" = None

--- a/claude/scripts/prune-merged-worktrees.py
+++ b/claude/scripts/prune-merged-worktrees.py
@@ -41,7 +41,7 @@ import sys
 from pathlib import Path
 
 from _worktree_liveness import parse_liveness_window_seconds, worktree_session_is_live
-from _worktree_topology import park_branch_for, parse_worktree_porcelain
+from _worktree_topology import main_squatter, park_branch_for, parse_worktree_porcelain
 
 
 # Default: the repo that owns this script (dev-env). Override with --repo-path.
@@ -80,8 +80,8 @@ def _liveness_window_seconds_from_args() -> int:
         sys.exit(str(exc))
 
 
-def run(args: list[str], cwd: str, check: bool = False) -> subprocess.CompletedProcess:
-    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=30, check=check)
+def run(args: list[str], cwd: str, check: bool = False, timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=timeout, check=check)
 
 
 def find_git_repos(scan_dir: str) -> list[str]:
@@ -164,6 +164,14 @@ def prune_one(repo: str, dry_run: bool, liveness_window_seconds: int) -> tuple[i
     primary = primary_worktree_path(worktrees)
     cwd = str(Path(os.getcwd()).resolve())
 
+    # Identify the squatter (if any) using the topology helper — handles bare/detached
+    # canonicals that legitimately yield a secondary worktree on main (dev-env#399, ADR-058).
+    # A bare/detached primary can't hold a working-tree checkout of main itself, so a
+    # secondary worktree on main there is the real home of main and must NOT be parked.
+    # main_squatter() returns None in that case; the naive `branch == "main"` check did not.
+    squatter = main_squatter(worktrees)
+    squatter_path = str(Path(squatter["path"]).resolve()) if squatter else None
+
     pruned: list[str] = []
     skipped: list[tuple[str, str]] = []
 
@@ -179,7 +187,7 @@ def prune_one(repo: str, dry_run: bool, liveness_window_seconds: int) -> tuple[i
         # Skip a worktree with a live Claude session (recent transcript activity). The
         # cwd guard above only covers THIS process; an out-of-process routine cannot see
         # another worktree's active session except via its transcript mtime — removing a
-        # live worktree severs the session mid-task (dev-env#384, ADR-051). Additive: this
+        # live worktree severs the session mid-task (dev-env#383, ADR-051). Additive: this
         # only ever adds a skip, never removes more than the merged/clean checks below.
         if worktree_session_is_live(path, window_seconds=liveness_window_seconds):
             skipped.append((path, "active Claude session (recent transcript activity)"))
@@ -192,7 +200,7 @@ def prune_one(repo: str, dry_run: bool, liveness_window_seconds: int) -> tuple[i
         # worktree is removed on a later run via the normal merged path once idle+clean
         # (dev-env#396, ADR-058). The ADR-051 liveness guard above already spared a live
         # squatter, so parking only ever moves an idle one.
-        if branch == "main":
+        if path == squatter_path:
             park = park_branch_for(path)
             if dry_run:
                 pruned.append(path)
@@ -223,7 +231,15 @@ def prune_one(repo: str, dry_run: bool, liveness_window_seconds: int) -> tuple[i
             print(f"  [dry-run] would remove: {path} ({branch})")
             continue
 
-        r = run(["git", "worktree", "remove", path], cwd=repo)
+        # Use a generous timeout: git worktree remove runs an internal untracked-file scan
+        # that is slow when node_modules is present. With timeout=30 the scan aborts the
+        # entire run (dev-env#350); 300s lets even a 1 GB worktree complete. TimeoutExpired
+        # is caught so one slow removal skips that worktree and continues the scan.
+        try:
+            r = run(["git", "worktree", "remove", path], cwd=repo, timeout=300)
+        except subprocess.TimeoutExpired:
+            skipped.append((path, "git worktree remove timed out — worktree may be large; retry manually"))
+            continue
         if r.returncode != 0:
             skipped.append((path, f"worktree remove failed: {r.stderr.strip()}"))
             continue

--- a/claude/scripts/reclaim-worktree-disk.py
+++ b/claude/scripts/reclaim-worktree-disk.py
@@ -55,6 +55,7 @@ import sys
 from pathlib import Path
 
 from _worktree_liveness import parse_liveness_window_seconds, worktree_session_is_live
+from _worktree_topology import parse_worktree_porcelain
 
 
 # Default: the repo that owns this script (dev-env). Override with --repo-path.
@@ -116,8 +117,8 @@ def _liveness_window_seconds_from_args() -> int:
         sys.exit(str(exc))
 
 
-def run(args: list[str], cwd: str) -> subprocess.CompletedProcess:
-    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=30)
+def run(args: list[str], cwd: str, timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=timeout)
 
 
 def find_git_repos(scan_dir: str) -> list[str]:
@@ -146,24 +147,6 @@ def detect_gh_repo(repo: str) -> str:
     if m:
         return m.group(1)
     raise RuntimeError(f"Cannot parse GitHub repo from remote URL: {url!r}")
-
-
-def parse_worktrees(output: str) -> list[dict]:
-    worktrees: list[dict] = []
-    current: dict | None = None
-    for line in output.splitlines():
-        if line.startswith("worktree "):
-            if current is not None:
-                worktrees.append(current)
-            current = {"path": line[len("worktree "):].strip(), "branch": ""}
-        elif line.startswith("branch ") and current is not None:
-            ref = line[len("branch "):].strip()
-            current["branch"] = ref.removeprefix("refs/heads/")
-        elif line == "detached" and current is not None:
-            current["branch"] = "<detached>"
-    if current is not None:
-        worktrees.append(current)
-    return worktrees
 
 
 def is_merged(branch: str, gh_repo: str, repo: str) -> bool:
@@ -318,7 +301,7 @@ def reclaim_one(repo: str, dry_run: bool, protect_cwd: str, liveness_window_seco
         print(f"  ERROR: git worktree list failed: {result.stderr}", file=sys.stderr)
         return 0
 
-    worktrees = parse_worktrees(result.stdout)
+    worktrees = parse_worktree_porcelain(result.stdout)
     primary = primary_worktree_path(worktrees)
 
     total = 0
@@ -333,7 +316,7 @@ def reclaim_one(repo: str, dry_run: bool, protect_cwd: str, liveness_window_seco
             continue
         # Skip a worktree with a live Claude session (recent transcript activity).
         # --protect-cwd only shields THIS session; stripping node_modules out from under a
-        # build/dev-server running in *another* worktree breaks it (dev-env#384, ADR-051).
+        # build/dev-server running in *another* worktree breaks it (dev-env#383, ADR-051).
         # Additive: only ever adds a skip, never reclaims more than the checks below.
         if worktree_session_is_live(path, window_seconds=liveness_window_seconds):
             skipped.append((path, "active Claude session (recent transcript activity)"))

--- a/claude/scripts/tests/test_prune_merged_worktrees.py
+++ b/claude/scripts/tests/test_prune_merged_worktrees.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Unit tests for prune-merged-worktrees.py.
+
+Covers the TimeoutExpired recovery introduced for dev-env#350:
+  prune_one() must skip a worktree when `git worktree remove` times out and
+  continue the loop — the exception must NOT propagate and abort the scan.
+
+Pure-helper tests follow the pattern of test_reclaim_worktree_disk.py and
+test_worktree_topology.py. The TimeoutExpired case is the exception: it lives
+inside the integration loop of prune_one(), which shells out to git/gh. It IS
+unit-testable here via subprocess.run mocking (unlike the merge-detection and
+worktree-list steps, which are exercised end-to-end by --dry-run in the PR).
+
+Usage:
+    py -3 claude/scripts/tests/test_prune_merged_worktrees.py
+
+Exit 0 = all pass.
+"""
+import importlib.util
+import subprocess
+import sys
+import types
+import unittest.mock
+from pathlib import Path
+
+# tests/ -> scripts/ -> claude/ -> repo root
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+_MODULE_PATH = SCRIPTS_DIR / "prune-merged-worktrees.py"
+_spec = importlib.util.spec_from_file_location("prune_merged_worktrees", _MODULE_PATH)
+prune = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prune)
+
+
+# Fake worktree porcelain: one primary on main, one merged claude/* branch.
+_PORCELAIN = (
+    "worktree /FAKE_PRIMARY_PRUNE_9a7\n"
+    "HEAD abc123\n"
+    "branch refs/heads/main\n"
+    "\n"
+    "worktree /FAKE_WORKTREE_PRUNE_9a7\n"
+    "HEAD 789abc\n"
+    "branch refs/heads/claude/some-feature\n"
+    "\n"
+)
+
+
+def _ok(stdout=""):
+    return types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+
+def _dispatch(args, **_kwargs):
+    """Route subprocess.run calls to canned responses; raise TimeoutExpired for worktree remove."""
+    if args[1:2] == ["remote"]:              # git remote get-url origin
+        return _ok("git@github.com:brownm09/dev-env.git\n")
+    if args[1:3] == ["fetch", "origin"]:     # git fetch
+        return _ok()
+    if args[1:3] == ["worktree", "list"]:    # git worktree list --porcelain
+        return _ok(_PORCELAIN)
+    if args[1:3] == ["status", "--porcelain"]:  # is_dirty → not dirty
+        return _ok("")
+    if args[1:3] == ["merge-base"]:          # is_merged → merged (returncode 0)
+        return _ok()
+    if args[1:3] == ["worktree", "remove"]:  # the slow operation → timeout
+        raise subprocess.TimeoutExpired(cmd=args, timeout=300)
+    return _ok()
+
+
+def test_timeout_skips_worktree_and_continues() -> str:
+    """git worktree remove timing out must skip that worktree and continue — not raise."""
+    with unittest.mock.patch("subprocess.run", side_effect=_dispatch):
+        with unittest.mock.patch.object(prune, "worktree_session_is_live", return_value=False):
+            with unittest.mock.patch.object(prune, "is_dirty", return_value=False):
+                pruned_count, skipped_count, fetch_failed = prune.prune_one(
+                    repo="/FAKE_REPO",
+                    dry_run=False,
+                    liveness_window_seconds=86400,
+                )
+
+    # The timed-out worktree must appear in skipped, not pruned.
+    assert pruned_count == 0, f"expected 0 pruned, got {pruned_count}"
+    # skipped = [primary (always), timed-out secondary]
+    assert skipped_count == 2, f"expected 2 skipped (primary + timed-out), got {skipped_count}"
+    assert not fetch_failed, "fetch should not be marked failed"
+    return "TimeoutExpired caught: pruned=0, skipped=2, fetch_failed=False — loop continued"
+
+
+def main() -> int:
+    tests = [
+        ("git worktree remove timeout: skip-and-continue, not abort", test_timeout_skips_worktree_and_continues),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            detail = fn()
+            print(f"PASS: {name}")
+            print(f"      {detail}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL: {name}")
+            for line in str(e).splitlines():
+                print(f"      {line}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR: {name}: {type(e).__name__}: {e}")
+    print()
+    print(f"Tests: {len(tests) - failed} passed, 0 skipped, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Four open issues that made worktree pruning unsafe — resolved together since they touch the same two scripts.

- **#383 (liveness guard)** — Already fixed in PR #384; this PR closes the issue.
- **#350 (timeout)** — `git worktree remove` runs an internal untracked-file scan that was slow with node_modules, firing the 30 s timeout and **aborting the entire scan**. Now uses `timeout=300` for that operation and catches `subprocess.TimeoutExpired` to skip-and-continue rather than crash.
- **#399 (bare/detached topology)** — The naive `branch == "main"` check in `prune_one()` incorrectly parked a secondary worktree that legitimately holds `main` when the primary is bare or detached. Now pre-computes the squatter via `main_squatter()` from `_worktree_topology.py` (which already handles this topology correctly) and compares by resolved path.
- **#400 (parser consolidation)** — `reclaim-worktree-disk.py` had a local `parse_worktrees()` function byte-identical to `_worktree_topology.parse_worktree_porcelain()`. Removed the duplicate; reclaim now imports the shared function.

## Files changed

- `claude/scripts/prune-merged-worktrees.py` — imports `main_squatter`, adds `timeout` param to `run()`, uses `main_squatter()` for squatter detection, applies 300 s timeout + `TimeoutExpired` catch for `git worktree remove`
- `claude/scripts/reclaim-worktree-disk.py` — removes local `parse_worktrees()`, imports `parse_worktree_porcelain` from `_worktree_topology`, adds `timeout` param to `run()`

## Testing

Tests: 35 passed, 0 skipped, 0 failed (updated in 8fbb26d)

```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
# -> SYNTAX OK

py -3 claude/scripts/tests/test_worktree_liveness.py
# -> Tests: 13 passed, 0 skipped, 0 failed

py -3 claude/scripts/tests/test_reclaim_worktree_disk.py
# -> Tests: 6 passed, 0 skipped, 0 failed

py -3 claude/scripts/tests/test_worktree_topology.py
# -> Tests: 14 passed, 0 skipped, 0 failed

py -3 claude/scripts/tests/test_prune_merged_worktrees.py
# -> Tests: 1 passed, 0 skipped, 0 failed
```

The bare/detached-canonical squatter guard is exercised by `test_main_squatter_bare_or_detached_canonical` in `test_worktree_topology.py` (already passing). The `TimeoutExpired` catch is now directly unit-tested in `test_prune_merged_worktrees.py` (new in 8fbb26d).

## Suppression policy check

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
```
No matches.

## Test integrity check

```
git diff origin/main -- . | grep -E '(it\.skip|xit\(|xdescribe\(|test\.skip|describe\.skip|\.todo\(|pending\(|passWithNoTests|--bail|testPathIgnorePatterns)'
```
No matches.

## Review findings disposition

- **[documentation] Stale `parse_worktree_porcelain` docstring** — Fixed in 8fbb26d. Updated to reflect that `reclaim-worktree-disk.py` now imports the shared function directly.
- **[maintainability] No regression test for `TimeoutExpired` catch** — Fixed in 8fbb26d. Added `claude/scripts/tests/test_prune_merged_worktrees.py` seeding the test file with the TimeoutExpired skip-and-continue case.

## Closes

Closes #350
Closes #383
Closes #399
Closes #400
