### PR TITLE
fix(routine): guard against silent gh issue list failures in weekly-memory-audit

### DIFF
--- a/claude/routines/weekly-memory-audit/SKILL.md
+++ b/claude/routines/weekly-memory-audit/SKILL.md
@@ -175,6 +175,10 @@ appears (no `jq` — parse with `node -e`):
 ISSUES="$SCRATCH/memaudit_issues_${R//\//_}.json"
 gh issue list --repo "${R}" --label memory-audit --state open --limit 500 \
   --json number,title,body > "$ISSUES" 2>/dev/null || echo '[]' > "$ISSUES"
+if ! node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$ISSUES" 2>/dev/null; then
+  echo "WARN: gh issue list failed for ${R} — skipping filing this run to avoid duplicates" >&2
+  continue
+fi
 
 # returns DUP or NEW for a given slug
 node -e '

--- a/claude/routines/weekly-memory-audit/SKILL.md
+++ b/claude/routines/weekly-memory-audit/SKILL.md
@@ -174,9 +174,13 @@ appears (no `jq` — parse with `node -e`):
 # R is the FULL owner/repo slug (e.g., "brownm09/lifting-logbook") from Step 3 routing.
 ISSUES="$SCRATCH/memaudit_issues_${R//\//_}.json"
 gh issue list --repo "${R}" --label memory-audit --state open --limit 500 \
-  --json number,title,body > "$ISSUES" 2>/dev/null || echo '[]' > "$ISSUES"
-if ! node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$ISSUES" 2>/dev/null; then
+  --json number,title,body > "$ISSUES" 2>/dev/null
+if [ $? -ne 0 ]; then
   echo "WARN: gh issue list failed for ${R} — skipping filing this run to avoid duplicates" >&2
+  continue
+fi
+if ! node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$ISSUES" 2>/dev/null; then
+  echo "WARN: gh issue list returned non-JSON for ${R} — skipping filing this run to avoid duplicates" >&2
   continue
 fi
 


### PR DESCRIPTION
## Summary

- In Step 4 of `weekly-memory-audit`, the `|| echo '[]' > "$ISSUES"` fallback fires on any non-zero `gh issue list` exit — but if `gh` writes partial output before failing, the file may hold non-JSON garbage rather than the intended `[]`.
- The dedup `node -e` call then either throws (crashing that repo's loop) or — if the garbage happens to be `[]` — silently treats every slug as NEW and re-files every promote finding as a duplicate.
- Fix: add a `node -e JSON.parse(...)` validity check immediately after the fallback. If unparseable, emit WARN to stderr and `continue` to skip filing for that repo this run. Leaves all previously filed issues untouched.

Both copies updated in this PR (canonical) and as a direct edit to `~/.claude/scheduled-tasks/weekly-memory-audit/SKILL.md` (live task, no PR needed).

Closes #455

## Testing

This change modifies a routine SKILL.md (prose instructions), not a Python script. The applicable test is the hook-script syntax check to confirm no Python regressions were introduced:

```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
```

Result: OK — all scripts parse. No automated test exists for SKILL.md prose content.

Tests: N/A — no automated tests for SKILL.md (no test suite added; coverage gate deferred — this is not testable behavior in the Python sense).

## Pre-PR checks

**Suppression grep:** N/A — markdown file only, no TS/JS suppressions possible.

**Test integrity grep:** N/A — no test files changed.

**Lockfile sync:** N/A — no `package.json` changes.

## ADR-warrant check

Not warranted. The change is a bug fix to an existing routine's guard logic. The rationale (prevent duplicate filing on transient `gh` failures) is fully recoverable from this commit message + issue #455. No new design decision or workflow rule is established.

## Doc-reconciliation check

Not warranted. The Documentation Maintenance table requires updates when routines are added, removed, or renamed. This is a behavior fix to an existing routine (`weekly-memory-audit`) with no name or description change — README.md and docs/REFERENCE.md listings are accurate as-is.

## Review findings disposition

**Finding 1 — [correctness]** The `|| echo '[]'` fallback produces parseable `[]` on every non-zero `gh` exit, so the JSON guard never fires for the primary failure mode (auth/rate-limit/network errors). The original bug from #455 was not closed by the initial 4-line guard.

**Fixed in `fdbc5fc`:** Removed the `|| echo '[]'` OR-fallback; replaced with explicit `if [ $? -ne 0 ]` exit-code check that emits WARN and `continue`s. Kept the JSON parse guard as a second layer for the gh-exits-0-with-garbage case (empty output, proxy HTML). Also updated the live copy description to accurately describe the two-guard approach. All dispositions: fixed in-PR.