### PR TITLE
[fix] Checkout target draft branch before pull in journal 'Subsequent sessions'

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -486,7 +486,7 @@ operational artifacts (compose lock files, log file timestamps).
    *(include `sessions/<project>/open-prs/` only if this session opened or merged a PR — it stages the added/deleted shard)*
 
 **Subsequent sessions:**
-1. `git -C C:/Users/brown/Git/engineering-journal pull origin draft/YYYY-MM-DD`
+1. `git -C C:/Users/brown/Git/engineering-journal checkout draft/YYYY-MM-DD && git -C C:/Users/brown/Git/engineering-journal pull`
 2. Read the open-PR records (`sessions/<project>/open-prs/*.json` shards, plus any legacy `open-prs.jsonl`) if present — include their PR list as session context before starting work (the `reconcile-open-prs.py` hook also surfaces this at session start).
 3. Find the most recent stub and read only its `<!-- next-session-context -->` paragraph:
    ```bash


### PR DESCRIPTION
## Summary

Fixes a silent wrong-branch-pull bug in the Engineering Journal **Subsequent sessions** workflow. `git pull origin draft/YYYY-MM-DD` from a different local branch merges the named remote into whatever is currently checked out — not the target. This contaminated `draft/2026-06-29` with 26 06-30 stub/manifest files during a 2026-06-30 session.

The fix replaces step 1 with an explicit `checkout` followed by a bare `pull`:

```bash
# Before (broken):
git -C ... pull origin draft/YYYY-MM-DD

# After (correct):
git -C ... checkout draft/YYYY-MM-DD && git -C ... pull
```

## Testing

Documentation-only change (CLAUDE.md only). No runnable tests.

Tests: N/A — docs only

## Risk dimensions
- **Testing:** N/A — docs only
- **Observability:** N/A
- **Security:** N/A
- **Resilience:** New form fails fast if branch doesn't exist; old form silently contaminated wrong draft
- **Performance:** N/A
- **Data integrity:** Prevents wrong-day stub contamination

Closes #440