### PR TITLE
docs: update stale worktree-merge usage-snapshot note

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -641,13 +641,18 @@ pre-merge tooling. This is now auto-corrected: `post-pr-merge-pull.py` parks the
 failed local-checkout tail (above) discarded the snapshot even though the remote merge had
 succeeded. The hook now gates on gh's output success marker instead (`merge_confirmed()`,
 matching `post-pr-merge-project.py`'s marker-based detection) and fires correctly on worktree
-merges — validated in practice merging PR #477 itself, which hit this exact failure and still
-moved dev-env#474's linked issue to Done via the same marker. The snapshot can still be
+merges — confirmed in practice merging PR #477 itself, which hit this exact failure: the real
+payload contained gh's success marker (`post-pr-merge-project.py`, using the same `_hookio`
+dependency, correctly moved dev-env#474's linked issue to Done), and credentials/token were
+independently healthy. `usage-snapshot.py`'s own output was not directly observed in chat (see
+the next note), but it shares the identical marker-detection call. The snapshot can still be
 legitimately absent for reasons unrelated to the worktree-exit-code case: `.credentials.json`
 missing or unparseable, an expired refresh token, or the usage API unreachable after one retry —
 all intentionally silent-or-advisory per the hook's own docstring, not a regression of this fix.
-Separately: a PostToolUse hook's own stderr does not reliably surface to the assistant in chat
-when the *parent* `gh pr merge` call itself is shown as an error (non-zero exit) — confirm a hook
+Separately: a PostToolUse hook's own stderr was not observed to surface to the assistant in chat
+in either of the two instances behind this fix — worth confirming with more data points before
+treating as a firm platform rule — when the *parent* `gh pr merge` call itself is shown as an
+error (non-zero exit); until then, confirm a hook
 actually ran by checking its side effect (e.g. the linked issue's board status) rather than
 assuming absence of visible reminder text means the hook didn't fire.
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -636,10 +636,20 @@ pre-merge tooling. This is now auto-corrected: `post-pr-merge-pull.py` parks the
 `main`), then `git -C ~/Git/dev-env checkout main`. See
 [ADR-058](adr/058-worktree-squatting-main-detection-correction.md) (incident: dev-env#396).
 
-**Secondary effect — no post-merge usage snapshot.** Because the `gh pr merge` invocation exits
-non-zero on the failed local-checkout tail, the `PostToolUse` post-merge hook does **not** emit its
-`### Usage Snapshot (post-merge)` block — it keys off a clean `gh pr merge`. When merging from a
-worktree, expect the snapshot to be absent and capture usage by other means for the journal stub.
+**Secondary effect — no post-merge usage snapshot (fixed by dev-env#474 / PR #477).** Before
+2026-07-01, `usage-snapshot.py` gated on `tool_response.exitCode != 0`, so a worktree merge's
+failed local-checkout tail (above) discarded the snapshot even though the remote merge had
+succeeded. The hook now gates on gh's output success marker instead (`merge_confirmed()`,
+matching `post-pr-merge-project.py`'s marker-based detection) and fires correctly on worktree
+merges — validated in practice merging PR #477 itself, which hit this exact failure and still
+moved dev-env#474's linked issue to Done via the same marker. The snapshot can still be
+legitimately absent for reasons unrelated to the worktree-exit-code case: `.credentials.json`
+missing or unparseable, an expired refresh token, or the usage API unreachable after one retry —
+all intentionally silent-or-advisory per the hook's own docstring, not a regression of this fix.
+Separately: a PostToolUse hook's own stderr does not reliably surface to the assistant in chat
+when the *parent* `gh pr merge` call itself is shown as an error (non-zero exit) — confirm a hook
+actually ran by checking its side effect (e.g. the linked issue's board status) rather than
+assuming absence of visible reminder text means the hook didn't fire.
 
 ### Stacked PR squash-merge sequencing — never `--delete-branch` a base with an open child
 


### PR DESCRIPTION
## Summary

`docs/REFERENCE.md`'s "Merging a PR developed in a worktree" runbook documented the "no post-merge usage snapshot" effect as permanent, expected behavior. That was the symptom of the exit-code-gating bug fixed in dev-env#474 / PR #477 (`usage-snapshot.py` now gates on gh's output success marker, matching `post-pr-merge-project.py`, instead of `tool_response.exitCode`).

Discovered while merging PR #477 itself: it hit this exact worktree-cleanup failure, and `post-pr-merge-project.py` (same marker-based detection) correctly moved dev-env#474's linked issue to Done — confirming the fix's premise in practice and making the existing doc paragraph stale.

Updates the paragraph to:
- Note the fix (linking #474/#477) instead of describing the old behavior as permanent.
- List the *remaining* legitimate silent-exit paths in `usage-snapshot.py` (missing/unparseable credentials, expired refresh token, unreachable usage API) that are unrelated to this fix and still apply.
- Record a separately-observed nuance: a PostToolUse hook's stderr doesn't reliably surface to the assistant in chat when the parent `gh pr merge` call itself is shown as an error — confirm a hook ran via its side effect (e.g. board status), not the absence/presence of visible reminder text.

Closes #483

## Testing

Docs-only change (no `.py` files touched). Ran the standard pre-PR checks anyway:

```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
# all files parse (unaffected by this change)
```

No automated tests apply — pure prose documentation change, no new testable behavior (coverage gate N/A). Suppression grep and test-integrity grep against `origin/main` both clean (no matches, exit 1). `baseline_test_failure_tracking` not enabled for dev-env (N/A).

## ADR-warrant check

N/A — documentation correction only; doesn't touch a rule/hook/skill/settings decision, doesn't restructure a `claude/` directory, doesn't set a new cross-CLAUDE.md rule. The underlying decision (marker-over-exit-code) was already recorded in the ADR-050 amendment landed in PR #477.

## Review findings disposition

`/review` posted at https://github.com/brownm09/dev-env/pull/484#issuecomment-4859581696 (`blocking=0 non_blocking=2`).

- Both non-blocking [documentation] findings (observed-vs-inferred wording precision in the new paragraph) — fixed in `1f817e3`.
