### PR TITLE
[fix] Extend explicit-pathspec git-commit fix to propose, nightly-research, merge-stale-pr.sh

### DIFF
--- a/claude/routines/nightly-research/SKILL.md
+++ b/claude/routines/nightly-research/SKILL.md
@@ -210,14 +210,20 @@ Before committing, check whether any note files were actually written. If `notes
 cd C:/Users/brown/Git/research-notes
 
 # Stage notes only if any were written
+NOTES_STAGED=""
 if [ -n "$(ls -A "notes/${RUN_DATE}" 2>/dev/null)" ]; then
   git add "notes/${RUN_DATE}/"
+  NOTES_STAGED="notes/${RUN_DATE}/"
 fi
 
 # Always stage the queue file (may have failure annotations even if no notes were written)
 git add research-queue.md
 
-git commit -m "research: ${RUN_DATE} — <N> topic(s): <comma-separated titles>"
+# Explicit pathspec, not a bare commit — this is a persistent checkout, not a
+# worktree isolated per run (see docs/adr/056-per-session-sharding-journal-companion-files.md
+# -> Addendum). Scoping to exactly what was staged above costs nothing and keeps
+# this commit from ever picking up an unrelated change in this checkout.
+git commit -m "research: ${RUN_DATE} — <N> topic(s): <comma-separated titles>" -- research-queue.md $NOTES_STAGED
 ```
 
 The commit message includes the count and titles so the git log is scannable without opening files.

--- a/claude/scripts/merge-stale-pr.sh
+++ b/claude/scripts/merge-stale-pr.sh
@@ -79,12 +79,17 @@ fi
 DRAFTS=$(find sessions -name "*_draft.md" 2>/dev/null || true)
 if [[ -n "$DRAFTS" ]]; then
   echo "==> Deleting orphaned draft files:"
-  echo "$DRAFTS" | while IFS= read -r f; do
+  mapfile -t DRAFT_FILES <<< "$DRAFTS"
+  for f in "${DRAFT_FILES[@]}"; do
     echo "    $f"
     rm -f "$f"
   done
-  git add -u
-  git commit -m "chore: remove orphaned draft files from $DATE_PART" || true
+  # Explicit pathspec on both add and commit -- not `add -u` + a bare commit --
+  # so this only touches the draft files just deleted, not anything else a
+  # concurrent session may have staged in this shared engineering-journal
+  # checkout (docs/adr/056-per-session-sharding-journal-companion-files.md -> Addendum).
+  git add -- "${DRAFT_FILES[@]}"
+  git commit -m "chore: remove orphaned draft files from $DATE_PART" -- "${DRAFT_FILES[@]}" || true
 fi
 
 # ── Step 5: rebase against main ───────────────────────────────────────────────

--- a/claude/scripts/pr-merge-reminder.py
+++ b/claude/scripts/pr-merge-reminder.py
@@ -361,7 +361,9 @@ def main() -> None:
             "  3. Write a <!-- session: <slug> --> block for this session."
             + shard_step + "\n"
             "  4. Add token comment and <!-- next-session-context --> paragraph.\n"
-            '  5. git commit -m "draft: YYYY-MM-DD session N" && git push'
+            "  5. git add the stub, manifest shard, and open-PR shard written above.\n"
+            '  6. git commit -m "draft: YYYY-MM-DD session N" -- <those same files>'
+            " && git push"
         )
 
     if is_merge:
@@ -374,7 +376,9 @@ def main() -> None:
             "  2. Check out or create the draft branch in engineering-journal.\n"
             "  3. Append a <!-- session: <slug> --> block documenting this PR merge.\n"
             "  4. Add token comment and <!-- next-session-context --> paragraph.\n"
-            '  5. git commit -m "draft: YYYY-MM-DD session N" && git push'
+            "  5. git add the updated stub (and manifest shard, if this session's own).\n"
+            '  6. git commit -m "draft: YYYY-MM-DD session N" -- <those same files>'
+            " && git push"
         )
 
     if is_push and not (is_create or is_merge):
@@ -401,7 +405,9 @@ def main() -> None:
                 "  2. Check out the draft branch in engineering-journal.\n"
                 "  3. Find today's stub for this session, or create one if absent.\n"
                 "  4. Add/update token comment and <!-- next-session-context --> paragraph.\n"
-                '  5. git commit -m "draft: YYYY-MM-DD session N" && git push'
+                "  5. git add the stub (and manifest shard, if this session's own).\n"
+                '  6. git commit -m "draft: YYYY-MM-DD session N" -- <those same files>'
+                " && git push"
             )
 
     if not messages:

