### PR TITLE
fix(hooks): write worktree-path-guard block reason to stderr, not stdout

### DIFF
--- a/claude/scripts/pre-tool-use-worktree-path-check.py
+++ b/claude/scripts/pre-tool-use-worktree-path-check.py
@@ -154,7 +154,11 @@ def main() -> None:
             f"  git worktree add --force {worktree_root} <branch>\n"
             f"(<branch> is typically claude/<worktree-name>; confirm with `git branch -a`.)"
         )
-        print(json.dumps({"reason": reason}))
+        # Claude Code discards stdout on a PreToolUse hook exit code 2 — only
+        # stderr is surfaced to the model. Write there, matching the working
+        # pattern in career-playbook's block-artifact-merge.py /
+        # block-letter-violations.py.
+        sys.stderr.write(json.dumps({"reason": reason}) + "\n")
         sys.exit(2)
 
     file_path = data.get("tool_input", {}).get(_PATH_FIELD[tool_name], "")
@@ -191,7 +195,11 @@ def main() -> None:
         f"\n"
         f"Re-issue with the corrected path."
     )
-    print(json.dumps({"reason": reason}))
+    # Claude Code discards stdout on a PreToolUse hook exit code 2 — only
+    # stderr is surfaced to the model. Write there, matching the working
+    # pattern in career-playbook's block-artifact-merge.py /
+    # block-letter-violations.py.
+    sys.stderr.write(json.dumps({"reason": reason}) + "\n")
     sys.exit(2)
 
 

--- a/claude/scripts/pre-tool-use-worktree-path-check.py
+++ b/claude/scripts/pre-tool-use-worktree-path-check.py
@@ -112,6 +112,19 @@ def _worktree_is_live(
     return _normalize(top) == _normalize(worktree_root)
 
 
+def _block(reason: str) -> None:
+    """Emit a blocking {"reason": ...} payload and exit 2.
+
+    Claude Code discards stdout on a PreToolUse hook exit code 2 — only
+    stderr is surfaced to the model. Write there, matching the working
+    pattern in career-playbook's block-artifact-merge.py /
+    block-letter-violations.py. Centralized so main()'s two independent
+    block sites can't drift out of sync on this again (dev-env#469).
+    """
+    sys.stderr.write(json.dumps({"reason": reason}) + "\n")
+    sys.exit(2)
+
+
 def main() -> None:
     raw = sys.stdin.read().strip()
     if not raw:
@@ -154,12 +167,7 @@ def main() -> None:
             f"  git worktree add --force {worktree_root} <branch>\n"
             f"(<branch> is typically claude/<worktree-name>; confirm with `git branch -a`.)"
         )
-        # Claude Code discards stdout on a PreToolUse hook exit code 2 — only
-        # stderr is surfaced to the model. Write there, matching the working
-        # pattern in career-playbook's block-artifact-merge.py /
-        # block-letter-violations.py.
-        sys.stderr.write(json.dumps({"reason": reason}) + "\n")
-        sys.exit(2)
+        _block(reason)
 
     file_path = data.get("tool_input", {}).get(_PATH_FIELD[tool_name], "")
     if not file_path or not os.path.isabs(file_path):
@@ -195,12 +203,7 @@ def main() -> None:
         f"\n"
         f"Re-issue with the corrected path."
     )
-    # Claude Code discards stdout on a PreToolUse hook exit code 2 — only
-    # stderr is surfaced to the model. Write there, matching the working
-    # pattern in career-playbook's block-artifact-merge.py /
-    # block-letter-violations.py.
-    sys.stderr.write(json.dumps({"reason": reason}) + "\n")
-    sys.exit(2)
+    _block(reason)
 
 
 if __name__ == "__main__":

