### PR TITLE
fix(claude-md): anchor xit\( test-integrity grep on a word boundary

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -212,7 +212,7 @@ The test-before-PR run must emit a summary of the form `Tests: N passed, N skipp
 **Rule 3 — Pre-PR test-integrity check (required before `gh pr create`).**
 Run this alongside the suppression grep:
 ```bash
-git diff origin/main -- . | grep -E '(it\.skip|xit\(|xdescribe\(|test\.skip|describe\.skip|\.todo\(|pending\(|passWithNoTests|--bail|testPathIgnorePatterns)'
+git diff origin/main -- . | grep -E '(it\.skip|\bxit\(|xdescribe\(|test\.skip|describe\.skip|\.todo\(|pending\(|passWithNoTests|--bail|testPathIgnorePatterns)'
 ```
 Also check for deleted test files and lowered coverage thresholds:
 ```bash

--- a/docs/adr/029-test-integrity-policy.md
+++ b/docs/adr/029-test-integrity-policy.md
@@ -66,6 +66,23 @@ A *test integrity violation* is defined as: adding a skip marker, deleting a tes
 
 ---
 
+## Amendment (2026-07-01) — word-boundary fix for the `xit\(` false positive
+
+Rule 3's grep pattern used bare `xit\(` to catch Mocha's `xit(` skip function. Because the check is a plain substring match, `xit\(` also matches inside any identifier ending in `...exit(` — most commonly Python's `exit(` / `sys.exit(` / `os._exit(` calls used throughout this repo's hook scripts as part of the safe-exit-guard convention, and any function name ending in `_exit(` (e.g. `..._on_clean_exit()`).
+
+This produced real false positives, each requiring a manual "these are not skip markers" note in the PR body: [dev-env#493](https://github.com/brownm09/dev-env/pull/493) (`sys.exit(0)`) and [dev-env#497](https://github.com/brownm09/dev-env/pull/497) (`sys.exit(0)` plus a `..._on_clean_exit()` function name).
+
+Fix: anchor the pattern on a word boundary — `\bxit\(` instead of `xit\(` — using GNU grep's `\b` extension (available in `-E` mode; confirmed on this repo's Git Bash / GNU grep). Verified empirically:
+
+```
+$ printf 'sys.exit(0)\nos._exit(1)\ndef clean_exit():\n  xit(%s\n' "'foo', () => {})" | grep -E '\bxit\('
+  xit('foo', () => {})
+```
+
+`sys.exit(0)`, `os._exit(1)`, and `clean_exit():` no longer match — there is no word boundary between `e` and `x` in either case — while a real Mocha `xit(` call still matches, since it is always preceded by whitespace, a quote, a paren, or line start, never by another word character. `claude/CLAUDE.md` Rule 3 was updated to `\bxit\(`; this ADR's original Decision code block above is left unchanged as the historical record. See [dev-env#501](https://github.com/brownm09/dev-env/issues/501).
+
+---
+
 ## References
 
 - [ADR-022 — Test Coverage Gate Before PR](022-test-coverage-gate-before-pr.md) — companion gate for *missing* tests on new behavior

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -33,7 +33,7 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [026](026-suppression-policy.md) | Suppression Policy: No Silent Workarounds for Type and Lint Errors | 2026-05-24 | Accepted | code-quality, typescript, eslint, workflow, suppression, pre-pr |
 | [027](027-userpromptsubmit-blocking-hook-conventions.md) | UserPromptSubmit Hook Output: stderr for Blocking, Per-Session Marker Files | 2026-05-27 | Accepted | hooks, UserPromptSubmit, stderr, per-session-state, claude-code-contract |
 | [028](028-all-findings-merge-gate.md) | All-Findings Merge Gate: Address Blocking and Non-Blocking Before Merge | 2026-05-27 | Accepted | review, workflow, git, pr, blocking-rule, non-blocking |
-| [029](029-test-integrity-policy.md) | Test Integrity Policy: No Silent Degradation of Existing Tests | 2026-05-27 | Accepted | testing, quality, review, suppression-parallel, workflow, pre-pr |
+| [029](029-test-integrity-policy.md) | Test Integrity Policy: No Silent Degradation of Existing Tests | 2026-05-27 (amended 2026-07-01) | Accepted | testing, quality, review, suppression-parallel, workflow, pre-pr, regex-false-positive |
 | [030](030-baseline-test-failure-policy.md) | Pre-existing Test Failure Policy: Baseline + Fix-on-Touch | 2026-05-27 | Accepted | testing, quality, pre-pr, baseline, fix-on-touch, workflow |
 | [031](031-auto-merge-disabled.md) | Auto-Merge Disabled Across All Repos | 2026-05-28 | Accepted | git, pr, merge, workflow, hooks, post-merge |
 | [032](032-journal-start-here-dashboard.md) | Top-of-README "Start here" Dashboard in journal-compose | 2026-05-28 | Accepted | journal, composition, skill, readme, manifest, dashboard |


### PR DESCRIPTION
## Summary

- Rule 3's pre-PR test-integrity grep (`claude/CLAUDE.md` → Code Quality → Test integrity policy) used bare `xit\(` to catch Mocha's `xit(` skip function. Because the check is a plain substring match, `xit\(` also matches inside any identifier ending in `...exit(` — Python's `exit(`/`sys.exit(`/`os._exit(` calls (this repo's standard hook-script safe-exit-guard idiom) and any `_exit(`-suffixed function name. Confirmed twice today: [#493](https://github.com/brownm09/dev-env/pull/493) (`sys.exit(0)`) and [#497](https://github.com/brownm09/dev-env/pull/497) (`sys.exit(0)` + `..._on_clean_exit()`).
- Fix: anchor the pattern on a word boundary, `\bxit\(` instead of `xit\(`, using GNU grep's `\b` extension (available in `-E` mode). There is no word boundary between `e` and `x` in `exit(`/`_exit(` (both word characters), so `\bxit\(` no longer matches Python's exit calls, while a real Mocha `xit(` — always preceded by whitespace, a quote, a paren, or line start — still does.
- Docs: amended [ADR-029](docs/adr/029-test-integrity-policy.md) with a dated `## Amendment (2026-07-01)` section documenting the false-positive history and empirical verification (leaving the original Decision code block untouched as the historical record, matching today's ADR-003/050/058 amendment pattern), and updated `docs/adr/INDEX.md`'s ADR-029 row date.

Closes #501

## Testing

This is a docs-only change to `claude/CLAUDE.md` + `docs/adr/`. No hook script (`.py`) was touched, so none of dev-env's `## Testing` items 1–33 apply beyond the docs-only guard. No automated suite targets this policy's grep pattern (confirmed — none of the 33 items exercise it; it's a manually-run documented command, not a script).

1. **Docs-only guard** (required for `claude/CLAUDE.md` changes): `grep -n 'date -u' claude/CLAUDE.md` → 0 matches. Vacuously clean.
2. **Manual empirical verification** of the fix:
   ```
   $ printf 'sys.exit(0)\nos._exit(1)\ndef clean_exit():\n  xit(%s\n' "'foo', () => {})" | grep -E '\bxit\('
     xit('foo', () => {})
   ```
   `sys.exit(0)`, `os._exit(1)`, and `clean_exit():` no longer match; a real `xit(` call still does.

**Tests: N/A — no automated suite covers this markdown text; verified manually as above.**

### Suppression / test-integrity pre-PR greps (CLAUDE.md Code Quality)

- Suppression grep: no matches.
- Deleted-test-files check / coverage-threshold check: no matches (no test files or jest/coverage config touched).
- Test-integrity grep (with the new `\bxit\(` pattern): **matches, expected** — this diff is *about* the `xit\(` pattern, so it necessarily contains the literal strings `xit\(`, `xit(`, and `clean_exit():` in the old/new grep-command lines and in the ADR-029 amendment prose that documents the fix. These are documentation text discussing the pattern, not actual skip markers or test code — there is no test framework of any kind in this repo for a real violation to occur in. Same rationale as the “Scope note” already in Rule 3, and the same self-referential-match shape as any diff that edits this exact grep line.

## ADR-warrant

Amended [ADR-029](docs/adr/029-test-integrity-policy.md) in this PR — it already owns the test-integrity grep pattern this fix corrects, so this is the natural home for the correction rather than a new ADR. Updated `docs/adr/INDEX.md` accordingly.
