### PR TITLE
docs: calibrate hook-stderr-visibility claim to confirmed symptom, open mechanism

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -665,12 +665,21 @@ the next note), but it shares the identical marker-detection call. The snapshot 
 legitimately absent for reasons unrelated to the worktree-exit-code case: `.credentials.json`
 missing or unparseable, an expired refresh token, or the usage API unreachable after one retry —
 all intentionally silent-or-advisory per the hook's own docstring, not a regression of this fix.
-Separately: a PostToolUse hook's own stderr was not observed to surface to the assistant in chat
-in either of the two instances behind this fix — worth confirming with more data points before
-treating as a firm platform rule — when the *parent* `gh pr merge` call itself is shown as an
-error (non-zero exit); until then, confirm a hook
-actually ran by checking its side effect (e.g. the linked issue's board status) rather than
-assuming absence of visible reminder text means the hook didn't fire.
+Separately: the observed *symptom* — no PostToolUse hook output surfacing in chat when the
+*parent* `gh pr merge` call itself is shown as an error (non-zero exit) — has now recurred in all
+three occurrences examined (the two instances behind this fix, plus dev-env PR #512 on
+2026-07-02). The *mechanism* remains unconfirmed and is likely confounded rather than a distinct
+platform behavior: gh's own stdout success marker is independently known to be lost on this exact
+failure path (dev-env#489, root-caused), the `gh pr view` fallback that works around that covers
+only 1 of the 6 marker-gated hooks (dev-env#504, open), and even that one hook's silence is
+inconclusive on its own — the fallback could race or fail silently rather than its stderr being
+dropped (dev-env#498, open). No occurrence yet isolates a hook whose merge-detection is
+independently known to have succeeded — not just inferred from a Done-status that GitHub's native
+close automation equally explains — with its stderr still failing to surface (dev-env#521). Until
+dev-env#498/#504 resolve that ambiguity, confirm a hook actually ran by checking its side effect
+(e.g. the linked issue's board status) rather than assuming absence of visible reminder text means
+the hook didn't fire — and don't over-read that absence as proof the hook's stderr specifically
+was dropped.
 
 ### Stacked PR squash-merge sequencing — never `--delete-branch` a base with an open child
 


### PR DESCRIPTION
## Summary

`docs/REFERENCE.md` → "Merging a PR developed in a worktree" → "Secondary effect" carried an
unconfirmed claim: a PostToolUse hook's own stderr "was not observed to surface to the assistant
in chat" when the parent `gh pr merge` errors, based on two instances, flagged as "worth confirming
with more data points." Merging dev-env PR #512 (2026-07-02) produced a third occurrence of the
same silence — but tracing it (dev-env#521) showed the claim was never actually isolated from a
simpler, already-diagnosed explanation:

- gh's own stdout success marker is independently known to be lost on this exact failure path
  (dev-env#489, root-caused).
- The `gh pr view` fallback that works around that covers only 1 of the 6 marker-gated hooks
  (dev-env#504, still open) — for the other 5, silence is fully explained by "marker never
  arrived, nothing to report," no dropped stderr required.
- Even the 1 hook with the fallback is inconclusive on its own silence (dev-env#498, still open):
  the fallback could race/fail rather than its stderr being dropped, and a Done-status is equally
  explained by GitHub's native close automation.

No occurrence recorded anywhere in this family isolates a hook whose merge-detection is
independently *known* to have succeeded, with its stderr still failing to surface. This PR
rewords the note to confirm only what's actually confirmed — the *symptom* (zero visible output,
3 for 3 so far) — while stating the *mechanism* is open and cross-linking dev-env#489/#498/#504/#521.
The existing operational advice (verify via side effect, not absence of visible text) is kept
unchanged.

## ADR-warrant check

N/A — no new architectural decision, no hook/skill/settings behavior change. This is a wording
calibration to an existing runbook note, fully covered by the existing ADR-050 (+ amendments)
family, which is already the documented home for this hook-output-reliability saga. The follow-up
investigation that would actually resolve the open mechanism question is tracked in dev-env#498
and dev-env#504, not a new ADR.

## Testing

Docs-only change (`docs/REFERENCE.md`, one paragraph) — no hook/script code touched, no new
testable behavior, dev-env has no `.claude/hook-config.json` (baseline test-failure tracking is
not opted in). Ran as general sanity/regression checks:

- Hook-script syntax check (`ast.parse` over `claude/scripts/*.py`) — passed, unaffected by this
  change as expected.
- Suppression + test-integrity grep (`git diff origin/main`) — no matches.

Tests: N/A — no automated test suite covers prose content in `docs/REFERENCE.md`; verification was
manual re-read of the edited paragraph plus the greps above.

Closes #521
