### PR TITLE
fix(weekly-memory-audit): surface subagent failures in reconciliation report (closes #456)

### DIFF
--- a/claude/routines/weekly-memory-audit/SKILL.md
+++ b/claude/routines/weekly-memory-audit/SKILL.md
@@ -131,19 +131,27 @@ For every `*.md` file in the memory dir **except `MEMORY.md`**, the subagent mus
    - Also flag **index-drift**: the entry is missing from `MEMORY.md`, or its `MEMORY.md` line
      disagrees with the file. Report-only.
 
-The subagent returns a structured findings list — one record per memory file with: file name, type,
-durable? (yes/no), instruction-home (path + verified yes/no, or "none"), disposition, a one-line
-rationale, and **for `promote` records additionally**: the rule text (verbatim or tight paraphrase),
-the suggested instruction home (which `CLAUDE.md`/doc it belongs in), and the entry's `name` slug.
+The subagent returns a structured findings response with two top-level fields:
+- **`scanned`** (bool, required): `true` if the subagent successfully read and classified the memory
+  files; `false` if it could not (permission error, empty-dir race, unexpected crash). This field
+  distinguishes a "subagent failure" from a legitimate "0 findings" result.
+- **`findings`** (list): one record per memory file with: file name, type, durable? (yes/no),
+  instruction-home (path + verified yes/no, or "none"), disposition, a one-line rationale, and
+  **for `promote` records additionally**: the rule text (verbatim or tight paraphrase), the suggested
+  instruction home (which `CLAUDE.md`/doc it belongs in), and the entry's `name` slug. Must be an
+  empty list when `scanned: false`.
 
-If a subagent fails or returns nothing for a project, **do not abort the whole run** — note the gap
-and continue with a partial report.
+If a subagent returns `scanned: false`, or returns nothing at all, **do not abort the whole run** —
+record the project name and the reason (or "subagent returned no data") in a running not-scanned
+list for Step 5, and continue with a partial report.
 
 ---
 
 ## Step 3 — Aggregate and route the promote findings
 
-Collect every subagent's findings. For each **promote** finding, determine the target repo:
+Collect every subagent's findings. Responses where `scanned` is `false` (or where nothing was
+returned) are already tracked in the not-scanned list — exclude them from promote routing. For each
+**promote** finding from a successfully-scanned project, determine the target repo:
 
 - **Project-specific durable** (a rule that governs only that project) → that project's own repo
   (its resolved GitHub `slug`), when it has a remote with Issues enabled.
@@ -253,6 +261,16 @@ fi
      slugs.
    - A **"Stale / drift / index-drift (report-only)"** subsection — each finding with file, what is
      stale/wrong, and the suggested human fix. These are *not* auto-actioned by design.
