### PR TITLE
[feat] Add weekly-memory-audit routine (autonomous cross-project memory reconciliation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Autonomous scheduled agents in `claude/routines/`. No user interaction.
 | Nightly 8:00 UTC (3 AM CDT) | `nightly-research` | Researches pending topics from the queue and writes structured markdown notes to `research-notes/` |
 | Biweekly (every other Sun 9am local) | `biweekly-retro` | Synthesizes a retrospective (global readout + per-repo sections + tracked ratio) from the trailing 4 weeks of journal entries; opens a report PR in `engineering-journal` and files deduped action-item issues in the correct repo per finding (cross-cutting → dev-env) |
 | Daily 6am local | `reconcile-project-board` | Adds open dev-env issues missing from the **Dev Env** board (#3) and surfaces any still missing Impact/Why; backstop for issues filed in background/`spawn_task` sessions where the add-hook is inert ([ADR-068](docs/adr/068-reconcile-project-board-orphan-issues.md)) |
+| Weekly (Mon 9am local) | `weekly-memory-audit` | Sweeps every project's memory store for never-ported durables, stale notes, and drift; auto-files deduped *promote* issues (label `memory-audit`) in the correct repo; commits a cross-project reconciliation report to `engineering-journal`. Read-only on memory — never edits or deletes a memory file. |
 
 ## Adding new configs
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -18,9 +18,9 @@ Agent memory (`~/.claude/projects/.../memory/`) is a private cache, not the sour
 - **Never let a durable preference or workflow rule live only in memory.** Whenever you commit one to a `user`/`feedback`/`project` memory file, **pair it — in the same session — with a GitHub issue whose explicit job is to immortalize it into the instructions** (the appropriate `CLAUDE.md`, global or project, or project docs). Link that issue from **both** the memory body and its `MEMORY.md` pointer so the two never drift apart.
 - **Filing the issue is the floor, not the finish.** The issue exists to drive the rule *into* the instructions — not to substitute for doing so. Prefer to make the instruction edit immediately and close the issue in the same session; a deferred issue is the backstop that keeps the rule from being forgotten, not a place to park it indefinitely.
 - **Transient context is exempt.** Session-local or fast-changing notes (open-PR lists, in-flight working state) may live in memory and expire there — no issue required. This rule governs only durable, cross-session rules: the things a human collaborator would need to know to work the way the user expects.
-- A non-blocking write-time hook (`memory-write-advisory.py`) reminds you when a memory file is written without such a link, and the `/memory-audit` skill reconciles memory against the instructions on demand.
+- A non-blocking write-time hook (`memory-write-advisory.py`) reminds you when a memory file is written without such a link, the `/memory-audit` skill reconciles memory against the instructions on demand, and the `weekly-memory-audit` routine runs every Monday to sweep existing memory across all projects for never-ported durables (auto-filing deduped *promote* issues in the correct repo) and report stale/drift findings without modifying any memory file.
 
-See [ADR-038](../docs/adr/038-durable-preferences-documented-in-repo.md), [ADR-048](../docs/adr/048-memory-immortalization-issue-pairing.md).
+See [ADR-038](../docs/adr/038-durable-preferences-documented-in-repo.md), [ADR-048](../docs/adr/048-memory-immortalization-issue-pairing.md), [ADR-069](../docs/adr/069-weekly-memory-audit-routine.md).
 
 ---
 

--- a/claude/routines/weekly-memory-audit/SKILL.md
+++ b/claude/routines/weekly-memory-audit/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: weekly-memory-audit
+description: Every Monday, reconcile agent memory against the repos across all projects (read-only on memory) — auto-file deduped promote issues for never-ported durables in the correct repo, report stale/drift findings, and commit a reconciliation report to engineering-journal.
+schedule: "0 9 * * 1"
+# Monday 09:00 LOCAL time (the scheduled-tasks scheduler evaluates cron in local time, not UTC).
+# Weekly, every week — NO parity gate (unlike biweekly-retro, which gates to even ISO weeks).
+---
+
+Reconcile agent memory against the version-controlled instructions across every project. Run
+**fully autonomously** — never call `AskUserQuestion`, never wait for input, never prompt for
+approval.
+
+**Objective:** Every Monday, walk every project's memory store, classify each entry against the
+repos, and act in a deliberately **safe** shape: **read-only on memory — never edit or delete a
+memory file**. Auto-file a deduped *promote* issue for each never-ported durable (a durable rule
+with no current instruction home and no open tracking issue), routed to the **correct repo**.
+Report stale/drift findings without auto-actioning them (they need human judgment). Produce a
+committed cross-project reconciliation report in the engineering-journal repo, and report
+completion via push notification.
+
+This is the audit-time, cross-project, **non-destructive** complement to the single-project,
+interactive `/memory-audit` skill (which can delete, human-in-the-loop). It extends the
+memory-immortalization family — write-time porting (ADR-038), the write-time advisory hook
+(ADR-048) — with a recurring audit-time backstop. The weekly cadence and read-only-on-memory shape
+were chosen by the user on 2026-06-30 (see dev-env#439, child of dev-env#363).
+
+---
+
+## Step 0 — Sync the engineering-journal working tree
+
+Read `~/.claude/skills/sync-routine-worktree/SKILL.md` and execute its Behavior section end-to-end
+with these parameters:
+
+- `REPO` = `C:/Users/brown/Git/engineering-journal`
+- `VERIFY_FILE` = `sessions/meta/README.md`
+- `PREFIX` = `weekly-memory-audit`
+
+On **SUCCESS**, continue. On **ABORT**, exit cleanly — the push notification has already been sent;
+do not commit, do not open a PR, do not create an issue.
+
+The other repos (lifting-logbook, career-playbook, dev-env, …) are **not** synced here — their
+instruction homes are verified by reading `origin/main` directly (`git fetch` + `git show
+origin/main:<path>` in Step 2), so no working-tree sync is needed for them. The memory stores under
+`~/.claude/projects/.../memory/` are machine-local live state, not a repo — nothing to sync.
+
+---
+
+## Step 1 — Enumerate the memory stores in scope
+
+```bash
+RUN_DATE=$(date +%Y-%m-%d)
+SCRATCH="C:/Users/brown/.claude/scratch"
+PROJECTS="C:/Users/brown/.claude/projects"
+mkdir -p "$SCRATCH"
+DIRS="$SCRATCH/memaudit_dirs_${RUN_DATE}.txt"
+: > "$DIRS"
+
+for memdir in "$PROJECTS"/*/memory/; do
+  [ -d "$memdir" ] || continue
+  projdir=$(basename "$(dirname "$memdir")")
+  # EXCLUDE Claude-managed worktree project dirs — they hold subagent JSON, not durable memory.
+  case "$projdir" in *--claude-worktrees-*) continue ;; esac
+  # Require at least one memory entry (any .md, including MEMORY.md).
+  shopt -s nullglob; mds=("$memdir"*.md); shopt -u nullglob
+  [ ${#mds[@]} -gt 0 ] || continue
+  echo "${projdir}|${memdir}" >> "$DIRS"
+done
+```
+
+If `$DIRS` is empty, send a push notification — `weekly-memory-audit: no memory stores found —
+nothing to audit` — and exit cleanly with status 0.
+
+**Decode each project dir to its repo + GitHub slug** (used for instruction-home verification and
+issue routing). The project dir encodes the working-tree path with separators replaced by `-`:
+
+```bash
+# projdir e.g. "C--Users-brown-Git-lifting-logbook"
+base="${projdir#C--Users-brown-Git-}"     # -> "lifting-logbook"
+wt="C:/Users/brown/Git/${base}"           # working tree (may not exist)
+slug=""                                    # GitHub "owner/repo", empty if no remote
+if [ -d "$wt" ]; then
+  url=$(git -C "$wt" remote get-url origin 2>/dev/null || true)
+  if [ -n "$url" ]; then
+    slug=$(printf '%s' "$url" | sed -E 's#\.git$##; s#^git@[^:]+:##; s#^https?://[^/]+/##')
+  fi
+fi
+```
+
+Resolve the slug from the **actual git remote**, not the dir name — e.g. the `job-search` working
+tree may push to `brownm09/job-search-agent`. A project with no working tree or no remote routes its
+findings to **dev-env** (see Step 3).
+
+---
+
+## Step 2 — Classify each project's memory in parallel (read-only)
+
+For each project line in `$DIRS`, spawn **one background subagent** (`Agent` tool,
+`subagent_type: Explore`, `run_in_background: true`) in a **single message with all spawns together**
+(no synchronous preflight agent). `Explore` cannot Edit/Write, which structurally enforces the
+read-only-on-memory guarantee. Give each a self-contained prompt naming that project's exact
+`memory/` path and its decoded repo worktree + GitHub slug, and asking it to apply the read-only
+classification subset of the `/memory-audit` skill.
+
+For every `*.md` file in the memory dir **except `MEMORY.md`**, the subagent must:
+
+1. Parse the frontmatter: `name`, `description`, and the entry type (accept either a top-level
+   `type:` or a nested `metadata.type:` — both spellings exist). Read the body.
+2. Detect an **immortalization link** in the body using the same patterns as
+   `memory-write-advisory.py`: a GitHub ref `#\d+`, an `ADR-\d+` (case-insensitive), or the
+   substrings `CLAUDE.md` or `Documented in repo`.
+3. When the body **claims** an instruction home (a `CLAUDE.md`/docs path or "Documented in repo:
+   <path>"), verify it on the **current remote**, not the local worktree:
+   `git -C <repo-worktree> fetch origin --quiet` then `git show origin/main:<claimed-path>` — the
+   claim is real only if the path resolves on `origin/main`. (The worktree can be a commit behind;
+   verifying against `origin/main` avoids false "gap" flags.)
+4. Assign exactly one **disposition**:
+   - **remain** — durable (`user`/`feedback`/`project` encoding a cross-session rule) **and** a
+     verified, current instruction home exists. Keep as a recall cache.
+   - **promote** — durable, **no** immortalization link, **and** no verified instruction home: a
+     *never-ported durable*. This is the forbidden state ADR-038 targets. (If the entry has a link
+     to an **open** tracking issue but no instruction home yet, it is **tracked-pending** —
+     report-only, do **not** promote; the existing issue is its dedup.)
+   - **stale** — the body cites merged/closed/shipped work as still-pending, or is contradicted by
+     current code. Report-only.
+   - **drift** — the body names a file/function/flag that has moved or no longer exists.
+     Report-only.
+   - **transient** — session-local / fast-changing (open-PR lists, in-flight state). Not durable;
+     no action (ADR-048 exempts these).
+   - Also flag **index-drift**: the entry is missing from `MEMORY.md`, or its `MEMORY.md` line
+     disagrees with the file. Report-only.
+
+The subagent returns a structured findings list — one record per memory file with: file name, type,
+durable? (yes/no), instruction-home (path + verified yes/no, or "none"), disposition, a one-line
+rationale, and **for `promote` records additionally**: the rule text (verbatim or tight paraphrase),
+the suggested instruction home (which `CLAUDE.md`/doc it belongs in), and the entry's `name` slug.
+
+If a subagent fails or returns nothing for a project, **do not abort the whole run** — note the gap
+and continue with a partial report.
+
+---
+
+## Step 3 — Aggregate and route the promote findings
+
+Collect every subagent's findings. For each **promote** finding, determine the target repo:
+
+- **Project-specific durable** (a rule that governs only that project) → that project's own repo
+  (its resolved GitHub `slug`), when it has a remote with Issues enabled.
+- **Global / cross-cutting durable** (a workflow rule that applies across projects) → **dev-env**
+  (`brownm09/dev-env`).
+- A project with **no working tree / no remote**, and the **engineering-journal** project
+  (no issue tracker by convention) → **dev-env**.
+
+Build a project-qualified dedup slug for each promote finding: `memory-slug = <projdir>/<name>`
+(qualified by project dir so two projects' identically-named entries — and global rules from
+different projects, which all land in dev-env — never collide).
+
+---
+
+## Step 4 — File the deduped promote issues (one per never-ported durable)
+
+File **one issue per never-ported durable** — not one consolidated issue per repo. Per-rule issues
+match ADR-048's immortalization model (each durable gets its own issue that drives it into the
+instructions).
+
+**Dedup guard (mandatory — keeps the weekly cadence from re-filing the same gap).** For each target
+repo `R`, read its existing open `memory-audit` issues once, then skip any finding whose slug already
+appears (no `jq` — parse with `node -e`):
+
+```bash
+ISSUES="$SCRATCH/memaudit_issues_${R//\//_}.json"
+gh issue list --repo "brownm09/${R}" --label memory-audit --state open \
+  --json number,title,body > "$ISSUES" 2>/dev/null || echo '[]' > "$ISSUES"
+
+# returns DUP or NEW for a given slug
+node -e '
+  const fs=require("fs");
+  const issues=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));
+  const slug=process.argv[2];
+  const hit=issues.some(i=>((i.title||"")+"\n"+(i.body||"")).includes(slug));
+  console.log(hit?"DUP":"NEW");
+' "$ISSUES" "$slug"
+```
+
+For each remaining (NEW) finding, ensure the label exists then file the issue:
+
+```bash
+gh label create memory-audit --repo "brownm09/${R}" --color 5319e7 \
+  --description "Never-ported durable surfaced by the weekly-memory-audit routine" 2>/dev/null || true
+
+gh issue create --repo "brownm09/${R}" --label memory-audit \
+  --title "[memory-audit] Promote durable: ${NAME} (${PROJ})" \
+  --body "$(cat <<EOF
+A durable rule in agent memory has no current instruction home and no open tracking issue. The
+weekly-memory-audit routine surfaced it for promotion into the version-controlled instructions
+(per ADR-038 / ADR-048): memory is a private cache, not the source of truth.
+
+**Memory file:** \`${MEMORY_FILE}\`
+**Rule (from memory):**
+> ${RULE_TEXT}
+
+**Suggested instruction home:** ${SUGGESTED_HOME}
+
+**To resolve:** port the rule into the suggested instruction file, link this issue from both the
+memory body and its \`MEMORY.md\` pointer (ADR-048), then close.
+
+memory-slug: ${PROJ}/${NAME}
+
+_Filed automatically by the \`weekly-memory-audit\` routine (dev-env
+\`claude/routines/weekly-memory-audit/\`). Parents: dev-env#363, dev-env#439._
+EOF
+)"
+```
+
+Capture every filed issue URL, and keep a running count of **filed** vs **deduped** (skipped) per
+repo. If a repo has zero genuinely-new promote findings this run, file nothing for it.
+
+Stale, drift, index-drift, tracked-pending, and remain dispositions are **never** auto-actioned —
+they go to the report only (Step 5).
+
+---
+
+## Step 5 — Write and PR the reconciliation report
+
+1. Ensure the audit folder exists; create a one-time README if missing:
+
+```bash
+EJ="C:/Users/brown/Git/engineering-journal"
+AUDIT_DIR="$EJ/sessions/meta/memory-audit"
+mkdir -p "$AUDIT_DIR"
+if [ ! -f "$AUDIT_DIR/README.md" ]; then
+  cat > "$AUDIT_DIR/README.md" <<'EOF'
+# Cross-Project Memory→Repo Reconciliation Audits
+
+Auto-generated by the `weekly-memory-audit` routine (dev-env `claude/routines/weekly-memory-audit/`).
+Each `YYYY-MM-DD-audit.md` reconciles every project's agent memory against the version-controlled
+instructions. The routine is **read-only on memory** — it never edits or deletes a memory file
+(deletion stays human-in-the-loop via the `/memory-audit` skill). It auto-files deduped *promote*
+issues (label `memory-audit`) for never-ported durables, routed to the correct repo
+(project-specific → that repo; global/cross-cutting → dev-env); stale / drift / index-drift findings
+are reported here only. See ADR-069, ADR-038, ADR-048.
+EOF
+fi
+```
+
+2. Write the report to `${AUDIT_DIR}/${RUN_DATE}-audit.md`:
+   - A title + the run date + the projects scanned.
+   - A one-line summary: `<N> projects, <F> memory files; <G> never-ported durables → <I> issues
+     filed (<D> deduped); <S> stale/drift/index-drift findings (report-only)`.
+   - The full **cross-project reconciliation table**, grouped by project:
+
+     ```
+     | Project | Memory file | Type | Durable? | Instruction home (verified) | Drift | Disposition |
+     |---|---|---|---|---|---|---|
+     ```
+   - A **"Promote issues filed"** subsection — each new issue (repo#N + URL) and the deduped/skipped
+     slugs.
+   - A **"Stale / drift / index-drift (report-only)"** subsection — each finding with file, what is
+     stale/wrong, and the suggested human fix. These are *not* auto-actioned by design.
+
+3. Commit on a dedicated branch and open a PR to `main` (this repo squash-merges; do **not** commit
+   to `main` directly, and do **not** auto-merge — auto-merge is disabled by ADR-031, the user
+   reviews and merges):
+
+```bash
+cd "$EJ"
+git checkout -b "memory-audit/${RUN_DATE}" origin/main 2>/dev/null || git checkout "memory-audit/${RUN_DATE}"
+git add "sessions/meta/memory-audit/${RUN_DATE}-audit.md" "sessions/meta/memory-audit/README.md"
+git commit -m "[docs] Weekly memory audit ${RUN_DATE} (cross-project reconciliation)"
+git push -u origin "memory-audit/${RUN_DATE}"
+gh pr create --repo brownm09/engineering-journal \
+  --base main --head "memory-audit/${RUN_DATE}" \
+  --title "Weekly memory audit ${RUN_DATE}" \
+  --body "Automated cross-project memory→repo reconciliation for ${RUN_DATE}. Read-only on memory (no memory file was edited or deleted). Promote issues filed: <Step 4 urls>. Stale/drift findings are report-only — see the report."
+```
+
+If any git/PR step fails, push-notify `weekly-memory-audit: report git/PR step failed — draft at
+${AUDIT_DIR}/${RUN_DATE}-audit.md` and continue to Step 6 (the report file still exists locally for
+recovery).
+
+---
+
+## Step 6 — Report
+
+Send a push notification summarizing the run:
+
+```
+weekly-memory-audit ${RUN_DATE} complete — <N> projects, <F> memory files.
+<G> never-ported durables; <I> issues filed (<D> deduped).
+<S> stale/drift findings (report-only).
+Report PR: <url>
+```
+
+Clean up any scratch files this run created.
+
+---
+
+## Constraints
+
+- **Read-only on memory.** The routine **never** edits or deletes a memory file or `MEMORY.md`.
+  Deletion and in-place fixes stay human-in-the-loop via the interactive `/memory-audit` skill. An
+  unattended cron must not mutate the user's memory.
+- **Memory stores:** `C:/Users/brown/.claude/projects/*/memory/`; exclude `*--claude-worktrees-*`
+  project dirs.
+- **Engineering-journal repo:** `C:/Users/brown/Git/engineering-journal`; report path
+  `sessions/meta/memory-audit/YYYY-MM-DD-audit.md`.
+- **Cadence:** weekly Monday 09:00 local trigger — **no parity gate** (runs every week).
+- **One promote issue per never-ported durable**, labelled `memory-audit`, deduped by the
+  project-qualified `memory-slug`. **Never** call `AskUserQuestion`.
+- **Never** commit to `main`; open a PR. **Never** auto-merge (ADR-031).
+- **Scratch dir:** `C:/Users/brown/.claude/scratch/` — all temp files; never `/tmp/`.
+- **No `jq`** — use `node -e` for JSON parsing.
+- **Platform:** Windows 11, Git Bash syntax.
+- **App-open caveat:** scheduled tasks run while the Claude app is open; if it was closed when the
+  task was due, the run happens on next launch.
+
+> **Dual-copy registration caveat (dev-env#344).** This file is the **canonical, version-controlled**
+> definition (`dev-env/claude/routines/weekly-memory-audit/`, surfaced at
+> `~/.claude/routines/weekly-memory-audit/` via the directory junction). The scheduler reads a
+> **separate** live copy at `~/.claude/scheduled-tasks/weekly-memory-audit/SKILL.md`, materialized by
+> the `create_scheduled_task` MCP tool — the two do **not** auto-sync. Any edit to this routine must
+> be applied to **both** copies (update this file in a dev-env PR, then re-register / update the live
+> task via the scheduled-tasks MCP). See ADR-069.

--- a/claude/routines/weekly-memory-audit/SKILL.md
+++ b/claude/routines/weekly-memory-audit/SKILL.md
@@ -71,7 +71,9 @@ If `$DIRS` is empty, send a push notification — `weekly-memory-audit: no memor
 nothing to audit` — and exit cleanly with status 0.
 
 **Decode each project dir to its repo + GitHub slug** (used for instruction-home verification and
-issue routing). The project dir encodes the working-tree path with separators replaced by `-`:
+issue routing). The project dir encodes the working-tree path with separators replaced by `-`. Apply
+this decode **once per entry when reading `$DIRS` in Step 2** — it is per-entry pseudocode, not a
+sequential post-loop script:
 
 ```bash
 # projdir e.g. "C--Users-brown-Git-lifting-logbook"
@@ -167,8 +169,11 @@ repo `R`, read its existing open `memory-audit` issues once, then skip any findi
 appears (no `jq` — parse with `node -e`):
 
 ```bash
+# R, PROJ, NAME, RULE_TEXT, SUGGESTED_HOME, MEMORY_FILE are model-filled placeholders —
+# the agent substitutes values from its Step 2/3 findings context (not shell assignments).
+# R is the FULL owner/repo slug (e.g., "brownm09/lifting-logbook") from Step 3 routing.
 ISSUES="$SCRATCH/memaudit_issues_${R//\//_}.json"
-gh issue list --repo "brownm09/${R}" --label memory-audit --state open \
+gh issue list --repo "${R}" --label memory-audit --state open --limit 500 \
   --json number,title,body > "$ISSUES" 2>/dev/null || echo '[]' > "$ISSUES"
 
 # returns DUP or NEW for a given slug
@@ -184,31 +189,23 @@ node -e '
 For each remaining (NEW) finding, ensure the label exists then file the issue:
 
 ```bash
-gh label create memory-audit --repo "brownm09/${R}" --color 5319e7 \
+gh label create memory-audit --repo "${R}" --color 5319e7 \
   --description "Never-ported durable surfaced by the weekly-memory-audit routine" 2>/dev/null || true
 
-gh issue create --repo "brownm09/${R}" --label memory-audit \
-  --title "[memory-audit] Promote durable: ${NAME} (${PROJ})" \
-  --body "$(cat <<EOF
+BODY_FILE="$SCRATCH/memaudit_body_$$.md"
+cat > "$BODY_FILE" << 'BODY_DELIM'
 A durable rule in agent memory has no current instruction home and no open tracking issue. The
 weekly-memory-audit routine surfaced it for promotion into the version-controlled instructions
 (per ADR-038 / ADR-048): memory is a private cache, not the source of truth.
-
-**Memory file:** \`${MEMORY_FILE}\`
-**Rule (from memory):**
-> ${RULE_TEXT}
-
-**Suggested instruction home:** ${SUGGESTED_HOME}
-
-**To resolve:** port the rule into the suggested instruction file, link this issue from both the
-memory body and its \`MEMORY.md\` pointer (ADR-048), then close.
-
-memory-slug: ${PROJ}/${NAME}
-
-_Filed automatically by the \`weekly-memory-audit\` routine (dev-env
-\`claude/routines/weekly-memory-audit/\`). Parents: dev-env#363, dev-env#439._
-EOF
-)"
+BODY_DELIM
+printf '\n**Memory file:** `%s`\n**Rule (from memory):**\n' "$MEMORY_FILE" >> "$BODY_FILE"
+printf '> %s\n' "$RULE_TEXT" >> "$BODY_FILE"
+printf '\n**Suggested instruction home:** %s\n\n**To resolve:** port the rule into the suggested instruction file, link this issue from both the\nmemory body and its `MEMORY.md` pointer (ADR-048), then close.\n\nmemory-slug: %s/%s\n\n_Filed automatically by the `weekly-memory-audit` routine (dev-env\n`claude/routines/weekly-memory-audit/`). Parents: dev-env#363, dev-env#439._\n' \
+  "$SUGGESTED_HOME" "$PROJ" "$NAME" >> "$BODY_FILE"
+gh issue create --repo "${R}" --label memory-audit \
+  --title "[memory-audit] Promote durable: ${NAME} (${PROJ})" \
+  --body-file "$BODY_FILE"
+rm -f "$BODY_FILE"
 ```
 
 Capture every filed issue URL, and keep a running count of **filed** vs **deduped** (skipped) per
@@ -262,11 +259,12 @@ fi
    reviews and merges):
 
 ```bash
-cd "$EJ"
-git checkout -b "memory-audit/${RUN_DATE}" origin/main 2>/dev/null || git checkout "memory-audit/${RUN_DATE}"
-git add "sessions/meta/memory-audit/${RUN_DATE}-audit.md" "sessions/meta/memory-audit/README.md"
-git commit -m "[docs] Weekly memory audit ${RUN_DATE} (cross-project reconciliation)"
-git push -u origin "memory-audit/${RUN_DATE}"
+git -C "$EJ" checkout -b "memory-audit/${RUN_DATE}" origin/main 2>/dev/null \
+  || git -C "$EJ" checkout "memory-audit/${RUN_DATE}"
+git -C "$EJ" add "sessions/meta/memory-audit/${RUN_DATE}-audit.md" "sessions/meta/memory-audit/README.md"
+git -C "$EJ" diff --cached --quiet \
+  || git -C "$EJ" commit -m "[docs] Weekly memory audit ${RUN_DATE} (cross-project reconciliation)"
+git -C "$EJ" push -u origin "memory-audit/${RUN_DATE}"
 gh pr create --repo brownm09/engineering-journal \
   --base main --head "memory-audit/${RUN_DATE}" \
   --title "Weekly memory audit ${RUN_DATE}" \

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -406,6 +406,60 @@ Reconciles the **Dev Env** project board (#3) against the repo's open issues: li
 
 ---
 
+### weekly-memory-audit
+
+**Schedule:** `0 9 * * 1` — Monday 09:00 **local** time (the `scheduled-tasks` scheduler evaluates
+cron in local time). Weekly every Monday — **no parity gate** (unlike `biweekly-retro`).
+
+Runs `sync-routine-worktree` as Step 0 (`REPO=engineering-journal`,
+`VERIFY_FILE=sessions/meta/README.md`). Enumerates every project's memory store under
+`~/.claude/projects/*/memory/`, excluding Claude-managed worktree project dirs
+(`*--claude-worktrees-*`). Decodes each project dir to its repo working tree and GitHub slug via the
+actual `git remote get-url origin` (not the dir name — handles mismatches like
+`job-search` → `job-search-agent`). For each project, fans out one background `Explore` subagent
+(all spawned in a single message — no synchronous preflight) to classify every non-`MEMORY.md`
+memory entry. Dispositions: **remain** (durable + verified instruction home on `origin/main`),
+**promote** (durable + no home + no open tracking issue = never-ported), **stale** (cites
+merged/closed work or is contradicted by current code), **drift** (names a moved/renamed file or
+flag), **transient** (session-local/fast-changing), **tracked-pending** (has an open issue but no
+instruction home yet — report-only, not re-filed), or **index-drift** (missing from or disagreeing
+with `MEMORY.md`).
+
+**Read-only on memory.** The routine **never** edits or deletes a memory file or `MEMORY.md`.
+Deletion and in-place fixes stay human-in-the-loop via the interactive `/memory-audit` skill.
+
+**Outputs:**
+- **Deduped promote issues, one per never-ported durable** (label `memory-audit`). The issue body
+  carries the rule text, memory file path, suggested instruction home, and a machine-readable
+  `memory-slug: <projdir>/<name>` line (project-qualified to prevent cross-project collisions when
+  global rules from different projects all land in dev-env). A dedup guard reads each target repo's
+  open `memory-audit` issues before filing, skipping slugs already present — the weekly cadence
+  never re-files the same gap. Routing: project-specific durable → that project's repo;
+  global/cross-cutting + no-remote + engineering-journal (no issue tracker by convention) → dev-env.
+- A committed reconciliation report at
+  `engineering-journal/sessions/meta/memory-audit/YYYY-MM-DD-audit.md` with a cross-project table
+  (project · file · type · durable? · instruction home · drift · disposition), a "Promote issues
+  filed" subsection, and a "Stale / drift / index-drift (report-only)" subsection. Opened as a PR
+  to `main` (never auto-merged — ADR-031; the user reviews and merges).
+
+Stale, drift, index-drift, and tracked-pending findings are included in the report but are **not**
+auto-actioned — they require human judgment.
+
+**Resilience:** no-memory-stores exit (push-notify + EXIT 0), per-project subagent failure →
+partial report (does not abort the run), git/PR failure → push-notify + keep draft for recovery.
+A push notification summarizes the run on every completion or abort path.
+
+**Dual-copy caveat (dev-env#344):** `claude/routines/weekly-memory-audit/` (version-controlled, via
+junction) is the canonical definition. The live task copy at
+`~/.claude/scheduled-tasks/weekly-memory-audit/SKILL.md` is written by the `create_scheduled_task`
+MCP tool into a *separate real directory* and does **not** auto-sync — both must be updated on any
+edit (PR for the canonical; re-register/update via MCP for the live copy).
+
+**Origin:** dev-env#439 (child of dev-env#363); cadence and read-only-on-memory shape chosen by the
+user 2026-06-30. [ADR-069](adr/069-weekly-memory-audit-routine.md)
+
+---
+
 ## Utilities
 
 On-demand scripts — not wired to any event. Run manually or from other scripts.

--- a/docs/adr/069-weekly-memory-audit-routine.md
+++ b/docs/adr/069-weekly-memory-audit-routine.md
@@ -1,0 +1,143 @@
+# ADR-069 — Weekly Memory Audit Routine
+
+**Date:** 2026-06-30
+**Status:** Accepted
+**Tags:** routines, memory, scheduled-tasks, autonomy, dedup, ADR-038, ADR-048, ADR-013
+
+---
+
+## Context
+
+ADR-038 and ADR-048 provide write-time guardrails for agent memory: every durable preference
+committed to a memory file must be paired with a GitHub issue and ported into the version-controlled
+instructions in the same session. The write-time advisory hook (`memory-write-advisory.py`) flags
+new memory writes that lack an immortalization link.
+
+However, both guards are write-time only. The *existing* body of memory entries accumulated before
+these rules were in force — and any entry where the issue was filed but the port to instructions was
+never completed — sits silently in invisible memory with no backstop. Three failure classes
+accumulate over time across every project:
+
+1. **Never-ported durables** — durable (`user`/`feedback`/`project`) rules with no current
+   instruction home and no open tracking issue: the forbidden state ADR-038 targets.
+2. **Stale notes** — entries claiming something is still pending or unresolved long after it shipped
+   or was superseded.
+3. **Drift** — entries that name a specific file, function, or flag that has since moved or been
+   removed.
+
+Issue [#363](https://github.com/brownm09/dev-env/issues/363) (2026-06-30) performed the first
+*manual* cross-project sweep and found all three classes. Sub-issue
+[#439](https://github.com/brownm09/dev-env/issues/439) automates the recurring version.
+
+The `/memory-audit` skill handles single-project reconciliation interactively (human-in-the-loop,
+can delete). It cannot run on a schedule and does not cover multiple projects. A complementary
+audit-time, cross-project, **non-destructive** backstop is needed.
+
+## Decision
+
+Implement the `weekly-memory-audit` routine in
+`claude/routines/weekly-memory-audit/SKILL.md` with the following shape:
+
+### Core shape
+
+| Property | Value |
+|---|---|
+| Schedule | `0 9 * * 1` — Monday 09:00 **local** time, every week |
+| Parity gate | **None** — runs every Monday (deliberate divergence from `biweekly-retro`) |
+| Memory mutation | **Read-only** — never edits or deletes any memory file or `MEMORY.md` |
+| Memory scope | `~/.claude/projects/*/memory/`, excluding `*--claude-worktrees-*` project dirs |
+| Report home | `engineering-journal/sessions/meta/memory-audit/YYYY-MM-DD-audit.md` |
+| Issue label | `memory-audit` |
+
+### Per-step decisions
+
+**Step 0 — Sync.** `sync-routine-worktree` with `REPO=engineering-journal`. Other repos are read via
+`git fetch` + `git show origin/main:<path>` for instruction-home verification — no working-tree sync
+needed. Memory dirs are machine-local live state, not a repo.
+
+**Step 2 — Classification.** Parallel background `Explore` subagents (one per project, all spawned
+in a single message — no synchronous preflight). `Explore` cannot Edit/Write, structurally enforcing
+the read-only-on-memory guarantee. Classification subset of `/memory-audit`: for each non-`MEMORY.md`
+entry, parse frontmatter (accept `type:` or `metadata.type:` — both spellings exist), detect an
+immortalization link using the `memory-write-advisory.py` patterns (`#\d+`, `ADR-\d+`, `CLAUDE.md`,
+"Documented in repo"), verify claimed instruction homes on `origin/main` (not the local worktree, to
+avoid false gaps when the worktree is a commit behind), and assign a disposition: **remain**,
+**promote**, **stale**, **drift**, **transient**, **tracked-pending**, or **index-drift**.
+
+**Step 3 — Routing.** Project-specific durable → that project's GitHub repo. Global/cross-cutting
+durable, projects with no remote, and engineering-journal (no issue tracker by convention) → dev-env.
+The GitHub slug is decoded from the actual `git remote get-url origin` (not the dir name — handles
+mismatches like `job-search` → `job-search-agent`).
+
+**Step 4 — One promote issue per never-ported durable.** This is the intentional divergence from
+`biweekly-retro`'s consolidated-per-repo model: ADR-048's immortalization model is per-rule, so each
+never-ported durable gets its own issue that drives it into the instructions. The
+project-qualified slug `<projdir>/<name>` avoids cross-project collisions in dev-env when global
+rules from different projects all land there. The dedup guard reads each target repo's open
+`memory-audit` issues before filing any, skipping findings whose slug already appears.
+
+**Step 5 — Report.** Branch `memory-audit/YYYY-MM-DD` off `origin/main`, commit the report, open a
+PR (no auto-merge — ADR-031). Stale, drift, index-drift, and tracked-pending findings are included in
+the report as report-only; they are **never** auto-actioned (they need human judgment).
+
+**Step 6 — Push notification** on every completion or abort path.
+
+### Dual-copy registration caveat
+
+The scheduler reads a **live** copy at `~/.claude/scheduled-tasks/weekly-memory-audit/SKILL.md`,
+materialized by the `create_scheduled_task` MCP tool into a *separate real directory* (not a
+junction) from `claude/routines/` (the version-controlled canonical). The two do not auto-sync.
+Any edit to this routine must be applied to **both** copies (PR to update `claude/routines/`, then
+re-register via the MCP). This follows the same pattern as `biweekly-retro` and is documented
+explicitly in the canonical SKILL.md's Constraints block. See [dev-env#344](https://github.com/brownm09/dev-env/issues/344).
+
+## Considered alternatives
+
+**Delete-capable autonomous audit.** Allow the routine to edit or delete stale/drift entries in
+addition to promoting. Rejected: an unattended cron with write access to the user's memory is
+unsafe — it can destroy context that hasn't yet been acted upon. Deletion stays human-in-the-loop
+via the interactive `/memory-audit` skill, which can reason about ambiguous cases.
+
+**Consolidated promote issue per repo** (one issue = all the repo's never-ported durables). Rejected:
+ADR-048's immortalization model is per-rule. A consolidated issue produces one large, hard-to-track
+task instead of discrete, closable action items — the user would have to sub-track manually anyway.
+
+**Parity gate (biweekly cadence).** Apply an even-ISO-week gate like `biweekly-retro` to make this
+routine run every other Monday. Rejected: the user chose weekly cadence on 2026-06-30 as the right
+balance for a memory audit (the write-time gap can accumulate quickly across sessions; catching it
+weekly is proportionate).
+
+**Thin-pointer live registration.** Register the live copy as a one-liner that reads the canonical
+file from disk, instead of a full self-contained copy. Rejected: the `biweekly-retro` precedent is a
+self-contained copy with a canonical-pointer note ("prefer the canonical file if present") for
+resilience against connectivity or file-resolution failures at scheduled-task fire time.
+
+## Consequences
+
+- **Every Monday:** never-ported durables are surfaced with an auto-filed promote issue in the
+  correct repo, labelled `memory-audit`, with the rule text and suggested instruction home. Stale,
+  drift, and index-drift findings are reported without auto-actioning.
+- **Safe by construction:** read-only on memory — no unattended writes. The dedup guard prevents the
+  weekly cadence from re-filing the same gap. A bad run produces only a draft PR that the user can
+  close.
+- **Weekly cadence risk:** if a project's memory dir grows very large, the parallel subagents become
+  many. Bounded in practice: each project's `memory/` is small (a few `.md` files), and the
+  subagents do only read classification.
+- **Dual-copy drift risk:** the live registered copy can get out of sync with the canonical version
+  if edited without updating both. Mitigated by the explicit caveat in the SKILL.md Constraints block
+  and in this ADR.
+- **No automated instruction-home patching:** the routine files the issue but does not make the
+  CLAUDE.md edit. That remains a human-approved action, consistent with ADR-038's intent that
+  instructions are deliberate.
+
+## References
+
+- [dev-env#439](https://github.com/brownm09/dev-env/issues/439) — the sub-issue this ADR addresses.
+- [dev-env#363](https://github.com/brownm09/dev-env/issues/363) — the parent initiative (manual sweep that motivated this automation).
+- [dev-env#344](https://github.com/brownm09/dev-env/issues/344) — the dual-copy registration caveat.
+- [ADR-038](038-durable-preferences-documented-in-repo.md) — write-time durable-preference rule.
+- [ADR-048](048-memory-immortalization-issue-pairing.md) — memory-write immortalization-issue pairing.
+- [ADR-013](013-sync-routine-worktree-skill.md) — `sync-routine-worktree` prerequisite pattern.
+- [ADR-031](031-auto-merge-disabled.md) — no auto-merge on report PRs.
+- `claude/routines/weekly-memory-audit/SKILL.md` — the canonical routine definition.
+- `claude/routines/biweekly-retro/SKILL.md` — the style model this routine follows.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -73,3 +73,4 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [066](066-worktree-session-safety-rules.md) | Worktree Session Safety: Origin Verification, Bash cd Prevention, Deregistration Recovery | 2026-06-30 | Accepted | git, worktree, workflow, memory, documentation, global-rule |
 | [067](067-scope-merge-keyed-hooks-to-target-repo.md) | Scope Merge-Keyed Hook Operations to the Merge-Target Repo | 2026-06-30 | Accepted | hooks, post-tool-use, gh-pr-merge, cross-repo, correction |
 | [068](068-reconcile-project-board-orphan-issues.md) | Reconcile the Project Board Against Orphaned Issues (Backstop for the Inert Add-Hook) | 2026-06-30 | Accepted | routines, github-project, post-tool-use, hook-config, reconciliation, background-sessions, automation |
+| [069](069-weekly-memory-audit-routine.md) | Weekly Memory Audit Routine | 2026-06-30 | Accepted | routines, memory, scheduled-tasks, autonomy, dedup, ADR-038, ADR-048, ADR-013 |


### PR DESCRIPTION
## Summary

Implements a weekly Monday 09:00 local scheduled routine that reconciles every project's
agent memory against the version-controlled instructions across all projects — the recurring,
autonomous complement to the single-project interactive `/memory-audit` skill.

**Key properties:**
- **Read-only on memory** — never edits or deletes a memory file; deletion stays human-in-the-loop via `/memory-audit`
- Auto-files **one deduped *promote* issue per never-ported durable** (label `memory-audit`, project-qualified `memory-slug` dedup guard) routed to the correct repo
- Stale / drift / index-drift findings are **report-only** — never auto-actioned
- Writes a committed cross-project reconciliation report to `engineering-journal`; push-notifies on every abort/completion path
- Fully autonomous — never calls `AskUserQuestion`

Closes #439

## Files changed

| File | Change |
|---|---|
| `claude/routines/weekly-memory-audit/SKILL.md` | **New** — canonical 6-step routine (323 lines) |
| `docs/adr/069-weekly-memory-audit-routine.md` | **New** — ADR documenting 9 locked design decisions, dual-copy caveat, 4 rejected alternatives |
| `docs/adr/INDEX.md` | Add ADR-069 row |
| `claude/CLAUDE.md` | Add weekly-memory-audit pointer in Durable Preferences bullet + `See ADR-069` |
| `README.md` | Add routine to Routines table |
| `docs/REFERENCE.md` | Add `### weekly-memory-audit` section |

Live scheduled task was also registered via `create_scheduled_task` MCP (task ID `weekly-memory-audit`, cron `0 9 * * 1`, next run Monday). Per dev-env#344 dual-copy caveat: both this SKILL.md and `~/.claude/scheduled-tasks/weekly-memory-audit/SKILL.md` must be updated on any future edit.

## ADR-warrant

ADR-069 (`docs/adr/069-weekly-memory-audit-routine.md`) — new routine + 9 locked design decisions (cadence, read-only-on-memory, one-per-rule dedup, repo routing, report shape, no parity gate, dedup slug, fully autonomous). Qualifies: adds a routine + new workflow rule (the `memory-audit` label and project-qualified slug convention, the dedup guard, the promote-vs-stale distinction).

## Doc-reconciliation

- [x] `README.md` Routines table — row added
- [x] `docs/REFERENCE.md` Routines section — `### weekly-memory-audit` H3 added with schedule, steps, outputs, resilience, dual-copy caveat, ADR-069 link
- [x] `claude/CLAUDE.md` `## Durable Preferences & Memory` — routine pointer + `ADR-069` in See line

## Testing

No `.py` files added or changed → Python syntax gate (test #1) N/A.

Verification performed before PR:

1. **bash -n syntax check** — all 6 bash blocks extracted from SKILL.md: **6/6 PASS**
2. **Memory dir enumeration dry-run** — confirmed 6 project dirs included, 0 `*--claude-worktrees-*` dirs:
   - `C--Users-brown-Git-brownm09` (2 .md files)
   - `C--Users-brown-Git-career-playbook` (4 .md files)
   - `C--Users-brown-Git-dev-env` (1 .md file)
   - `C--Users-brown-Git-engineering-journal` (3 .md files)
   - `C--Users-brown-Git-job-search` (2 .md files)
   - `C--Users-brown-Git-lifting-logbook` (2 .md files)
3. **Dedup probe** — `gh issue list --repo brownm09/dev-env --label memory-audit --state open`: exits 0, returns `[]` (no pre-existing open issues with this label — clean slate)
4. **Cron validation** — `0 9 * * 1`: PASS (minute=0, hour=9, DOM=*, month=*, DOW=1)
5. **Scheduled task registration** — `create_scheduled_task` MCP returned success; next run: in 5 days (Monday)

**End-to-end is intentionally not auto-run during implementation** (it would file real issues and open a real engineering-journal PR). The dry-run above exercises every read path; the first live Monday run is the true end-to-end.

Tests: N/A — no test suite for this project (docs/config/routine only). Manual verification above.

## Code quality

- Suppression grep: **clean** (no ts-ignore, ts-expect-error, eslint-disable, non-null assertions)
- Test-integrity grep: **clean** (no skip markers, no deleted test files)
- No new `.py` scripts added — pre-existing test suite unaffected

## Review findings disposition

`/review` run: [PR #452 comment](https://github.com/brownm09/dev-env/pull/452#issuecomment-4850392966) — 4 blocking, 5 non-blocking. All 9 addressed.

| # | Finding | Disposition |
|---|---|---|
| 1 | `brownm09/${R}` double-owner bug [blocking] | Fixed in `5a69b07` — changed to `"${R}"` (full slug, no prefix) |
| 2 | Unquoted heredoc `${RULE_TEXT}` injection [blocking] | Fixed in `5a69b07` — switched to `--body-file` with single-quoted `BODY_DELIM` |
| 3 | `projdir` post-loop slug decode ambiguity [blocking] | Fixed in `5a69b07` — added annotation: "Apply this decode once per entry when reading `$DIRS` in Step 2" |
| 4 | `gh issue list` missing `--limit` [blocking] | Fixed in `5a69b07` — added `--limit 500` |
| 5 | `cd "$EJ"` vs. `git -C` [non-blocking] | Fixed in `5a69b07` — all git calls now use `git -C "$EJ"` |
| 6 | `git commit` re-run spurious failure [non-blocking] | Fixed in `5a69b07` — added `git diff --cached --quiet \|\|` guard |
| 7 | Auth failure treated as "no issues" [non-blocking] | Filed as [dev-env#455](https://github.com/brownm09/dev-env/issues/455) |
| 8 | Template variable notation ambiguity [non-blocking] | Fixed in `5a69b07` — added comment annotating model-filled placeholders vs. shell vars |
| 9 | Subagent failure gap unspecified [non-blocking] | Filed as [dev-env#456](https://github.com/brownm09/dev-env/issues/456) |

**Rebase note:** PRs #448 and #451 landed on `main` after this branch was cut — they created ADR-067 and ADR-068 for different features. This branch's ADR was renumbered to **ADR-069** (`docs/adr/069-weekly-memory-audit-routine.md`) during successive rebases; all in-branch references updated in commits `8baac4c` + `fa1fa10`.
