### PR TITLE
fix(hooks): migrate pre-merge-message-check/pre-merge-findings-gate to scan_top_level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,8 +575,8 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     Two layers, mirroring this hook family's established split. A pure-helper Python test exercises
     `is_pr_merge_command` offline (built on the shared `_hookio.scan_top_level`, matching
     `pre-merge-numbering-check.py`'s and `pre-merge-message-check.py`'s identically-named predicate —
-    dev-env#519): pins a bare and a `cd`-chained top-level `gh pr merge` match, and that a non-merge
-    command or a `gh pr merge` mentioned only inside a heredoc body (dev-env#499) does not match, so
+    dev-env#519): pins a bare, `&&`-chained, and `cd`-chained top-level `gh pr merge` match, and that
+    a non-merge command or a `gh pr merge` mentioned only inside a heredoc body (dev-env#499) does not match, so
     the hook's live `gh pr view` call is never paid for a command that never actually merges. A
     behavioral shell test drives the real hook end-to-end via the `MERGE_GATE_TEST_JSON` seam (no
     live `gh`, no network): pins the clean-review / open-findings-blocked / disposition-recorded /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,12 +315,14 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     ```
 
 24. **pre-merge-message-check test** — required when changing `claude/scripts/pre-merge-message-check.py`.
-    Exercises the pure `_GH_PR_MERGE_RE` regex and the `_read_queue()` helper offline (tmp files for
-    queue content; no network, no gh): pins that the merge-detection regex fires on bare / flagged /
-    chained `gh pr merge` invocations and stays silent on non-merge commands, that `_read_queue` returns
-    content verbatim, returns `""` for an empty or whitespace-only file, and returns `""` when the queue
-    file is absent (fail-open). The stdin plumbing and exit-2 emission are not covered (pure-helper
-    convention). ([ADR-061](docs/adr/061-pre-merge-message-queue.md))
+    Exercises the pure `is_pr_merge_command` predicate (built on the shared `_hookio.scan_top_level`,
+    matching `pre-merge-numbering-check.py`'s identically-named predicate — dev-env#519) and the
+    `_read_queue()` helper offline (tmp files for queue content; no network, no gh): pins that
+    detection fires on a bare / flagged / chained / `cd`-chained `gh pr merge` invocation and stays
+    silent on a non-merge command or a `gh pr merge` mentioned only inside a heredoc body
+    (dev-env#499), that `_read_queue` returns content verbatim, returns `""` for an empty or
+    whitespace-only file, and returns `""` when the queue file is absent (fail-open). The stdin
+    plumbing and exit-2 emission are not covered (pure-helper convention). ([ADR-061](docs/adr/061-pre-merge-message-queue.md))
 
     ```bash
     py -3 claude/scripts/tests/test_pre_merge_message_check.py
@@ -567,6 +569,25 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
 
     ```bash
     py -3 claude/scripts/tests/test_pre_merge_numbering_check.py
+    ```
+
+38. **pre-merge-findings-gate test** — required when changing `claude/scripts/pre-merge-findings-gate.py`.
+    Two layers, mirroring this hook family's established split. A pure-helper Python test exercises
+    `is_pr_merge_command` offline (built on the shared `_hookio.scan_top_level`, matching
+    `pre-merge-numbering-check.py`'s and `pre-merge-message-check.py`'s identically-named predicate —
+    dev-env#519): pins a bare and a `cd`-chained top-level `gh pr merge` match, and that a non-merge
+    command or a `gh pr merge` mentioned only inside a heredoc body (dev-env#499) does not match, so
+    the hook's live `gh pr view` call is never paid for a command that never actually merges. A
+    behavioral shell test drives the real hook end-to-end via the `MERGE_GATE_TEST_JSON` seam (no
+    live `gh`, no network): pins the clean-review / open-findings-blocked / disposition-recorded /
+    no-review-marker / gh-failure-fail-open / non-merge-command decision paths, and that `--repo` and
+    `--repo=` both parse to the right repo in `_parse_merge_target`. The shell test file pre-dates
+    this list — added here (alongside the new pure-helper file) to close the gap where it existed but
+    was never cross-referenced ([ADR-028](docs/adr/028-all-findings-merge-gate.md), [ADR-039](docs/adr/039-merge-gate-findings-enforcement.md)).
+
+    ```bash
+    py -3 claude/scripts/tests/test_pre_merge_findings_gate.py
+    bash claude/scripts/tests/test-merge-findings-gate.sh
     ```
 
 ## Observability

--- a/claude/scripts/pre-merge-findings-gate.py
+++ b/claude/scripts/pre-merge-findings-gate.py
@@ -27,6 +27,13 @@ Fails OPEN: any error resolving or fetching the PR exits 0 with an advisory
 systemMessage, so a transient `gh`/network problem never wedges a legitimate
 merge. The gate is one layer; CLAUDE.md and the reviewer remain responsible.
 
+Merge detection is built on `_hookio.scan_top_level` (dev-env#519), the same
+quote/subshell/heredoc-aware engine `pre-merge-numbering-check.py` and
+`pr-merge-reminder.py` already use — not a plain unanchored `re.search` over
+the whole command string, which could spuriously fire on a `gh pr merge`
+mentioned only inside a heredoc body or `$()` subshell (dev-env#499) and pay
+this hook's live `gh pr view` call for a command that never actually merges.
+
 Stdin JSON shape (PreToolUse): {"tool_name":"Bash","tool_input":{"command":...},"cwd":...}
 
 Exit 2 — block the merge (stderr shown to Claude).
@@ -39,7 +46,9 @@ import re
 import subprocess
 import sys
 
-_GH_PR_MERGE_RE = re.compile(r"(?:^|&&|\|+|;|\n)\s*gh\s+pr\s+merge\b")
+from _hookio import scan_top_level
+
+_MERGE_STMT_RE = re.compile(r"gh\s+pr\s+merge\b")
 _MARKER_RE = re.compile(
     r"<!--\s*review-findings:\s*blocking\s*=\s*(\d+)\s+non_blocking\s*=\s*(\d+)\s*-->"
 )
@@ -50,6 +59,19 @@ _DISPOSED_RE = re.compile(r"findings[\s\-]dispos", re.IGNORECASE)
 # Flags to `gh pr merge` that consume the following token as their value.
 _VALUE_FLAGS = {"--repo", "-R", "-b", "--body", "-t", "--subject", "--match-head-commit",
                 "--author-email"}
+
+
+def _check_merge_stmt(token):
+    return bool(_MERGE_STMT_RE.match(token.lstrip()))
+
+
+def is_pr_merge_command(command):
+    """True iff *command* contains a top-level `gh pr merge` -- i.e. not one
+    merely mentioned inside a quoted string, $() subshell, or heredoc body
+    (dev-env#499). Mirrors `pre-merge-numbering-check.py`'s identically-named
+    predicate (dev-env#519).
+    """
+    return scan_top_level(command, _check_merge_stmt)
 
 
 def _parse_merge_target(command):
@@ -136,7 +158,7 @@ def main() -> None:
     if data.get("tool_name") != "Bash":
         sys.exit(0)
     command = data.get("tool_input", {}).get("command", "")
-    if not _GH_PR_MERGE_RE.search(command):
+    if not is_pr_merge_command(command):
         sys.exit(0)
 
     cwd = data.get("cwd", "") or None

--- a/claude/scripts/pre-merge-message-check.py
+++ b/claude/scripts/pre-merge-message-check.py
@@ -14,6 +14,12 @@ then re-attempts the merge.
 Fails OPEN: any I/O or JSON error exits 0 so a misconfigured queue file never
 permanently wedges a merge.
 
+Merge detection is built on `_hookio.scan_top_level` (dev-env#519), the same
+quote/subshell/heredoc-aware engine `pre-merge-numbering-check.py` and
+`pr-merge-reminder.py` already use — not a plain unanchored `re.search` over
+the whole command string, which could spuriously fire on a `gh pr merge`
+mentioned only inside a heredoc body or `$()` subshell (dev-env#499).
+
 Stdin JSON shape (PreToolUse): {"tool_name":"Bash","tool_input":{"command":...},"cwd":...}
 
 Exit 2 — block the merge and show queued messages (queue has content).
@@ -24,8 +30,23 @@ import json
 import re
 import sys
 
+from _hookio import scan_top_level
+
 _QUEUE_FILE = "C:/Users/brown/.claude/merge-queue.md"
-_GH_PR_MERGE_RE = re.compile(r"(?:^|&&|\|+|;|\n)\s*gh\s+pr\s+merge\b")
+_MERGE_STMT_RE = re.compile(r"gh\s+pr\s+merge\b")
+
+
+def _check_merge_stmt(token):
+    return bool(_MERGE_STMT_RE.match(token.lstrip()))
+
+
+def is_pr_merge_command(command):
+    """True iff *command* contains a top-level `gh pr merge` -- i.e. not one
+    merely mentioned inside a quoted string, $() subshell, or heredoc body
+    (dev-env#499). Mirrors `pre-merge-numbering-check.py`'s identically-named
+    predicate (dev-env#519).
+    """
+    return scan_top_level(command, _check_merge_stmt)
 
 
 def _read_queue():
@@ -48,7 +69,7 @@ def main() -> None:
     if data.get("tool_name") != "Bash":
         sys.exit(0)
     command = data.get("tool_input", {}).get("command", "")
-    if not _GH_PR_MERGE_RE.search(command):
+    if not is_pr_merge_command(command):
         sys.exit(0)
 
     content = _read_queue().strip()

--- a/claude/scripts/tests/test_pre_merge_findings_gate.py
+++ b/claude/scripts/tests/test_pre_merge_findings_gate.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for pre-merge-findings-gate.py's is_pr_merge_command pure helper.
+
+Exercises the command-detection predicate offline (no disk, no network, no
+gh). This is the file's *pure-helper* coverage layer, added alongside the
+existing behavioral self-test `test-merge-findings-gate.sh` (which drives the
+real hook end-to-end via the MERGE_GATE_TEST_JSON seam to pin the
+clean-review / open-findings / disposition-recorded / no-marker / gh-failure
+decision paths). `_parse_merge_target`, `_fetch_pr_json`, and the stdin/exit-2
+plumbing are not covered here (pure-helper convention; `_parse_merge_target`
+is already exercised by the shell test's step 7).
+"""
+import importlib.util
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Load the module under test without executing main()
+# ---------------------------------------------------------------------------
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "pre-merge-findings-gate.py")
+# The script imports _winsubp and _hookio (siblings in scripts/); make them resolvable.
+sys.path.insert(0, os.path.dirname(_SCRIPT))
+spec = importlib.util.spec_from_file_location("pre_merge_findings_gate", _SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+is_pr_merge_command = mod.is_pr_merge_command
+
+
+# ---------------------------------------------------------------------------
+# is_pr_merge_command tests
+# ---------------------------------------------------------------------------
+
+def test_bare_merge():
+    assert is_pr_merge_command("gh pr merge 999 --repo o/r --squash --delete-branch")
+
+def test_merge_chained():
+    assert is_pr_merge_command("git fetch origin && gh pr merge --squash")
+
+def test_merge_cd_chained():
+    assert is_pr_merge_command("cd C:/Users/brown/Git/dev-env && gh pr merge --squash")
+
+def test_non_merge_gh_command():
+    assert not is_pr_merge_command("gh pr view 999 --repo o/r")
+
+def test_unrelated_command():
+    assert not is_pr_merge_command("git status")
+
+def test_merge_heredoc_body_not_matched():
+    # dev-env#499: a "gh pr merge" mentioned only inside a heredoc body
+    # (e.g. as prose in a commit message) must not count as a genuine
+    # top-level invocation -- it must not pay this hook's live `gh pr view`
+    # call for a command that never actually merges.
+    command = 'git commit -m "$(cat <<\'EOF\'\nmentions gh pr merge in prose\nEOF\n)"'
+    assert is_pr_merge_command(command) is False
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"  FAIL  {t.__name__}: {e}")
+            failed += 1
+    total = passed + failed
+    print(f"\nTests: {passed} passed, 0 skipped, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/claude/scripts/tests/test_pre_merge_message_check.py
+++ b/claude/scripts/tests/test_pre_merge_message_check.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Tests for pre-merge-message-check.py pure helpers.
 
-Exercises the command-detection regex and queue-read helper offline (no disk I/O
-for the regex tests, a tmp file for the read tests). The stdin plumbing and exit-2
-emission are not covered (pure-helper convention).
+Exercises the command-detection predicate and queue-read helper offline (no
+disk I/O for the detection tests, a tmp file for the read tests). The stdin
+plumbing and exit-2 emission are not covered (pure-helper convention).
 """
 import importlib.util
 import os
@@ -14,47 +14,53 @@ import tempfile
 # Load the module under test without executing main()
 # ---------------------------------------------------------------------------
 _SCRIPT = os.path.join(os.path.dirname(__file__), "..", "pre-merge-message-check.py")
-# The script imports _winsubp (a sibling in scripts/); make it resolvable.
+# The script imports _winsubp and _hookio (siblings in scripts/); make them resolvable.
 sys.path.insert(0, os.path.dirname(_SCRIPT))
 spec = importlib.util.spec_from_file_location("pre_merge_message_check", _SCRIPT)
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
-_RE = mod._GH_PR_MERGE_RE
-
-
-def _check_regex(cmd: str) -> bool:
-    return bool(_RE.search(cmd))
+is_pr_merge_command = mod.is_pr_merge_command
 
 
 # ---------------------------------------------------------------------------
-# Regex tests
+# is_pr_merge_command tests
 # ---------------------------------------------------------------------------
 
 def test_bare_merge():
-    assert _check_regex("gh pr merge")
+    assert is_pr_merge_command("gh pr merge")
 
 def test_merge_with_flags():
-    assert _check_regex("gh pr merge --squash --delete-branch")
+    assert is_pr_merge_command("gh pr merge --squash --delete-branch")
 
 def test_merge_with_number():
-    assert _check_regex("gh pr merge 42")
+    assert is_pr_merge_command("gh pr merge 42")
 
 def test_merge_chained():
-    assert _check_regex("git fetch origin && gh pr merge --squash")
+    assert is_pr_merge_command("git fetch origin && gh pr merge --squash")
 
 def test_merge_after_semicolon():
-    assert _check_regex("git status; gh pr merge")
+    assert is_pr_merge_command("git status; gh pr merge")
+
+def test_merge_cd_chained():
+    assert is_pr_merge_command("cd C:/Users/brown/Git/dev-env && gh pr merge --squash")
 
 def test_non_merge_gh_command():
-    assert not _check_regex("gh pr create --title foo")
+    assert not is_pr_merge_command("gh pr create --title foo")
 
 def test_unrelated_command():
-    assert not _check_regex("git push origin main")
+    assert not is_pr_merge_command("git push origin main")
 
 def test_merge_in_string_but_not_command():
     # "merge" appears inside a string argument, not as a gh subcommand
-    assert not _check_regex("echo 'about to merge' && git push")
+    assert not is_pr_merge_command("echo 'about to merge' && git push")
+
+def test_merge_heredoc_body_not_matched():
+    # dev-env#499: a "gh pr merge" mentioned only inside a heredoc body
+    # (e.g. as prose in a commit message) must not count as a genuine
+    # top-level invocation.
+    command = 'git commit -m "$(cat <<\'EOF\'\nmentions gh pr merge in prose\nEOF\n)"'
+    assert is_pr_merge_command(command) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `pre-merge-message-check.py` and `pre-merge-findings-gate.py` detected `gh pr merge` via a plain unanchored regex (`_GH_PR_MERGE_RE`) over the whole command string — not the quote/subshell/heredoc-aware `scan_top_level` engine `pre-merge-numbering-check.py`, `pr-merge-reminder.py`, and `pre-tool-use-canonical-mutate-guard.py` already use. A `gh pr merge` mentioned only inside a heredoc body or `$()` subshell (e.g. commit-message prose) could spuriously match, firing the message-check's file read or the findings-gate's live `gh pr view` call on a command that never actually merges.
- Both hooks fail open, so this never wrongly *blocked* a merge — but it reintroduced the false-positive class `scan_top_level` exists to eliminate, and left `pre-merge-numbering-check.py` (migrated in #518) no longer sharing this limitation with its two siblings.
- Both files now expose an `is_pr_merge_command()` predicate built on `_hookio.scan_top_level`, mirroring `pre-merge-numbering-check.py`'s identically-named function exactly. `pre-merge-findings-gate.py`'s separate `_parse_merge_target()` (which locates flags *after* the gate has already confirmed a merge command) is untouched — out of scope per the issue.
- Closes a pre-existing documentation gap while in these files: `pre-merge-findings-gate.py`'s test suite (`test-merge-findings-gate.sh`) was never cross-referenced in CLAUDE.md's `## Testing` section. Added as new item 38, alongside the new pure-helper test file, mirroring the precedent set by items 30/32/33 for other test files that pre-dated the list.

Closes #519

## Testing

Ran the full pre-PR checklist from `CLAUDE.md`:

```bash
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py   # clean
py -3 claude/scripts/tests/test_pre_merge_message_check.py       # 15 passed, 0 skipped, 0 failed
py -3 claude/scripts/tests/test_pre_merge_findings_gate.py       # 6 passed, 0 skipped, 0 failed (new file)
bash claude/scripts/tests/test-merge-findings-gate.sh            # 8 passed, 0 failed
py -3 claude/scripts/tests/test_pre_merge_numbering_check.py     # 34 passed, 0 skipped, 0 failed (sibling sanity check)
py -3 claude/scripts/tests/test_hookio.py                        # 44 passed, 0 skipped, 0 failed (shared engine sanity check)
```

**Tests: 107 passed, 0 skipped, 0 failed** (across all five suites run; no automated test framework failures).

- Suppression grep (`git diff origin/main -- . | grep -E '(ts-ignore|...)'`) — clean, no matches.
- Test-integrity grep (skip markers / deleted tests / lowered thresholds) — clean, no matches.
- No `package.json` in this repo — lockfile policy N/A.
- Coverage gate: new/changed pure-helper behavior (`is_pr_merge_command` in both files) is covered by new/updated tests in the same PR.

## ADR-warrant check

N/A — this migrates two hooks onto an already-established, already-documented pattern (`_hookio.scan_top_level`, governed by ADR-050 Amendment 5) for consistency with their already-migrated sibling (`pre-merge-numbering-check.py`, ADR-074). No new architectural decision is introduced; the rationale is fully captured in #519.

## Doc-reconciliation checkpoint

- `CLAUDE.md` Testing section: item 24 rewritten to describe `is_pr_merge_command` (was `_GH_PR_MERGE_RE`); new item 38 added for `pre-merge-findings-gate.py`'s test suite.
- `README.md` hooks table: no change needed — the one-line hook descriptions describe externally-visible behavior (still accurate; only the internal detection engine changed).

## Review findings disposition

[`/review` posted](https://github.com/brownm09/dev-env/pull/523#issuecomment-4868140759): 0 blocking, 2 non-blocking findings.

1. **[correctness] Piped `gh pr merge` no longer detected** — `scan_top_level` is pipe-unaware by default, so the retired regex's `\|+` anchor coverage (e.g. `echo x | gh pr merge`) is dropped in all three sibling hooks; verified this predates this PR (`pre-merge-numbering-check.py`, merged in #518, already has the identical gap). Fixing only the two files in this PR would have reintroduced the cross-hook inconsistency #519 exists to eliminate. **Filed [dev-env#524](https://github.com/brownm09/dev-env/issues/524)** to track the real fix (a `split_pipe` passthrough on `scan_top_level` in `_hookio.py`, touching all three hooks at once).
2. **[maintainability] Language-scope coverage note** — the diff's test files are Python, but the Test Integrity Gate's automated patterns target JS/TS. **Fixed via manual verification** (documented here, no code change needed): no `@pytest.mark.skip` / `pytest.skip(` / `pytest.xfail(` / `unittest.skip` anywhere in the diff, and no test functions were deleted — all 8 original `test_pre_merge_message_check.py` test names are preserved with 2 new ones added, and the new `test_pre_merge_findings_gate.py` adds 6 more.

Also fixed a Style nit inline (Testing item 38's prose now names all three positive-match test cases: bare, `&&`-chained, and `cd`-chained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
