### PR TITLE
fix(hooks): scope merge-reminder repo label to explicit --repo flag

### DIFF
--- a/claude/scripts/pr-merge-reminder.py
+++ b/claude/scripts/pr-merge-reminder.py
@@ -276,7 +276,6 @@ def _effective_push_dir(command: str, cwd: str) -> str:
     return path
 
 
-
 # An explicit `--repo owner/repo` flag names the merge target directly — the
 # highest-confidence signal, ahead of any cd-chain or cwd resolution. Mirrors
 # extract_repo's resolution order in post-pr-merge-pull.py (ADR-067).

--- a/claude/scripts/pr-merge-reminder.py
+++ b/claude/scripts/pr-merge-reminder.py
@@ -276,6 +276,28 @@ def _effective_push_dir(command: str, cwd: str) -> str:
     return path
 
 
+
+# An explicit `--repo owner/repo` flag names the merge target directly — the
+# highest-confidence signal, ahead of any cd-chain or cwd resolution. Mirrors
+# extract_repo's resolution order in post-pr-merge-pull.py (ADR-067).
+_REPO_FLAG_RE = re.compile(r"--repo\s+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)")
+
+
+def _effective_merge_repo(command: str, cwd: str) -> str:
+    """Best-effort repo label for a top-level ``gh pr merge`` in *command*.
+
+    An explicit ``--repo owner/repo`` flag takes precedence over cwd and any
+    ``cd``-chain prefix — e.g. ``gh pr merge 110 --repo other/repo`` run from an
+    unrelated cwd reports ``other/repo``, not the session directory (dev-env#470).
+    Falls back to ``effective_merge_dir(command, cwd)`` (the cd-chain / cwd
+    resolution, ADR-067) when no ``--repo`` flag is present.
+    """
+    m = _REPO_FLAG_RE.search(command)
+    if m:
+        return m.group(1)
+    return effective_merge_dir(command, cwd)
+
+
 def _create_shard_step(output: str) -> str:
     """Return the shard-writing instruction lines for a gh pr create reminder.
 
@@ -367,7 +389,7 @@ def main() -> None:
         )
 
     if is_merge:
-        merge_dir = effective_merge_dir(command, cwd)
+        merge_dir = _effective_merge_repo(command, cwd)
         messages.append(
             "[journal-reminder] gh pr merge detected — update the engineering journal now:\n"
             f"  cwd: {cwd}\n"

--- a/claude/scripts/tests/test_pr_merge_reminder.py
+++ b/claude/scripts/tests/test_pr_merge_reminder.py
@@ -36,6 +36,7 @@ is_git_push_command = pmr.is_git_push_command
 _create_shard_step = pmr._create_shard_step
 _is_successful_merge_call = pmr._is_successful_merge_call
 _effective_push_dir = pmr._effective_push_dir
+_effective_merge_repo = pmr._effective_merge_repo
 
 # read_command_output and effective_merge_dir live in _hookio (a sibling).
 # SCRIPT.parent already on sys.path, so import them directly.
@@ -301,6 +302,44 @@ def test_merge_dir_cd_chain_redirects_for_reminder() -> str:
 
 
 # ---------------------------------------------------------------------------
+# _effective_merge_repo  (dev-env#470)
+# ---------------------------------------------------------------------------
+
+def test_merge_repo_explicit_flag_overrides_cwd() -> str:
+    # The dev-env#470 repro: an explicit --repo run from an unrelated cwd with
+    # no cd-chain must report the flag's repo, not cwd.
+    out = _effective_merge_repo(
+        "gh pr merge 110 --repo brownm09/engineering-journal --squash --delete-branch",
+        "C:\\Users\\brown\\Git\\dev-env",
+    )
+    assert out == "brownm09/engineering-journal", f"got {out!r}"
+    return "gh pr merge --repo other/repo from unrelated cwd -> that repo, not cwd"
+
+
+def test_merge_repo_explicit_flag_overrides_cd_chain() -> str:
+    # --repo is the highest-confidence signal (ADR-067 resolution order) — it
+    # wins even when a cd-chain prefix is also present.
+    out = _effective_merge_repo(
+        "cd /Git/other-repo && gh pr merge 5 --repo brownm09/engineering-journal",
+        "/Git/lifting-logbook",
+    )
+    assert out == "brownm09/engineering-journal", f"got {out!r}"
+    return "cd <other-repo> && gh pr merge --repo X -> X, not the cd-chain dir"
+
+
+def test_merge_repo_no_flag_falls_back_to_effective_merge_dir() -> str:
+    # No --repo flag -> delegate to effective_merge_dir unchanged (bare merge
+    # returns cwd; a cd-chain prefix still redirects).
+    bare = _effective_merge_repo("gh pr merge --squash --delete-branch", "/session/cwd")
+    assert bare == "/session/cwd", f"got {bare!r}"
+    chained = _effective_merge_repo(
+        "cd /Git/dev-env && gh pr merge --squash --delete-branch", "/Git/lifting-logbook"
+    )
+    assert chained == "/Git/dev-env", f"got {chained!r}"
+    return "no --repo flag -> falls back to effective_merge_dir (cwd / cd-chain)"
+
+
+# ---------------------------------------------------------------------------
 # runner
 # ---------------------------------------------------------------------------
 
@@ -335,6 +374,9 @@ def main() -> int:
         ("push dir: cd after push ignored", test_push_dir_cd_after_push_ignored),
         ("merge dir: bare merge -> cwd (reminder unchanged)", test_merge_dir_bare_merge_is_cwd),
         ("merge dir: cd <dev-env> && merge from lb cwd -> dev-env", test_merge_dir_cd_chain_redirects_for_reminder),
+        ("merge repo: --repo flag overrides cwd", test_merge_repo_explicit_flag_overrides_cwd),
+        ("merge repo: --repo flag overrides cd-chain", test_merge_repo_explicit_flag_overrides_cd_chain),
+        ("merge repo: no flag -> falls back to effective_merge_dir", test_merge_repo_no_flag_falls_back_to_effective_merge_dir),
     ]
     failed = 0
     for name, fn in tests:


### PR DESCRIPTION
## Summary
- `pr-merge-reminder.py`'s `gh pr merge` reminder called `effective_merge_dir(command, cwd)` unconditionally, which only resolves a `cd <path> &&` chain prefix or falls back to cwd (ADR-067) - it had no awareness of an explicit `--repo owner/repo` flag.
- `post-pr-merge-pull.py`'s `extract_repo` (also touched by ADR-067) already checks `--repo` *first*, ahead of cd-chain/cwd resolution - this PR ports that same precedence to the reminder's `repo:` line via a new `_effective_merge_repo(command, cwd)` helper, scoped to `pr-merge-reminder.py` only.
- `effective_merge_dir` in `_hookio.py` is untouched - it stays a pure directory-resolution helper for `post-pr-merge-pull.py`'s local-clone `git -C` operations, which need an actual filesystem path, not a GitHub owner/repo label.

## Repro (now fixed)
From `C:\Users\brown\Git\dev-env`:
```
gh pr merge 110 --repo brownm09/engineering-journal --squash --delete-branch
```
Before: reminder printed `repo: C:\Users\brown\Git\dev-env`. After: `repo: brownm09/engineering-journal`.

## Testing
Ran `py -3 claude/scripts/tests/test_pr_merge_reminder.py` (item 28 in dev-env's CLAUDE.md `## Testing` section) - added 3 new cases covering `--repo`-flag precedence (over cwd, over a cd-chain, and the no-flag fallback to `effective_merge_dir`).

Tests: 32 passed, 0 skipped, 0 failed

Also ran the hook-script syntax check (item 1): `py -3 -c "import ast,sys; ..." claude/scripts/*.py` - clean, no output.

Pre-PR suppression/test-integrity greps (both required before `gh pr create`) both exited clean (no matches). No deleted test files. `baseline_test_failure_tracking` is not enabled for dev-env (no `.claude/hook-config.json`) - N/A.

## ADR-warrant
N/A - this is a routine bug fix inside the existing ADR-065/ADR-067 structure (a parity fix: porting `extract_repo`'s already-documented `--repo`-first resolution order to the sibling `pr-merge-reminder.py` call site). It doesn't change, invalidate, or extend either ADR's stated decision or trade-offs, doesn't restructure a `claude/` directory, and doesn't set a new cross-CLAUDE.md workflow rule. Per [ADR-011](https://github.com/brownm09/dev-env/blob/main/docs/adr/011-adr-warrant-check.md)'s own mitigation note, routine bug fixes inside an existing structure are explicitly the case the warrant check should NOT fire on.

## Scope note
Small and self-contained, per the originating task: one function (`_effective_merge_repo`) + one wiring change in `main()` + test coverage. No other dev-env behavior changes.

## Review findings disposition
Per `/review` ([comment](https://github.com/brownm09/dev-env/pull/476#issuecomment-4859459808)): 0 blocking, 2 non-blocking, 1 style note.

- **[style]** Extra blank line before the `_REPO_FLAG_RE` section — **fixed in `ad29711`**.
- **[correctness]** `_REPO_FLAG_RE.search` is unbounded across the whole command string instead of scoped to the `gh pr merge` statement — **filed as [dev-env#482](https://github.com/brownm09/dev-env/issues/482)** (fixing correctly requires bounding the search to the region *after* the merge token, not before, plus updating the sibling `extract_repo` in `post-pr-merge-pull.py` to match — out of scope for this PR's one-function fix).
- **[correctness]** Regex matches only long-form `--repo`, not gh's `-R` shorthand — **filed as [dev-env#482](https://github.com/brownm09/dev-env/issues/482)** (same rationale — fixing only this function would desync it from `extract_repo`, which has the identical gap).

Closes #470
