### PR TITLE
[docs] Add test_prune_merged_worktrees.py to ## Testing section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,8 +307,8 @@ before PR" rule in [`claude/CLAUDE.md`](claude/CLAUDE.md) defers to this section
     ```
 
 26. **prune-merged-worktrees test** — required when changing `claude/scripts/prune-merged-worktrees.py`.
-    Exercises `prune_one()` via subprocess mocking (the one exception to the pure-helper convention):
-    pins that a `subprocess.TimeoutExpired` from a slow `git worktree remove` is caught, the timed-out
+    Exercises `prune_one()` via subprocess mocking (subprocess.run mocking, unlike the other offline
+    pure-helper tests): pins that a `subprocess.TimeoutExpired` from a slow `git worktree remove` is caught, the timed-out
     worktree is counted as skipped, and the prune loop continues rather than propagating the exception
     and aborting the scan ([dev-env#350](https://github.com/brownm09/dev-env/issues/350)). The
     merge-detection and worktree-list steps are not covered here — they are exercised end-to-end by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,18 @@ before PR" rule in [`claude/CLAUDE.md`](claude/CLAUDE.md) defers to this section
     py -3 claude/scripts/tests/test_validate_manifest.py
     ```
 
+26. **prune-merged-worktrees test** — required when changing `claude/scripts/prune-merged-worktrees.py`.
+    Exercises `prune_one()` via subprocess mocking (the one exception to the pure-helper convention):
+    pins that a `subprocess.TimeoutExpired` from a slow `git worktree remove` is caught, the timed-out
+    worktree is counted as skipped, and the prune loop continues rather than propagating the exception
+    and aborting the scan ([dev-env#350](https://github.com/brownm09/dev-env/issues/350)). The
+    merge-detection and worktree-list steps are not covered here — they are exercised end-to-end by
+    `--dry-run` in the PR.
+
+    ```bash
+    py -3 claude/scripts/tests/test_prune_merged_worktrees.py
+    ```
+
 ## Observability
 
 dev-env has **no long-running runtime to instrument** — it is a configuration repo whose


### PR DESCRIPTION
Adds item 26 to the \`## Testing\` section of \`CLAUDE.md\` documenting \`test_prune_merged_worktrees.py\`, which was introduced in PR #430 but omitted from the canonical test list.

## Summary

- \`CLAUDE.md\` \`## Testing\` section now lists item 26 — the prune-merged-worktrees test — with description and invocation command
- Describes what is covered (TimeoutExpired catch-and-continue in \`prune_one()\`) and what is not (merge-detection and worktree-list steps, exercised end-to-end by \`--dry-run\`)

## Testing

This is a docs-only change. Ran the docs-only guard (item 4):

\`\`\`
grep -n 'date -u' CLAUDE.md
\`\`\`

No matches — no operational-artifact context affected.

Suppression grep: clean (no new suppressions).
Test integrity grep: clean (no skip markers, no deleted tests, no threshold changes).

Tests: N/A — docs only

## Acceptance Criteria

- [x] \`## Testing\` section includes item 26 for \`test_prune_merged_worktrees.py\`
- [x] Description names script under test, what is covered (TimeoutExpired), and what is NOT covered (merge-detection, worktree-list)

## Review findings disposition

- **[maintainability]** `CLAUDE.md:309` — "the one exception to the pure-helper convention": fixed in f71bd27 — reworded to "(subprocess.run mocking, unlike the other offline pure-helper tests)" to scope the claim to this test's context rather than asserting a suite-wide singleton.

Closes #431