--- a/claude/skills/propose/SKILL.md
+++ b/claude/skills/propose/SKILL.md
@@ -286,6 +286,12 @@ If `config.roadmap_file` is non-null:
 git add <config.roadmap_file>
 ```
 
+Commit with an explicit pathspec — not a bare `git commit` — scoped to exactly the file(s)
+staged above. Step 6 checked out `main` and branched directly in the current working
+directory with no worktree isolation, so a bare commit here would sweep in anything else
+staged by a concurrent session in this checkout (see
+`docs/adr/056-per-session-sharding-journal-companion-files.md` → Addendum):
+
 ```bash
 git commit -m "$(cat <<'EOF'
 [docs] Propose: <title>
@@ -293,7 +299,7 @@ git commit -m "$(cat <<'EOF'
 Adds proposal doc and links GitHub issue #N.
 
 EOF
-)"
+)" -- <config.proposals_dir>/YYYY-MM-DD-<slug>.md <config.roadmap_file, if staged above>
 git push -u origin docs/propose-<slug>
 ```
 

--- a/docs/adr/056-per-session-sharding-journal-companion-files.md
+++ b/docs/adr/056-per-session-sharding-journal-companion-files.md
@@ -160,3 +160,49 @@ design, which remains structurally sound for what it claims (content-level disjo
 
 **Status:** this is a refinement, not a reversal — ADR-056's Decision, Considered alternatives, and
 Consequences stand unchanged; Status remains Accepted. Tracked in [dev-env#449](https://github.com/brownm09/dev-env/issues/449).
+
+---
+
+## Addendum (2026-07-01) — Extended to propose, nightly-research, and merge-stale-pr.sh
+
+The first addendum (2026-06-30) scoped the explicit-pathspec fix to the engineering-journal Stub
+file workflow in `claude/CLAUDE.md`, plus `claude/skills/journal-compose/SKILL.md` and
+`claude/routines/biweekly-retro/SKILL.md` — the sites confirmed at the time to write the shared
+`C:/Users/brown/Git/engineering-journal` checkout. A `/review` pass on that PR flagged two more
+bare-`git commit` sites pending verification of their shared-checkout status, and a follow-up
+repo-wide grep across `claude/scripts/*.py` and `*.sh` (not covered by the original audit, which
+was scoped to `claude/skills/` and `claude/routines/`) surfaced two more.
+
+**Investigated and fixed** (same hazard: a persistent, non-worktree-isolated checkout with a bare
+`git commit` that would silently absorb anything else staged in that checkout's index):
+
+- `claude/skills/propose/SKILL.md` Step 10 — commits to whatever repo `config.roadmap_file` /
+  `config.github_repo` targets. Step 6 does `git checkout main && git pull && git checkout -b
+  docs/propose-<slug>` directly in the current working directory; no worktree isolation is set up
+  anywhere in the skill.
+- `claude/routines/nightly-research/SKILL.md` Step 4 — commits to `C:/Users/brown/Git/research-notes`.
+  This repo has exactly one automated writer across all of `claude/` (confirmed by grep: the
+  `/research` skill's "shared source library" is a different path, `~/.claude/skills/sources.md`;
+  `biweekly-retro` only routes issue-filing there, never writes) — materially lower concurrency risk
+  than engineering-journal. Fixed anyway: the script already computes the exact paths it stages, so
+  scoping the commit is free and matches the pattern established for the structurally identical
+  engineering-journal case.
+- `claude/scripts/merge-stale-pr.sh` Step 4 — operates directly on the shared engineering-journal
+  checkout (`cd "$JOURNAL_REPO"`, no worktree). Was `git add -u` (repo-wide stage) followed by a bare
+  commit — broader than the original bug, since even the `add` was untargeted, not just the `commit`.
+- `claude/scripts/pr-merge-reminder.py` (3 sites) — does not itself commit, but printed reminder text
+  instructing the *next* session to run a bare `git commit` for the same stub workflow this ADR
+  already fixed in `claude/CLAUDE.md`. Left uncorrected, the hook's own guidance would keep
+  reintroducing the hazard it exists to help prevent. Reminder text updated to match the pathspec
+  convention.
+
+**Investigated and confirmed exempt (no change):**
+
+- `claude/scripts/reconcile-late-stubs.py:198` — a bare `git commit`, but it runs inside a freshly
+  created, detached, single-purpose temporary worktree (`git worktree add --detach <temp_dir>
+  origin/<target_branch>`, line ~174) that is removed in the `finally` block immediately after. A
+  fresh worktree has its own index; nothing else can be staged there. Adding a pathspec would be
+  redundant defensive code for a scenario the isolation already rules out — left as-is.
+
+**Status:** this is a scope extension of the same fix, not a reversal — ADR-056's Decision and both
+addenda's Fix stand unchanged. Tracked in [dev-env#459](https://github.com/brownm09/dev-env/issues/459).


### PR DESCRIPTION
## Summary

PR #450 fixed a bug class: a bare `git commit` (no pathspec) commits the *entire* staged git index, not just the files just `git add`-ed. Dangerous specifically when a checkout is shared by multiple concurrent Claude Code sessions with no per-session worktree isolation. That PR fixed the engineering-journal Stub file workflow (`claude/CLAUDE.md`, `journal-compose/SKILL.md`, `biweekly-retro/SKILL.md`).

This PR extends the same fix to four more sites, closing out the two follow-ups explicitly deferred from PR #450's review plus two more found via a repo-wide grep of `claude/scripts/` (not covered by the original audit).

## Investigation findings

- **`claude/skills/propose/SKILL.md` Step 10** — Shared checkout. Step 6 does `git checkout main && git pull && git checkout -b docs/propose-<slug>` directly in cwd; no worktree isolation anywhere in the skill. **Fixed.**
- **`claude/routines/nightly-research/SKILL.md` Step 4** — `research-notes` has exactly one automated writer across all of `claude/` (confirmed by grep: `/research`'s "shared source library" is a different path, `~/.claude/skills/sources.md`; `biweekly-retro` only routes issue-filing there, never writes). Lower concurrency risk than engineering-journal, but same persistent non-worktree-isolated checkout shape, and the script already computes the exact paths it stages. **Fixed** (free, consistent with the established pattern).
- **`claude/scripts/merge-stale-pr.sh` Step 4** (found via grep) — Operates directly on the shared engineering-journal checkout (`cd "$JOURNAL_REPO"`, no worktree). Was `git add -u` (repo-wide stage) + bare commit — broader than the original bug since even the `add` was untargeted. **Fixed** (scoped `git add --`/`git commit --` to exactly the deleted draft files, via a `mapfile` array instead of `add -u`).
- **`claude/scripts/pr-merge-reminder.py`** (3 sites, found via grep) — Doesn't itself commit, but prints reminder text instructing the *next* session to run a bare `git commit` for the same stub workflow — actively contradicting the CLAUDE.md convention. **Fixed** (reminder text now includes the pathspec step).

**Investigated and confirmed exempt (no change):**

- `claude/scripts/reconcile-late-stubs.py:198` — bare `git commit`, but runs inside a freshly created, detached, single-purpose temp worktree (created line ~174, destroyed in the `finally` block). Independent index, nothing else can be staged there — a pathspec would be redundant defensive code for a scenario the isolation already rules out.

## ADR

Added an addendum to `docs/adr/056-per-session-sharding-journal-companion-files.md` documenting the extended scope and the `reconcile-late-stubs.py` exemption rationale, following the shape of PR #450's existing addendum.

## Testing

This is a docs/shell/Python config repo — see dev-env `CLAUDE.md` → `## Testing`.

- Hook-script syntax check (`py -3 -c "import ast..." claude/scripts/*.py`) — clean, no errors.
- `py -3 claude/scripts/tests/test_pr_merge_reminder.py` (required — `pr-merge-reminder.py` changed) — **Tests: 29 passed, 0 skipped, 0 failed.** No test asserts the literal reminder text (confirmed by reading the suite before editing), so the message-text change is untested by design; the predicate/helper functions it does test are unchanged.
- `bash claude/scripts/tests/run-shellcheck.sh` (recommended — `merge-stale-pr.sh` changed) — **SKIP**: `shellcheck` not installed locally (documented skip path, exit 0). Manually reviewed the diff (`mapfile -t` + `"${DRAFT_FILES[@]}"`) for quoting correctness in place of the automated pass.
- Suppression grep (`git diff origin/main -- . | grep -E '(ts-ignore|...)'`) — empty, no justification needed.
- Test-integrity grep — empty, no justification needed.
- No automated test exists for `propose/SKILL.md` or `nightly-research/SKILL.md` (documentation/instruction files, not executable scripts) — consistent with how PR #450 covered the analogous `journal-compose`/`biweekly-retro` SKILL.md changes.

## Observability

N/A — no stdout/stderr/exit-code contract changed on any hook; `pr-merge-reminder.py`'s exit-2 reminder path and message triggers are unchanged, only the reminder body text.

## Review findings disposition

`/review` posted: no blocking findings.

- **[maintainability] `merge-stale-pr.sh` has no automated test coverage** — filed and linked: [#463](https://github.com/brownm09/dev-env/issues/463). Genuinely separate scope from this PR (a proper fixture-based harness, matching `test-pre-push-lockfile.sh`'s throwaway-repo pattern, is its own task); the gap is pre-existing (the script had zero test coverage before this PR too) and this PR does not reduce coverage, only touches already-untested logic.

Closes #459.
