### PR TITLE
refactor(hooks): consolidate usage-snapshot.py and post-pr-merge-project.py onto shared scan_top_level

### DIFF
--- a/claude/scripts/post-pr-merge-project.py
+++ b/claude/scripts/post-pr-merge-project.py
@@ -41,12 +41,12 @@ from _hookio import (
     merge_pr_number_from_output,
     output_has_merge_marker,
     read_command_output,
+    scan_top_level,
     should_confirm_via_gh,
 )
 
 CONFIG_FILE = ".claude/hook-config.json"
 
-# _scan_top_level and helpers below are duplicated from pr-merge-reminder.py.
 _MERGE_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+merge\b")
 _CLOSES_RE = re.compile(r"(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
 _PR_URL_RE = re.compile(r"https://github\.com/\S+/pull/(\d+)")
@@ -59,114 +59,6 @@ _MERGE_ARGS_RE = re.compile(r"\bgh\s+pr\s+merge\b([^\n;|&]*)")
 
 def _check_merge_stmt(token: str) -> bool:
     return bool(_MERGE_RE.match(token.lstrip()))
-
-
-def _find_heredoc_end(cmd: str, start: int) -> int:
-    n = len(cmd)
-    i = start + 2
-    strip_tabs = False
-    if i < n and cmd[i] == "-":
-        strip_tabs = True
-        i += 1
-    quote: str | None = None
-    if i < n and cmd[i] in ("'", '"'):
-        quote = cmd[i]
-        i += 1
-    stop_chars = "\n\r" + (quote or "")
-    delim_start = i
-    while i < n and cmd[i] not in stop_chars:
-        i += 1
-    delimiter = cmd[delim_start:i]
-    if quote and i < n and cmd[i] == quote:
-        i += 1
-    while i < n and cmd[i] not in ("\n", "\r"):
-        i += 1
-    if i < n:
-        i += 1
-    while i < n:
-        line_start = i
-        if strip_tabs:
-            while i < n and cmd[i] == "\t":
-                i += 1
-            line_start = i
-        while i < n and cmd[i] not in ("\n", "\r"):
-            i += 1
-        if cmd[line_start:i] == delimiter:
-            if i < n:
-                i += 1
-            return i
-        if i < n:
-            i += 1
-    return i
-
-
-def _scan_top_level(command: str) -> bool:
-    """Return True when command contains a top-level `gh pr merge` statement."""
-    n = len(command)
-    i = 0
-    stmt_start = 0
-    stack = ["top"]
-
-    while i < n:
-        c = command[i]
-        state = stack[-1]
-
-        if state == "single":
-            if c == "'":
-                stack.pop()
-        elif state == "double":
-            if c == "\\" and i + 1 < n:
-                i += 1
-            elif c == '"':
-                stack.pop()
-            elif c == "$" and i + 1 < n and command[i + 1] == "(":
-                stack.append("subshell")
-                i += 1
-        elif state == "subshell":
-            if c == ")":
-                stack.pop()
-            elif c == "'":
-                stack.append("single")
-            elif c == '"':
-                stack.append("double")
-            elif c == "$" and i + 1 < n and command[i + 1] == "(":
-                stack.append("subshell")
-                i += 1
-            elif c == "(":
-                stack.append("subshell")
-            elif c == "<" and i + 1 < n and command[i + 1] == "<":
-                i = _find_heredoc_end(command, i)
-                continue
-        else:  # top
-            if c == "'":
-                stack.append("single")
-            elif c == '"':
-                stack.append("double")
-            elif c == "$" and i + 1 < n and command[i + 1] == "(":
-                stack.append("subshell")
-                i += 1
-            elif c == "<" and i + 1 < n and command[i + 1] == "<":
-                i = _find_heredoc_end(command, i)
-                continue
-            elif c in (";", "\n"):
-                if _check_merge_stmt(command[stmt_start:i]):
-                    return True
-                stmt_start = i + 1
-            elif c == "&" and i + 1 < n and command[i + 1] == "&":
-                if _check_merge_stmt(command[stmt_start:i]):
-                    return True
-                stmt_start = i + 2
-                i += 1
-            elif c == "|" and i + 1 < n and command[i + 1] == "|":
-                if _check_merge_stmt(command[stmt_start:i]):
-                    return True
-                stmt_start = i + 2
-                i += 1
-        i += 1
-
-    if stack == ["top"]:
-        return _check_merge_stmt(command[stmt_start:])
-    return False
 
 
 def load_config(cwd: str) -> dict | None:
@@ -312,7 +204,7 @@ def main() -> None:
         sys.exit(0)
 
     command = data.get("tool_input", {}).get("command", "")
-    if not _scan_top_level(command):
+    if not scan_top_level(command, _check_merge_stmt):
         sys.exit(0)
 
     output = read_command_output(data)

--- a/claude/scripts/usage-snapshot.py
+++ b/claude/scripts/usage-snapshot.py
@@ -38,7 +38,7 @@ import urllib.error
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-from _hookio import output_has_merge_marker, read_command_output
+from _hookio import output_has_merge_marker, read_command_output, scan_top_level
 
 CREDS_PATH = "C:/Users/brown/.claude/.credentials.json"
 CONFIG_PATH = "C:/Users/brown/Git/dev-env/claude/usage-config.json"
@@ -56,111 +56,6 @@ def _check_merge_stmt(token: str) -> bool:
     return bool(_MERGE_RE.match(token.lstrip()))
 
 
-def _find_heredoc_end(cmd: str, start: int) -> int:
-    n = len(cmd)
-    i = start + 2
-    strip_tabs = False
-    if i < n and cmd[i] == "-":
-        strip_tabs = True
-        i += 1
-    quote: str | None = None
-    if i < n and cmd[i] in ("'", '"'):
-        quote = cmd[i]
-        i += 1
-    stop_chars = "\n\r" + (quote or "")
-    delim_start = i
-    while i < n and cmd[i] not in stop_chars:
-        i += 1
-    delimiter = cmd[delim_start:i]
-    if quote and i < n and cmd[i] == quote:
-        i += 1
-    while i < n and cmd[i] not in ("\n", "\r"):
-        i += 1
-    if i < n:
-        i += 1
-    while i < n:
-        line_start = i
-        if strip_tabs:
-            while i < n and cmd[i] == "\t":
-                i += 1
-            line_start = i
-        while i < n and cmd[i] not in ("\n", "\r"):
-            i += 1
-        if cmd[line_start:i] == delimiter:
-            if i < n:
-                i += 1
-            return i
-        if i < n:
-            i += 1
-    return i
-
-
-def _scan_top_level(command: str) -> bool:
-    """Return True when command contains a top-level `gh pr merge` statement."""
-    n = len(command)
-    i = 0
-    stmt_start = 0
-    stack = ["top"]
-    while i < n:
-        c = command[i]
-        state = stack[-1]
-        if state == "single":
-            if c == "'":
-                stack.pop()
-        elif state == "double":
-            if c == "\\" and i + 1 < n:
-                i += 1
-            elif c == '"':
-                stack.pop()
-            elif c == "$" and i + 1 < n and command[i + 1] == "(":
-                stack.append("subshell")
-                i += 1
-        elif state == "subshell":
-            if c == ")":
-                stack.pop()
-            elif c == "'":
-                stack.append("single")
-            elif c == '"':
-                stack.append("double")
-            elif c == "$" and i + 1 < n and command[i + 1] == "(":
-                stack.append("subshell")
-                i += 1
-            elif c == "(":
-                stack.append("subshell")
-            elif c == "<" and i + 1 < n and command[i + 1] == "<":
-                i = _find_heredoc_end(command, i)
-                continue
-        else:  # top
-            if c == "'":
-                stack.append("single")
-            elif c == '"':
-                stack.append("double")
-            elif c == "$" and i + 1 < n and command[i + 1] == "(":
-                stack.append("subshell")
-                i += 1
-            elif c == "<" and i + 1 < n and command[i + 1] == "<":
-                i = _find_heredoc_end(command, i)
-                continue
-            elif c in (";", "\n"):
-                if _check_merge_stmt(command[stmt_start:i]):
-                    return True
-                stmt_start = i + 1
-            elif c == "&" and i + 1 < n and command[i + 1] == "&":
-                if _check_merge_stmt(command[stmt_start:i]):
-                    return True
-                stmt_start = i + 2
-                i += 1
-            elif c == "|" and i + 1 < n and command[i + 1] == "|":
-                if _check_merge_stmt(command[stmt_start:i]):
-                    return True
-                stmt_start = i + 2
-                i += 1
-        i += 1
-    if stack == ["top"]:
-        return _check_merge_stmt(command[stmt_start:])
-    return False
-
-
 def merge_confirmed(command: str, output: str) -> bool:
     """Return True iff *command* is a top-level `gh pr merge` whose *output*
     confirms a completed merge via gh's success marker.
@@ -173,7 +68,7 @@ def merge_confirmed(command: str, output: str) -> bool:
     this repo (dev-env#474; mirrors post-pr-merge-project.py's
     merge_succeeded(), see ADR-049/ADR-050).
     """
-    return _scan_top_level(command) and output_has_merge_marker(output)
+    return scan_top_level(command, _check_merge_stmt) and output_has_merge_marker(output)
 
 
 # --- credentials ---

--- a/docs/adr/050-shared-hookio-sibling-hook-fixes.md
+++ b/docs/adr/050-shared-hookio-sibling-hook-fixes.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-21
 **Status:** Accepted
-**Amended:** 2026-07-01, 2026-07-02 (five amendments — see Amendment sections below)
+**Amended:** 2026-07-01, 2026-07-02 (six amendments — see Amendment sections below)
 **Tags:** hooks, post-tool-use, tool_response, payload, github-project, automation, reliability, dry, usage-snapshot, pr-merge-reminder, gh-pr-view, api-fallback, message-dispatch, top-level-statement-scan, issue-create, false-positive, command-parsing, heredoc, regex
 
 ---
@@ -305,3 +305,49 @@ standing invitation to check whether every sibling hook that does the same *kind
 command output; detect a specific CLI invocation) has the same fix — the sweep in Amendment 1 found
 one missed sibling for the output-reading fix; this amendment is that same sweep for the
 statement-scanning fix, one release later.