+   - A **"Projects not scanned (subagent failures)"** subsection — **include only when at least one
+     subagent returned `scanned: false` or returned no data at all**. Format:
+     ```
+     ## Projects not scanned (subagent failures)
+     | Project | Reason |
+     |---|---|
+     | lifting-logbook | Subagent returned no data |
+     ```
+     Omit this section entirely when every subagent returned `scanned: true`. A missing section means
+     "no scan failures" — not that failures were silently swallowed.
 
 3. Commit on a dedicated branch and open a PR to `main` (this repo squash-merges; do **not** commit
    to `main` directly, and do **not** auto-merge — auto-merge is disabled by ADR-031, the user

--- a/claude/routines/weekly-memory-audit/SKILL.md
+++ b/claude/routines/weekly-memory-audit/SKILL.md
@@ -133,8 +133,13 @@ For every `*.md` file in the memory dir **except `MEMORY.md`**, the subagent mus
 
 The subagent returns a structured findings response with two top-level fields:
 - **`scanned`** (bool, required): `true` if the subagent successfully read and classified the memory
-  files; `false` if it could not (permission error, empty-dir race, unexpected crash). This field
-  distinguishes a "subagent failure" from a legitimate "0 findings" result.
+  files; `false` if it could not (permission error, empty-dir race, unexpected crash). A missing or
+  null `scanned` field is treated as `false`. This field distinguishes a "subagent failure" from a
+  legitimate "0 findings" result.
+- **`reason`** (string, optional): when `scanned` is `false`, a one-line explanation of the failure
+  (e.g., "permission error reading memory dir", "memory dir was empty during scan"). Omit when
+  `scanned: true`. The orchestrator falls back to "subagent returned no data" when this field is
+  absent and the subagent returned nothing at all.
 - **`findings`** (list): one record per memory file with: file name, type, durable? (yes/no),
   instruction-home (path + verified yes/no, or "none"), disposition, a one-line rationale, and
   **for `promote` records additionally**: the rule text (verbatim or tight paraphrase), the suggested
@@ -142,8 +147,9 @@ The subagent returns a structured findings response with two top-level fields:
   empty list when `scanned: false`.
 
 If a subagent returns `scanned: false`, or returns nothing at all, **do not abort the whole run** —
-record the project name and the reason (or "subagent returned no data") in a running not-scanned
-list for Step 5, and continue with a partial report.
+record the project name and the `reason` field value (or "subagent returned no data" if the
+subagent returned nothing) in a running not-scanned list for Step 5, and continue with a partial
+report.
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -454,14 +454,17 @@ Deletion and in-place fixes stay human-in-the-loop via the interactive `/memory-
 - A committed reconciliation report at
   `engineering-journal/sessions/meta/memory-audit/YYYY-MM-DD-audit.md` with a cross-project table
   (project · file · type · durable? · instruction home · drift · disposition), a "Promote issues
-  filed" subsection, and a "Stale / drift / index-drift (report-only)" subsection. Opened as a PR
+  filed" subsection, a "Stale / drift / index-drift (report-only)" subsection, and a "Projects not
+  scanned (subagent failures)" subsection (omitted when every subagent returned `scanned: true` —
+  absent section means no scan failures, not that failures were silently swallowed). Opened as a PR
   to `main` (never auto-merged — ADR-031; the user reviews and merges).
 
 Stale, drift, index-drift, and tracked-pending findings are included in the report but are **not**
 auto-actioned — they require human judgment.
 
 **Resilience:** no-memory-stores exit (push-notify + EXIT 0), per-project subagent failure →
-partial report (does not abort the run), git/PR failure → push-notify + keep draft for recovery.
+accumulated in a not-scanned list (project + reason) and surfaced as a "Projects not scanned"
+table in the report (does not abort the run), git/PR failure → push-notify + keep draft for recovery.
 A push notification summarizes the run on every completion or abort path.
 
 **Dual-copy caveat (dev-env#344):** `claude/routines/weekly-memory-audit/` (version-controlled, via


### PR DESCRIPTION
## Summary

- **Step 2:** Subagent response schema gains a required `scanned` (bool) field alongside `findings`. `scanned: true` = files were classified; `scanned: false` = subagent could not run (crash, permission error, etc.). This makes subagent failures explicitly typed instead of indistinguishable from a clean "0 findings" result. Also adds optional `reason` (string) field so failing subagents can report a specific failure message; missing/null `scanned` is treated as `false`.
- **Step 3:** Aggregation now explicitly excludes `scanned: false` responses from promote routing (they go to the not-scanned list only).
- **Step 5:** Report must include a "Projects not scanned (subagent failures)" table whenever ≥1 subagent returned `scanned: false` or no data. Section is omitted when all subagents succeeded — absence means "no failures", not "failures were silently swallowed".
- **docs/REFERENCE.md:** Updated `### weekly-memory-audit` **Outputs** section to list the new "Projects not scanned" subsection. Updated **Resilience** note to describe the structured not-scanned list.

The live copy (`~/.claude/scheduled-tasks/weekly-memory-audit/SKILL.md`) was updated in-place to match. No PR needed for machine-local files.

## Testing

Only `claude/routines/weekly-memory-audit/SKILL.md` and `docs/REFERENCE.md` changed — Markdown documentation files, not Python scripts. The hook-script syntax check (test 1) was run and passes:

```
Tests: N/A — no .py files modified
```

Syntax check against all unchanged hook scripts: PASS.

Suppression grep: clean (Markdown files, no applicable patterns).
Test-integrity grep: clean.

## Review findings disposition

**/review** posted as [comment](https://github.com/brownm09/dev-env/pull/475#issuecomment-4859452251) — 1 blocking, 1 non-blocking.

| Finding | Disposition |
|---|---|
| **[blocking/documentation]** `docs/REFERENCE.md` Outputs + Resilience sections stale | Fixed in `7af3f8a` — appended "Projects not scanned" subsection to Outputs list; updated Resilience note to describe the structured not-scanned list |
| **[non-blocking/maintainability]** Missing `reason` field in subagent schema; no `scanned`-absent fallback defined | Fixed in `7af3f8a` — added optional `reason` (string) field; added explicit rule that missing/null `scanned` is treated as `false` |

Closes #456