--- a/claude/scripts/tests/test_worktree_path_check.py
+++ b/claude/scripts/tests/test_worktree_path_check.py
@@ -9,8 +9,16 @@ Two layers, both hermetic (no real git repos, no real worktrees):
   2. End-to-end main() via subprocess — drives the real hook over stdin and
      asserts exit codes for:
        - an Edit from an orphaned `.claude/worktrees/<name>` cwd (no `.git`) is
-         BLOCKED (exit 2) with the orphan recovery message;
+         BLOCKED (exit 2) with the orphan recovery message, on stderr;
+       - a Write escaping to the canonical root from a live worktree is
+         BLOCKED (exit 2) with the escape recovery message, on stderr
+         (dev-env#469 — this call site had zero coverage before);
        - a call from a non-worktree cwd is a no-op (exit 0).
+
+Both block scenarios assert the reason lands on stderr with empty stdout —
+Claude Code discards a PreToolUse hook's stdout on exit code 2, so a reason
+printed there is silently invisible to the model even though the block
+itself still works (dev-env#469).
 
 Usage:
     py -3 claude/scripts/tests/test_worktree_path_check.py
@@ -97,7 +105,13 @@ def _run_hook(payload: dict) -> subprocess.CompletedProcess:
 
 
 def test_main_blocks_edit_from_orphaned_worktree() -> str:
-    """Acceptance: an Edit from an orphaned worktree cwd (no .git) is blocked."""
+    """Acceptance: an Edit from an orphaned worktree cwd (no .git) is blocked.
+
+    The block reason must land on stderr, not stdout — Claude Code discards
+    stdout on a PreToolUse hook exit code 2 and surfaces only stderr to the
+    model. Asserting against proc.stdout here would pass even if the reason
+    were silently invisible to the model (dev-env#469).
+    """
     with tempfile.TemporaryDirectory() as tmp:
         # Build <tmp>/.claude/worktrees/<name> with NO .git link — an orphan.
         orphan = Path(tmp) / ".claude" / "worktrees" / "orphan-name"
@@ -113,13 +127,58 @@ def test_main_blocks_edit_from_orphaned_worktree() -> str:
             raise AssertionError(
                 f"expected exit 2 (block), got {proc.returncode}. stderr={proc.stderr!r}"
             )
+        if proc.stdout.strip():
+            raise AssertionError(f"expected empty stdout (reason must go to stderr), got {proc.stdout!r}")
         try:
-            reason = json.loads(proc.stdout).get("reason", "")
+            reason = json.loads(proc.stderr).get("reason", "")
         except json.JSONDecodeError:
-            raise AssertionError(f"stdout was not JSON: {proc.stdout!r}")
+            raise AssertionError(f"stderr was not JSON: {proc.stderr!r}")
         if "orphaned" not in reason or "git worktree add --force" not in reason:
             raise AssertionError(f"block reason missing orphan/recovery text: {reason!r}")
-    return "Edit from orphaned worktree cwd blocked (exit 2) with recovery recipe"
+    return "Edit from orphaned worktree cwd blocked (exit 2) with recovery recipe, reason on stderr"
+
+
+def test_main_blocks_write_escaping_to_canonical_root() -> str:
+    """Acceptance: a Write whose absolute path targets the canonical root
+    instead of the active (live) worktree is blocked — the hook's primary,
+    most-documented scenario (ADR-024), and a code path the orphan test above
+    does not reach (it exercises the *other* print-before-exit(2) call site
+    in main()). The block reason must land on stderr, not stdout, same
+    requirement as the orphan case (dev-env#469).
+
+    The worktree must be LIVE (not orphaned) to reach this code path. A
+    bogus (non-gitdir-link) `.git` file is enough: `git rev-parse
+    --show-toplevel` fails against it (non-zero exit), and `_worktree_is_live`
+    treats a git-resolution failure as live (see module docstring) — no real
+    git repo needed, keeping this test hermetic like its siblings.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        canonical_root = Path(tmp) / "canon-repo"
+        worktree_root = canonical_root / ".claude" / "worktrees" / "some-worktree"
+        worktree_root.mkdir(parents=True)
+        (worktree_root / ".git").write_text("not a real gitdir link")
+        escaping_path = canonical_root / "some_file.py"
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(escaping_path)},
+            "cwd": str(worktree_root),
+        }
+        proc = _run_hook(payload)
+        if proc.returncode != 2:
+            raise AssertionError(
+                f"expected exit 2 (block), got {proc.returncode}. "
+                f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+            )
+        if proc.stdout.strip():
+            raise AssertionError(f"expected empty stdout (reason must go to stderr), got {proc.stdout!r}")
+        try:
+            reason = json.loads(proc.stderr).get("reason", "")
+        except json.JSONDecodeError:
+            raise AssertionError(f"stderr was not JSON: {proc.stderr!r}")
+        if "canonical repo root" not in reason or "Corrected" not in reason:
+            raise AssertionError(f"block reason missing expected markers: {reason!r}")
+    return "Write escaping to canonical root blocked (exit 2), reason on stderr"
 
 
 def test_main_noop_outside_worktree() -> str:
@@ -145,6 +204,7 @@ def main() -> int:
         ("_worktree_is_live decision table", test_worktree_is_live_decision_table),
         ("missing .git short-circuits before git", test_git_link_check_short_circuits_before_git),
         ("main() blocks Edit from orphaned worktree", test_main_blocks_edit_from_orphaned_worktree),
+        ("main() blocks Write escaping to canonical root", test_main_blocks_write_escaping_to_canonical_root),
         ("main() no-op outside worktree", test_main_noop_outside_worktree),
     ]
     failed = 0

--- a/docs/adr/024-worktree-path-guard-hook.md
+++ b/docs/adr/024-worktree-path-guard-hook.md
@@ -60,6 +60,7 @@ On Windows, `os.path.relpath` raises `ValueError` when source and target are on 
 - **No-op outside worktrees** — the hook exits 0 instantly when `cwd` does not match the worktree pattern.
 - **Coverage gap remains for Bash** — commands like `cp`, `tee`, or here-doc redirects that write to the canonical root are not intercepted. This is acceptable for now given the complexity; extend if recurrence is observed.
 - **Bypass for intentional canonical edits from a worktree:** The hook blocks `Write`, `Edit`, and `NotebookEdit` — not `Bash`. When a worktree session legitimately needs to modify a canonical repo file (e.g., editing `settings.json` on a config branch checked out in the main working tree), use `Bash` with `node -e` or a targeted `sed`/`py -3` invocation. This is the correct pattern — the hook is designed to surface accidental path mistakes, not to prevent deliberate file operations through a different tool surface.
+- **Block reason is written to stderr, not stdout** — Claude Code discards a `PreToolUse` hook's stdout on exit code 2, so a reason printed to stdout is silently invisible to the model even though the block itself still works. Both `main()` block sites emit through a shared `_block()` helper to keep this from drifting (dev-env#469 — the hook originally printed to stdout at both sites for over a month before this was caught and fixed).
 - **ADR warranted** because the hook is a new file under `claude/scripts/`, is wired in `claude/settings.json`, and establishes a harness-level safety invariant applicable to all repos using Claude-managed worktrees.
 
 ---
@@ -155,6 +156,7 @@ and giving the recovery recipe `git worktree add --force <worktree_root> <branch
 - `claude/settings.json` — hook wiring
 - `brownm09/career-playbook#276` — downstream symptom tracker (original)
 - `brownm09/dev-env#328` — orphaned-worktree hardening (addendum)
+- `brownm09/dev-env#469` — stdout→stderr block-reason fix (both sites), `_block()` helper introduced
 - Engineering-journal `sessions/career-playbook/2026-05-22_140307.stub.md` — third occurrence
 - Engineering-journal `sessions/career-playbook/2026-06-06_105718.stub.md` — orphaned-worktree incident
 - [Claude Code Hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks) — hook exit codes and JSON output format


### PR DESCRIPTION
## Summary

`pre-tool-use-worktree-path-check.py` (ADR-024's `PreToolUse` hook) had the same bug just fixed in its sibling `pre-tool-use-canonical-mutate-guard.py` (#468, finding #1, 0b103b6): the block-reason JSON was printed to **stdout** at both `sys.exit(2)` call sites, but Claude Code discards a PreToolUse hook's stdout on exit code 2 — only stderr is surfaced to the model.

The hook still worked mechanically (the write was blocked), but the model never saw why or how to fix the path, defeating the hook's documented purpose (surfacing a clear reason + recovery recipe).

## Reproduction (pre-fix)

Invoked the hook directly via subprocess with both trigger scenarios:

- **Canonical-root escape** (the primary, most-documented scenario — a live worktree, absolute `file_path` targeting the canonical root): exit 2, reason JSON on stdout, stderr empty.
- **Orphaned-worktree liveness guard** (dev-env#328 addendum): exit 2, reason JSON on stdout, stderr empty.

Both confirmed the bug at both `print(json.dumps(...))` call sites.

## Fix

Switched both call sites to `sys.stderr.write(json.dumps({"reason": reason}) + "\n")`, keeping `sys.exit(2)` — identical pattern to #468's fix and to career-playbook's `block-artifact-merge.py` / `block-letter-violations.py`.

Re-ran both reproduction scenarios post-fix: exit 2, stdout empty, reason correctly on stderr for both.

**Post-review (`710f213`):** extracted both call sites into a shared `_block(reason)` helper, and added an explicit stderr note + a References entry to ADR-024. See disposition section below.

## Test changes

`test_worktree_path_check.py`:
- Fixed `test_main_blocks_edit_from_orphaned_worktree`'s assertion from `proc.stdout` to `proc.stderr` (plus an explicit empty-stdout check) — this is the test that should have caught the bug but was itself asserting against the wrong stream.
- **Added** `test_main_blocks_write_escaping_to_canonical_root` — the canonical-root-escape block path (the hook's primary scenario per ADR-024) had **zero** main()-level test coverage before this change; only the orphan path was exercised. The new test uses a bogus (non-gitdir-link) `.git` file to make the worktree register as "live" without needing a real git repo (confirmed empirically: `git rev-parse --show-toplevel` exits non-zero against it, which `_worktree_is_live` treats as fail-open live) — keeps the test hermetic, matching this file's existing convention.
- Test suite grew from 4 to 5 passing cases.

No ADR text needed correction for the original bug: unlike #468's finding #7 (ADR-071 explicitly described the mechanism as stdout), ADR-024 and `docs/REFERENCE.md` described the hook's blocking behavior without naming a specific stream, so neither had gone stale. (ADR-024 was still updated post-review to add a positive statement of the correct mechanism — see disposition below.)

## Testing

Ran the checks required for this change per dev-env's `CLAUDE.md` → `## Testing` (item 1, since a `claude/scripts/*.py` file changed) plus the test file directly (not individually numbered in that section, same as its sibling):

```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
py -3 claude/scripts/tests/test_worktree_path_check.py
```

Tests: 5 passed, 0 skipped, 0 failed. Syntax check: OK. Re-ran both, identically green, after the post-review refactor commit (`710f213`).

## Review findings disposition

Reviewed at https://github.com/brownm09/dev-env/pull/473#issuecomment-4859408888 (blocking=0, non_blocking=2). Both fixed in `710f213`:

1. **[maintainability]** Duplicated block-emission comment/logic across `main()`'s two `sys.exit(2)` call sites → fixed: extracted a shared `_block(reason)` helper, both sites now call it.
2. **[documentation]** ADR-024 didn't positively state the stderr mechanism (so a future reader had nothing to check against) → fixed: added an explicit line to ADR-024's Consequences section plus a References entry for #469.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