+
+## Amendment 6 (2026-07-02) — completing the sweep: `usage-snapshot.py` and `post-pr-merge-project.py`
+
+Amendment 5 promoted `scan_top_level` out of `pr-merge-reminder.py` and wired it into
+`post-tool-use.py`, but did not touch two other hooks that had independently reinvented the same
+parser before Amendment 5 ever existed. `/review` of Amendment 5's own PR ([#508](https://github.com/brownm09/dev-env/pull/508))
+surfaced them:
+
+- **`usage-snapshot.py`** carried its own `_find_heredoc_end` plus a merge-only
+  `_scan_top_level(command: str) -> bool`, hardcoded to `_check_merge_stmt` rather than
+  parameterized.
+- **`post-pr-merge-project.py`** carried the identical shape, with a comment that admitted it
+  outright: `# _scan_top_level and helpers below are duplicated from pr-merge-reminder.py.`
+
+**Symptom (dev-env#509):** no functional bug — both local copies handled `;`, `\n`, `&&`, `||`,
+single/double quotes, `$()` subshells, and heredoc bodies identically to the by-then-shared
+`_hookio.scan_top_level`. The issue was purely the drift `scan_top_level` was created to end: two
+more hand-maintained copies of a ~100-line stack-based parser, invisible to Amendment 5's sweep
+because neither hook was on ADR-049's original four-sibling list (both were fixed later — in
+Amendment 1 and the base decision, respectively — for the unrelated output-reading bug) and
+Amendment 5 scoped its own sweep to `post-tool-use.py` alone.
+
+**Fix:** for each of the two files — import `scan_top_level` from `_hookio` in place of the local
+`_scan_top_level` definition; delete the now-redundant local `_find_heredoc_end`; change the call
+site from `_scan_top_level(command)` to `scan_top_level(command, _check_merge_stmt)`, using the
+`_check_merge_stmt` predicate each file already defined for its own single-purpose regex match.
+Behavior-preserving by construction — the two local copies and the shared engine were verified
+character-for-character equivalent in control flow before this PR, so this is deletion of dead
+duplication, not a rewrite. `post-pr-merge-project.py` also drops its now-inaccurate "duplicated
+from pr-merge-reminder.py" comment.
+
+**Coverage:** `test_usage_snapshot.py` and `test_post_pr_merge_project.py` exercise only the public
+`merge_confirmed()` / `merge_succeeded()` and extraction helpers, never the private
+`_scan_top_level` / `_find_heredoc_end` names directly, so both suites pass unchanged — confirming
+the refactor is behavior-preserving rather than requiring test updates. `test_hookio.py`'s existing
+`scan_top_level` coverage (Amendment 5) now backs all four hooks that need top-level statement
+scanning (`pr-merge-reminder.py`, `post-tool-use.py`, `usage-snapshot.py`,
+`post-pr-merge-project.py`) from one implementation.
+
+**General lesson (continuing Amendments 1 and 5's):** a sweep is only as complete as the list it
+started from. Amendment 5's sweep was scoped to "hooks needing `gh pr create` detection like
+`pr-merge-reminder.py`," which correctly caught `post-tool-use.py` but missed two hooks whose need
+was narrower (merge detection only), so their duplication didn't look like the same shape at a
+glance. Generalized: when consolidating a cross-hook utility, grep for the *engine* (the parser
+body itself), not just the *call pattern* that motivated the current fix — the two would have
+surfaced together.


### PR DESCRIPTION
## Summary

- `claude/scripts/usage-snapshot.py` and `claude/scripts/post-pr-merge-project.py` each carried their own independent, near-identical copy of `_find_heredoc_end` + a merge-only `_scan_top_level(command: str) -> bool` (hardcoded to `_check_merge_stmt`, not parameterized), predating dev-env#499 / PR #508's extraction of that exact parser into a shared, parameterized `scan_top_level(command, check_fn)` in `claude/scripts/_hookio.py` (ADR-050 Amendment 5).
- Both files now import `scan_top_level` from `_hookio` and call it as `scan_top_level(command, _check_merge_stmt)`, using the `_check_merge_stmt` predicate each file already defined. The local `_find_heredoc_end`/`_scan_top_level` duplicates are removed, along with `post-pr-merge-project.py`'s now-inaccurate "duplicated from pr-merge-reminder.py" comment.
- Behavior-preserving by construction — verified during #508's review that both local scanners handle `;`, `\n`, `&&`, `||`, single/double quotes, `$()` subshells, and heredoc bodies identically to the shared engine.
- Adds ADR-050 Amendment 6 documenting completion of the sweep Amendment 5 started (`docs/adr/050-shared-hookio-sibling-hook-fixes.md`).

Closes #509

## Testing

Ran the dev-env `## Testing` items relevant to this change (hook-script syntax check, plus the three test suites covering the touched code):

```
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
py -3 claude/scripts/tests/test_usage_snapshot.py
py -3 claude/scripts/tests/test_post_pr_merge_project.py
py -3 claude/scripts/tests/test_hookio.py
```

- Syntax check: clean, no errors.
- `test_usage_snapshot.py` — Tests: 11 passed, 0 skipped, 0 failed
- `test_post_pr_merge_project.py` — Tests: 16 passed, 0 skipped, 0 failed
- `test_hookio.py` — Tests: 31 passed, 0 skipped, 0 failed

All three suites exercise only the public surface (`merge_confirmed()`, `merge_succeeded()`, extraction helpers, `scan_top_level()` itself) — neither suite references the removed private `_scan_top_level`/`_find_heredoc_end` names directly, so both pass unchanged with no test edits, confirming the refactor is behavior-preserving.

Pre-PR suppression grep, test-integrity grep, and deleted-test-file check all ran clean (no matches).

## ADR

Added **Amendment 6** to [ADR-050](https://github.com/brownm09/dev-env/blob/main/docs/adr/050-shared-hookio-sibling-hook-fixes.md) — this change touches hook scripts already documented under that ADR, whose established amendment pattern (Amendments 1 and 5) explicitly records each "sweep found one more sibling" case. This amendment closes out the `scan_top_level` consolidation across all four PostToolUse hooks that need top-level statement scanning.