### PR TITLE
[feat] Add always-plan rule to global CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -318,6 +318,8 @@ Default to Sonnet when uncertain. Never use Opus for tasks a Haiku prompt handle
 
 **Mechanical operations:** If a task is fully scriptable with known inputs, write the script rather than running an interactive session. Candidate operations: stale PR remediation, branch cleanup, rebase-and-merge sequences. Use `~/.claude/scripts/merge-stale-pr.sh` for engineering-journal stale draft PRs.
 
+**Always plan first — permission modes don't bypass it:** Plan mode (Shift+Tab cycles modes) is the session default for every substantive task. Bypass and auto modes reduce permission prompts only; they do not relax the plan-first discipline.
+
 **Plan-then-optimize before acting:** Any task involving an Agent spawn, a skill invocation, reads across more than one file, or a switch to a new primary objective within the same session (e.g., moving from a `/review` or other skill output to addressing findings, or from one issue to another) requires this protocol. State a numbered plan first, then apply three explicit revision passes before taking any action.
 
 **Pass 1 — Token efficiency:** check:

--- a/docs/adr/063-always-plan-rule-permission-mode-does-not-bypass-planning.md
+++ b/docs/adr/063-always-plan-rule-permission-mode-does-not-bypass-planning.md
@@ -68,4 +68,6 @@ complexity for what is fundamentally a behavioral clarification.
 ## References
 
 - [`claude/CLAUDE.md` → Context & Token Efficiency](../claude/CLAUDE.md#context--token-efficiency)
+- [ADR-025](025-default-plan-mode.md) — established plan mode as the settings default
+- [ADR-008](008-plan-then-optimize-forcing-function.md) — Plan-Then-Optimize protocol this rule contextualizes
 - [dev-env issue #409](https://github.com/brownm09/dev-env/issues/409) — motivating issue

--- a/docs/adr/063-always-plan-rule-permission-mode-does-not-bypass-planning.md
+++ b/docs/adr/063-always-plan-rule-permission-mode-does-not-bypass-planning.md
@@ -1,0 +1,71 @@
+# ADR-063 — Always-Plan Rule: Permission Mode Does Not Bypass Planning
+
+**Date:** 2026-06-30
+**Status:** Accepted
+**Tags:** workflow, planning, permission-mode, bypass, auto, claude-behavior, global-rule
+
+---
+
+## Context
+
+Claude Code has three permission modes (plan, bypass, auto), cycled with Shift+Tab. Plan mode
+requires explicit approval for each tool call; bypass and auto modes reduce or eliminate those
+prompts to enable faster, less-interrupted operation.
+
+The existing `Plan-then-optimize before acting` rule in `claude/CLAUDE.md` triggers on specific
+conditions: Agent spawns, skill invocations, multi-file reads, or a switch of primary objective.
+In bypass and auto modes, where Claude acts without per-call confirmation, users observed Claude
+skipping planning and acting immediately on substantive tasks — behavior inconsistent with what
+plan mode enforces but not explicitly prohibited by the existing rule.
+
+The distinction that was missing: permission modes govern **tool execution approval**, not the
+**plan-first discipline**. The two are orthogonal. A bypass-mode session still benefits from a
+stated plan before action — arguably more so, since there are no individual approval gates to
+catch scope drift mid-execution.
+
+---
+
+## Decision
+
+Add an explicit rule to the `## Context & Token Efficiency` section of the global
+`claude/CLAUDE.md`, placed before the `Plan-then-optimize before acting` paragraph:
+
+> **Always plan first — permission modes don't bypass it:** Plan mode (Shift+Tab cycles modes)
+> is the session default for every substantive task. Bypass and auto modes reduce permission
+> prompts only; they do not relax the plan-first discipline.
+
+This establishes plan mode as the conceptual default and makes clear that permission mode is a
+separate dimension from the plan-first requirement.
+
+---
+
+## Consequences
+
+**Positive:**
+- Eliminates the ambiguity that bypass/auto modes imply permission to skip planning.
+- Complements rather than duplicates the existing `Plan-then-optimize` protocol — the new rule
+  states *when* planning is required (always); the existing rule states *how* to plan.
+- Short and durable — two sentences, unlikely to need revision as modes evolve.
+
+**Negative / Trade-offs:**
+- Behavioral rule, not hook-enforced. Relies on Claude reading and following the instruction,
+  the same as all other `claude/CLAUDE.md` rules.
+
+---
+
+## Alternatives Considered
+
+**Extend the Plan-then-optimize trigger list to include "bypass/auto mode."** Rejected — the
+trigger list describes task characteristics, not session configuration; mixing the two would
+confuse the rule's logic and make the trigger conditions harder to reason about.
+
+**Add a hook that detects permission mode and forces plan mode.** Rejected — no reliable way to
+detect the current permission mode from a hook; implementing it would introduce significant
+complexity for what is fundamentally a behavioral clarification.
+
+---
+
+## References
+
+- [`claude/CLAUDE.md` → Context & Token Efficiency](../claude/CLAUDE.md#context--token-efficiency)
+- [dev-env issue #409](https://github.com/brownm09/dev-env/issues/409) — motivating issue

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -67,3 +67,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [060](060-post-merge-tile-checkpoint-hook.md) | Post-Merge Tile Checkpoint Hook | 2026-06-28 | Accepted | hooks, post-tool-use, tiles, spawn-task, post-merge, enforcement, ADR-046 |
 | [061](061-pre-merge-message-queue.md) | Pre-Merge User Message Queue | 2026-06-28 | Accepted | hooks, pre-tool-use, merge, workflow, bypass-mode, feedback, global-rule |
 | [062](062-journal-report-analysis-trigger.md) | Report / Analysis Generation as a Journal Update Trigger | 2026-06-29 | Accepted | journal, stubs, reports, update-trigger, workflow, global-rule |
+| [063](063-always-plan-rule-permission-mode-does-not-bypass-planning.md) | Always-Plan Rule: Permission Mode Does Not Bypass Planning | 2026-06-30 | Accepted | workflow, planning, permission-mode, bypass, auto, claude-behavior, global-rule |


### PR DESCRIPTION
## Summary

Adds a two-sentence rule to the `## Context & Token Efficiency` section of `claude/CLAUDE.md`, placed immediately before the existing `Plan-then-optimize before acting` paragraph:

> **Always plan first — permission modes don't bypass it:** Plan mode (Shift+Tab cycles modes) is the session default for every substantive task. Bypass and auto modes reduce permission prompts only; they do not relax the plan-first discipline.

Also files ADR-063 recording the rationale and updates `docs/adr/INDEX.md`.

## Motivation

The existing `Plan-then-optimize` rule triggers on specific task characteristics (Agent spawn, skill invocation, multi-file read, new objective) but did not address permission mode. In bypass and auto modes, Claude was acting immediately without stating a plan — the approval gates that normally prompt reflection were absent, making unplanned action more likely precisely when it is most consequential.

The fix: one declarative sentence that plan mode is the session default, and one that clarifies bypass/auto affect prompts, not the plan requirement. These two sentences complement the existing `Plan-then-optimize` protocol rather than duplicating it.

## ADR warrant

This qualifies under the warrant criteria: adds a workflow rule to the global `claude/CLAUDE.md`. ADR-063 filed at `docs/adr/063-always-plan-rule-permission-mode-does-not-bypass-planning.md`.

## Testing

Pure docs/config change — no hook scripts modified. Ran:

1. Hook-script syntax check: `py -3 -c "import ast,sys; [...]" claude/scripts/*.py` → **Syntax OK**
2. pyw stdio verification: `py -3 claude/scripts/tests/test_pyw_stdio.py` → **Tests: 6 passed, 0 skipped, 0 failed**

Tests: 6 passed, 0 skipped, 0 failed — outcome: pass.

## Suppression / test-integrity checks

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
```
No output — no suppressions introduced.

```
git diff origin/main -- . | grep -E '(it\.skip|xit\(|xdescribe\(|test\.skip|describe\.skip|\.todo\(|pending\(|passWithNoTests|--bail|testPathIgnorePatterns)'
```
No output — no test-integrity violations.

Closes #409

## Review findings disposition

- **[maintainability] ADR-063 missing cross-references** — fixed in 36e091d (added ADR-025 and ADR-008 links to `## References`)
