### PR TITLE
fix(hooks): roll out confirm_merge_via_gh fallback to the 5 remaining marker-gated hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,8 +389,13 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     `cd <repo> && git push` target — so a cross-repo push is evaluated against THAT repo, not the
     session cwd — and falls back to cwd for a bare push; and that `_is_successful_merge_call` gates
     solely on gh's success marker, not the exit code, so an exit-0 non-merge invocation like
-    `gh pr merge --help` no longer fires the reminder (dev-env#485). The live `_open_pr_for_cwd`
-    subprocess boundary is not covered (the repo avoids subprocess mocks).
+    `gh pr merge --help` no longer fires the reminder (dev-env#485). Also exercises `_build_messages`'s
+    `live_confirmed: bool | None` parameter (dev-env#504 — the live `gh pr view` fallback for when the
+    marker itself is lost, dev-env#489): `True` overrides a marker-less `merge_ok` to fire the merge
+    reminder, `False` leaves it unfired, and the default `None` (every pre-existing call in this suite)
+    reproduces the exact pre-#504 marker-only behavior — `main()`, not `_build_messages`, decides
+    whether to attempt the live call, so this suite never shells out. The live `_open_pr_for_cwd` and
+    `confirm_merge_via_gh` subprocess boundaries are not covered (the repo avoids subprocess mocks).
 
     ```bash
     py -3 claude/scripts/tests/test_pr_merge_reminder.py

--- a/claude/scripts/post-merge-tile-checkpoint.py
+++ b/claude/scripts/post-merge-tile-checkpoint.py
@@ -21,13 +21,20 @@ Stdin JSON shape (PostToolUse):
 Output is read via _hookio.read_command_output (stdout+stderr, legacy output
 fallback) per ADR-049/ADR-050 — do NOT read tool_response.output directly.
 
-Exit 0 — not a successful `gh pr merge` call; no action.
+Exit 0 — not a successful `gh pr merge` call (including a genuinely-failed
+         merge the live `gh pr view` fallback also could not confirm); no action.
 Exit 2 — successful merge detected; tile-checkpoint reminder emitted via stderr.
 """
 import json
 import sys
 
-from _hookio import output_has_merge_marker, read_command_output
+from _hookio import (
+    confirm_merge_via_gh,
+    effective_merge_dir,
+    output_has_merge_marker,
+    read_command_output,
+    should_confirm_via_gh,
+)
 
 
 def is_successful_merge(command: str, output: str) -> bool:
@@ -60,9 +67,20 @@ def main() -> None:
 
     command = data.get("tool_input", {}).get("command", "")
     output = read_command_output(data)
+    cwd = data.get("cwd", "")
 
     if not is_successful_merge(command, output):
-        sys.exit(0)
+        # gh's marker does not always survive to this hook's captured output
+        # when gh exits abruptly right after a worktree's local-cleanup
+        # failure (dev-env#489) — fall back to a live `gh pr view` confirmation
+        # rather than silently dropping the tile-checkpoint reminder (dev-env#504).
+        if "gh pr merge" not in command:
+            sys.exit(0)
+        exit_code = data.get("tool_response", {}).get("exitCode", -1)
+        if not should_confirm_via_gh(exit_code, output):
+            sys.exit(0)
+        if confirm_merge_via_gh(None, "", effective_merge_dir(command, cwd)) is None:
+            sys.exit(0)
 
     print(
         "[tile-checkpoint] PR merged — spawn follow-up tiles now via spawn_task for "

--- a/claude/scripts/post-pr-merge-pull.py
+++ b/claude/scripts/post-pr-merge-pull.py
@@ -28,7 +28,13 @@ import re
 import subprocess
 import sys
 
-from _hookio import effective_merge_dir, output_has_merge_marker, read_command_output
+from _hookio import (
+    confirm_merge_via_gh,
+    effective_merge_dir,
+    output_has_merge_marker,
+    read_command_output,
+    should_confirm_via_gh,
+)
 from _worktree_topology import canonical_on_main, merge_park_target, parse_worktree_porcelain
 
 # Map GitHub repo slugs to local clone paths.
@@ -231,7 +237,17 @@ def main() -> None:
     cwd = data.get("cwd", "")
 
     if not is_successful_merge(command, output):
-        sys.exit(0)
+        # gh's marker does not always survive to this hook's captured output
+        # when gh exits abruptly right after a worktree's local-cleanup
+        # failure (dev-env#489) — fall back to a live `gh pr view` confirmation
+        # rather than silently skipping the local-main fast-forward (dev-env#504).
+        if "gh pr merge" not in command:
+            sys.exit(0)
+        exit_code = data.get("tool_response", {}).get("exitCode", -1)
+        if not should_confirm_via_gh(exit_code, output):
+            sys.exit(0)
+        if confirm_merge_via_gh(None, "", effective_merge_dir(command, cwd)) is None:
+            sys.exit(0)
 
     repo = extract_repo(command, cwd)
     if not repo:

--- a/claude/scripts/post-pr-merge-reclaim.py
+++ b/claude/scripts/post-pr-merge-reclaim.py
@@ -41,7 +41,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-from _hookio import output_has_merge_marker, read_command_output
+from _hookio import (
+    confirm_merge_via_gh,
+    effective_merge_dir,
+    output_has_merge_marker,
+    read_command_output,
+    should_confirm_via_gh,
+)
 
 SCAN_DIR = "C:/Users/brown/Git"
 RECLAIM_SCRIPT = Path(__file__).resolve().parent / "reclaim-worktree-disk.py"
@@ -108,7 +114,17 @@ def main() -> None:
     cwd = data.get("cwd", "")
 
     if not is_successful_merge(command, output):
-        sys.exit(0)
+        # gh's marker does not always survive to this hook's captured output
+        # when gh exits abruptly right after a worktree's local-cleanup
+        # failure (dev-env#489) — fall back to a live `gh pr view` confirmation
+        # rather than silently skipping the disk reclaim (dev-env#504).
+        if "gh pr merge" not in command:
+            sys.exit(0)
+        exit_code = data.get("tool_response", {}).get("exitCode", -1)
+        if not should_confirm_via_gh(exit_code, output):
+            sys.exit(0)
+        if confirm_merge_via_gh(None, "", effective_merge_dir(command, cwd)) is None:
+            sys.exit(0)
 
     if _spawn_reclaim(cwd):
         print(

--- a/claude/scripts/pr-merge-reminder.py
+++ b/claude/scripts/pr-merge-reminder.py
@@ -31,10 +31,12 @@ import subprocess
 import sys
 
 from _hookio import (
+    confirm_merge_via_gh,
     effective_merge_dir,
     output_has_merge_marker,
     read_command_output,
     scan_top_level,
+    should_confirm_via_gh,
 )
 
 # Matches the start of a statement token against `gh pr merge`, `gh pr create`,
@@ -217,6 +219,7 @@ def _build_messages(
     is_create: bool,
     is_merge: bool,
     is_push: bool,
+    live_confirmed: bool | None = None,
 ) -> list[str]:
     """Build the reminder message(s) for a detected create/merge/push command.
 
@@ -243,8 +246,21 @@ def _build_messages(
     against a PR that was never opened — so it counts as evidence for create
     even when the chain's aggregate exit code is non-zero (the #275 worktree
     case, chained with a preceding create).
+
+    *live_confirmed* — dev-env#504: gh's marker does not always survive to
+    this hook's captured output when gh exits abruptly right after a
+    worktree's local-cleanup failure (dev-env#489). `main()` resolves the
+    live `gh pr view` fallback (a subprocess call) itself, BEFORE calling this
+    function, and passes the result here — this function never shells out.
+    `None` (the default) means main() never attempted the live check (marker
+    already found, or exit_code/output didn't warrant it) and `merge_ok` keeps
+    its marker-only value, so every existing caller/test that omits this
+    parameter is unaffected. `True`/`False` means main() did attempt it and
+    authoritatively overrides `merge_ok`.
     """
     merge_ok = is_merge and _is_successful_merge_call(output)
+    if live_confirmed is not None:
+        merge_ok = live_confirmed
     create_push_ok = exit_code == 0 or merge_ok
     messages = []
 
@@ -338,8 +354,25 @@ def main() -> None:
         sys.exit(0)
 
     output = read_command_output(data)
+
+    # dev-env#504: when the marker-based check fails but the command was a
+    # genuine gh pr merge with a non-zero exit code, fall back to a live
+    # `gh pr view` confirmation (dev-env#489) before conceding no merge
+    # happened. Resolved here, not inside _build_messages, so that function's
+    # existing direct-call test suite can never trigger a live subprocess.
+    live_confirmed = None
+    if (
+        is_merge
+        and not _is_successful_merge_call(output)
+        and should_confirm_via_gh(exit_code, output)
+    ):
+        live_confirmed = (
+            confirm_merge_via_gh(None, "", effective_merge_dir(command, cwd)) is not None
+        )
+
     messages = _build_messages(
-        command, cwd, exit_code, output, is_create, is_merge, is_push
+        command, cwd, exit_code, output, is_create, is_merge, is_push,
+        live_confirmed=live_confirmed,
     )
 
     if not messages:

--- a/claude/scripts/tests/test_pr_merge_reminder.py
+++ b/claude/scripts/tests/test_pr_merge_reminder.py
@@ -35,6 +35,15 @@ reaching that call by only combining is_push=True with a failing
 create_push_ok or with is_create/is_merge also true — both conditions
 short-circuit before _open_pr_for_cwd would be invoked.
 
+dev-env#504 added a live `gh pr view` fallback (dev-env#489's fix, already
+wired into post-pr-merge-project.py) for when gh's marker doesn't survive a
+worktree merge's local-cleanup failure. `main()` resolves that live check
+itself and passes the result into `_build_messages` as `live_confirmed` —
+the function itself never shells out, so its existing direct-call tests
+above are unaffected (they all omit the parameter, which defaults to None).
+The three `live_confirmed` tests below exercise only the pure override
+logic, not the live call.
+
 Usage:
     py -3 claude/scripts/tests/test_pr_merge_reminder.py
 
@@ -561,6 +570,66 @@ def test_build_messages_push_suppressed_when_also_create() -> str:
 
 
 # ---------------------------------------------------------------------------
+# _build_messages: live_confirmed override (dev-env#504 — main() resolves the
+# live gh-pr-view fallback itself and passes the result in; this function
+# never shells out, so these tests stay offline like every other case above.
+# ---------------------------------------------------------------------------
+
+def test_build_messages_live_confirmed_true_overrides_marker_less_merge() -> str:
+    # Simulates main()'s live confirmation succeeding after the marker was
+    # lost on the dev-env#489 worktree-cleanup failure shape — merge_ok must
+    # be forced True even though the marker-based check alone says False.
+    messages = _build_messages(
+        command="gh pr merge --squash --delete-branch",
+        cwd="/session/cwd",
+        exit_code=1,
+        output="failed to run git: fatal: 'main' is already checked out at 'C:/Users/brown/Git/dev-env'",
+        is_create=False,
+        is_merge=True,
+        is_push=False,
+        live_confirmed=True,
+    )
+    assert len(messages) == 1
+    assert "gh pr merge detected" in messages[0]
+    return "live_confirmed=True overrides marker-less merge_ok -> merge reminder fires (dev-env#504)"
+
+
+def test_build_messages_live_confirmed_false_stays_unfired() -> str:
+    # main() attempted the live check and it came back negative (genuinely
+    # not merged, or gh pr view itself failed) -> no message, same as if the
+    # marker check alone had run.
+    messages = _build_messages(
+        command="gh pr merge --squash --delete-branch",
+        cwd="/session/cwd",
+        exit_code=1,
+        output="failed to run git: fatal: 'main' is already checked out at 'C:/Users/brown/Git/dev-env'",
+        is_create=False,
+        is_merge=True,
+        is_push=False,
+        live_confirmed=False,
+    )
+    assert messages == [], f"live_confirmed=False must not fire, got {messages!r}"
+    return "live_confirmed=False -> no message (live check attempted, not confirmed)"
+
+
+def test_build_messages_live_confirmed_default_none_unchanged() -> str:
+    # Omitting the parameter entirely (every pre-existing test call above, and
+    # main()'s own "never attempted" case) must behave exactly as before this
+    # change -- marker-only.
+    messages = _build_messages(
+        command="gh pr merge --squash",
+        cwd="/session/cwd",
+        exit_code=1,
+        output="X Pull request #1 is not mergeable",
+        is_create=False,
+        is_merge=True,
+        is_push=False,
+    )
+    assert messages == [], "default live_confirmed=None must not change prior marker-only behavior"
+    return "live_confirmed omitted -> unchanged marker-only behavior"
+
+
+# ---------------------------------------------------------------------------
 # runner
 # ---------------------------------------------------------------------------
 
@@ -608,6 +677,9 @@ def main() -> int:
         ("build_messages: create fails, merge never ran -> no message", test_build_messages_create_fails_merge_never_ran_no_message),
         ("build_messages: chained create + worktree-merge success -> both fire (#275)", test_build_messages_chained_create_and_worktree_merge_nonzero_exit_both_fire),
         ("build_messages: push suppressed when also create", test_build_messages_push_suppressed_when_also_create),
+        ("build_messages: live_confirmed=True overrides marker-less merge (dev-env#504)", test_build_messages_live_confirmed_true_overrides_marker_less_merge),
+        ("build_messages: live_confirmed=False stays unfired", test_build_messages_live_confirmed_false_stays_unfired),
+        ("build_messages: live_confirmed omitted -> unchanged", test_build_messages_live_confirmed_default_none_unchanged),
     ]
     failed = 0
     for name, fn in tests:

--- a/claude/scripts/usage-snapshot.py
+++ b/claude/scripts/usage-snapshot.py
@@ -20,8 +20,9 @@ Stdin JSON shape (PostToolUse):
     "cwd": "..."
   }
 
-Exit 0  — not a merge command, an unconfirmed merge (no success marker in the
-          output — e.g. a queued `--auto`), or creds file absent; silent
+Exit 0  — not a merge command, an unconfirmed merge (no success marker and the
+          live `gh pr view` fallback also found nothing — e.g. a queued
+          `--auto`, or a genuinely failed merge), or creds file absent; silent
 Exit 2  — snapshot emitted via stderr, OR an expired token whose on-demand refresh
           failed (advisory), OR the usage API was unreachable after one retry
           (advisory — #302). An expired token is first refreshed on demand via the
@@ -38,7 +39,15 @@ import urllib.error
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-from _hookio import output_has_merge_marker, read_command_output, scan_top_level
+from _hookio import (
+    confirm_merge_via_gh,
+    effective_merge_dir,
+    merge_pr_number_from_output,
+    output_has_merge_marker,
+    read_command_output,
+    scan_top_level,
+    should_confirm_via_gh,
+)
 
 CREDS_PATH = "C:/Users/brown/.claude/.credentials.json"
 CONFIG_PATH = "C:/Users/brown/Git/dev-env/claude/usage-config.json"
@@ -67,6 +76,12 @@ def merge_confirmed(command: str, output: str) -> bool:
     silently dropped the snapshot on every worktree merge, the default flow in
     this repo (dev-env#474; mirrors post-pr-merge-project.py's
     merge_succeeded(), see ADR-049/ADR-050).
+
+    gh's already-printed marker does not always survive to this hook's
+    captured output when gh exits abruptly right after that same
+    local-cleanup failure (dev-env#489) — main() falls back to a live
+    `gh pr view` confirmation when this predicate returns False but the
+    command was still a `gh pr merge` invocation (dev-env#504).
     """
     return scan_top_level(command, _check_merge_stmt) and output_has_merge_marker(output)
 
@@ -418,8 +433,17 @@ def main() -> None:
 
     command = data.get("tool_input", {}).get("command", "")
     output = read_command_output(data)
+    cwd = data.get("cwd", "")
+
     if not merge_confirmed(command, output):
-        sys.exit(0)
+        if not scan_top_level(command, _check_merge_stmt):
+            sys.exit(0)
+        exit_code = data.get("tool_response", {}).get("exitCode", -1)
+        if not should_confirm_via_gh(exit_code, output):
+            sys.exit(0)
+        pr_number = merge_pr_number_from_output(output)
+        if confirm_merge_via_gh(pr_number, "", effective_merge_dir(command, cwd)) is None:
+            sys.exit(0)
 
     creds = load_credentials()
     if not creds:
@@ -469,7 +493,6 @@ def main() -> None:
 
     config = load_config()
     session_id = data.get("session_id", "")
-    cwd = data.get("cwd", "")
 
     jsonl_path = find_session_jsonl(cwd, session_id)
     exchanges = top_exchanges(jsonl_path) if jsonl_path else []

--- a/claude/scripts/usage-snapshot.py
+++ b/claude/scripts/usage-snapshot.py
@@ -42,7 +42,6 @@ from pathlib import Path
 from _hookio import (
     confirm_merge_via_gh,
     effective_merge_dir,
-    merge_pr_number_from_output,
     output_has_merge_marker,
     read_command_output,
     scan_top_level,
@@ -441,8 +440,13 @@ def main() -> None:
         exit_code = data.get("tool_response", {}).get("exitCode", -1)
         if not should_confirm_via_gh(exit_code, output):
             sys.exit(0)
-        pr_number = merge_pr_number_from_output(output)
-        if confirm_merge_via_gh(pr_number, "", effective_merge_dir(command, cwd)) is None:
+        # No PR number to extract here: merge_confirmed() already ruled out "not a
+        # merge command" above, so its False result means the marker itself is
+        # missing from `output` — and merge_pr_number_from_output() scans that same
+        # `output` for the identical marker regex, so it would always return None
+        # too. `gh pr view` with no number infers the PR from cwd's checked-out
+        # branch instead (matching the other five hooks' identical fallback call).
+        if confirm_merge_via_gh(None, "", effective_merge_dir(command, cwd)) is None:
             sys.exit(0)
 
     creds = load_credentials()

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -666,20 +666,25 @@ legitimately absent for reasons unrelated to the worktree-exit-code case: `.cred
 missing or unparseable, an expired refresh token, or the usage API unreachable after one retry —
 all intentionally silent-or-advisory per the hook's own docstring, not a regression of this fix.
 Separately: the observed *symptom* — no PostToolUse hook output surfacing in chat when the
-*parent* `gh pr merge` call itself is shown as an error (non-zero exit) — has now recurred in all
-three occurrences examined (the two instances behind this fix, plus dev-env PR #512 on
-2026-07-02). The *mechanism* remains unconfirmed and is likely confounded rather than a distinct
-platform behavior: gh's own stdout success marker is independently known to be lost on this exact
-failure path (dev-env#489, root-caused), the `gh pr view` fallback that works around that covers
-only 1 of the 6 marker-gated hooks (dev-env#504, open), and even that one hook's silence is
-inconclusive on its own — the fallback could race or fail silently rather than its stderr being
-dropped (dev-env#498, open). No occurrence yet isolates a hook whose merge-detection is
-independently known to have succeeded — not just inferred from a Done-status that GitHub's native
-close automation equally explains — with its stderr still failing to surface (dev-env#521). Until
-dev-env#498/#504 resolve that ambiguity, confirm a hook actually ran by checking its side effect
-(e.g. the linked issue's board status) rather than assuming absence of visible reminder text means
-the hook didn't fire — and don't over-read that absence as proof the hook's stderr specifically
-was dropped.
+*parent* `gh pr merge` call itself is shown as an error (non-zero exit) — has now recurred in at
+least four occurrences examined (the two instances behind this fix, dev-env PR #512 on
+2026-07-02, and career-playbook PR #635 on 2026-07-02 — the first occurrence outside dev-env
+itself, confirming the gap is a property of the shared *global* hook architecture rather than
+anything specific to dev-env's own worktree/board setup, since these hooks fire for every repo
+without a `hook-config.json` opt-in requirement). The *mechanism* remains partially unconfirmed:
+gh's own stdout success marker is independently known to be lost on this exact failure path
+(dev-env#489, root-caused), and the `gh pr view` fallback that works around that now covers all
+6 marker-gated hooks (dev-env#504, closed by the dev-env#504 rollout PR — [ADR-050 Amendment
+8](adr/050-shared-hookio-sibling-hook-fixes.md)) — but even the original hook to receive that
+fallback (`post-pr-merge-project.py`, Amendment 3) has inconclusive evidence of it actually firing
+on its own: the fallback could race or fail silently rather than its stderr being dropped
+(dev-env#498, open). No occurrence yet isolates a hook whose merge-detection is independently
+known to have succeeded — not just inferred from a Done-status that GitHub's native close
+automation equally explains — with its stderr still failing to surface (dev-env#521). Until
+dev-env#498 resolves that ambiguity, confirm a hook actually ran by checking its side effect (e.g.
+the linked issue's board status) rather than assuming absence of visible reminder text means the
+hook didn't fire — and don't over-read that absence as proof the hook's stderr specifically was
+dropped.
 
 ### Stacked PR squash-merge sequencing — never `--delete-branch` a base with an open child
 

--- a/docs/adr/050-shared-hookio-sibling-hook-fixes.md
+++ b/docs/adr/050-shared-hookio-sibling-hook-fixes.md
@@ -467,3 +467,83 @@ needs the same audit the shape change itself got. `/review`'s adversarial pass, 
 test suite, is what caught this; the test suite only exercised the *inverse* direction (heredoc body
 text that must NOT trigger) because that was the bug being fixed, not the one this fix could
 introduce.
+
+## Amendment 8 (2026-07-02) — rolling `confirm_merge_via_gh` out to the five remaining marker-gated hooks (dev-env#504)
+
+Amendment 3 added a live `gh pr view` fallback (`should_confirm_via_gh` / `confirm_merge_via_gh` in
+`_hookio.py`) for when gh's merge-success marker doesn't survive to a PostToolUse hook's captured
+output — but wired it into `post-pr-merge-project.py` **only**, per that PR's own stated rationale: it
+is the one hook of the six with no other eventual-consistency backstop for a missed action
+(dev-env#498 later found even that one hook's own confirmation inconclusive to observe — a separate,
+still-open question this amendment does not resolve). dev-env#504 tracked the rollout to the other
+five as an explicit follow-up rather than leaving it implied. This amendment closes that gap.
+
+**Evidence the gap was live, not theoretical:** the identical worktree-cleanup failure
+(`fatal: 'main' is already checked out`) recurred on dev-env PRs #491, #493, and #512, and — new since
+#504 was filed — on a **different repo entirely**, career-playbook PR #635. Since these hooks are
+global (fire "for every repo without a hook-config.json opt-in requirement," per `usage-snapshot.py`'s
+own docstring), the career-playbook occurrence confirms the gap is a property of the shared hook
+architecture, not something specific to dev-env's own worktree/board setup.
+
+**Fix:** wired `should_confirm_via_gh` / `confirm_merge_via_gh` into the remaining five hooks —
+`usage-snapshot.py`, `post-merge-tile-checkpoint.py`, `post-pr-merge-pull.py`,
+`post-pr-merge-reclaim.py`, `pr-merge-reminder.py` — mirroring `post-pr-merge-project.py`'s existing
+pattern: when the marker-based check fails but the command was still a genuine `gh pr merge` with a
+non-zero exit code, fall back to a live confirmation before conceding no merge happened. Per #504's own
+"Scope" section, this takes the simpler of the two named options — accepting up to six independent
+(redundant) `gh pr view` calls per failed-merge event rather than building a cross-hook shared-result
+cache, since each PostToolUse hook is a separate process with no natural place to share one result
+short of new infrastructure that six calls to a cheap, read-only `gh` command don't justify.
+
+Four of the five hooks (`usage-snapshot.py`, `post-merge-tile-checkpoint.py`, `post-pr-merge-pull.py`,
+`post-pr-merge-reclaim.py`) gate on a simple 2-argument marker predicate
+(`merge_confirmed(command, output)` / `is_successful_merge(command, output)`) that existing tests call
+directly and offline. The fallback was added only in each hook's own `main()`, never inside those
+tested predicates, so no existing test's behavior or coverage changed.
+
+`pr-merge-reminder.py` needed a different shape: its `_build_messages()` helper — which computes
+`merge_ok` from the marker alone — is itself directly unit-tested with ~20 synthetic `(command,
+exit_code, output)` combinations, several of which have a non-zero `exit_code` and no marker (e.g. the
+dev-env#494 "create fails, merge never ran" case). Naively calling `confirm_merge_via_gh` from inside
+`_build_messages` would have made those existing tests shell out to a **real** `gh pr view` subprocess
+call — one of them stayed accidentally safe only because its synthetic `cwd` doesn't exist on disk
+(`subprocess.run(cwd=...)` raises before `gh` ever runs, caught by `confirm_merge_via_gh`'s broad
+exception handler). Relying on that accident would have been fragile, and violates the repo's own
+"avoids subprocess mocks by never reaching the live boundary in a pure-helper test" convention. Instead,
+`_build_messages` gained a `live_confirmed: bool | None = None` parameter: `None` (the default, and
+every pre-existing test call) leaves `merge_ok` exactly as the marker-only check already computed it;
+`True`/`False` authoritatively overrides it. `main()` — never `_build_messages` — decides whether to
+attempt the live check and calls `confirm_merge_via_gh` itself, before the `_build_messages` call. This
+keeps the live subprocess boundary exactly where every sibling hook already keeps it: in `main()`,
+untested by convention, never inside a function synthetic inputs can reach.
+
+All six hooks resolve the `gh pr view` cwd via `effective_merge_dir(command, cwd)` rather than the raw
+session `cwd` — a `cd <other-repo> && gh pr merge` chain must confirm against the repo the merge
+actually targeted, matching the existing cd-chain-scoping convention `pr-merge-reminder.py` and
+`post-pr-merge-pull.py` already use for their own repo/dir resolution (ADR-067). `post-pr-merge-pull.py`
+and `post-pr-merge-reclaim.py` keep their pre-existing raw-`cwd` uses (`extract_repo`'s cd-chain
+resolution; `_spawn_reclaim`'s `--protect-cwd`) untouched — those are semantically distinct from "which
+directory should `gh pr view` run from," so the new `effective_merge_dir` call is additive, not a
+replacement.
+
+**Coverage:** all five hooks' existing marker-predicate tests pass unchanged — no existing test was
+modified or reinterpreted, only new code paths added around them in each `main()`.
+`pr-merge-reminder.py`'s suite gained three new tests exercising `live_confirmed=True` / `False` /
+omitted directly — pure, no subprocess — bringing that file's suite to 45 passing tests. The live
+`confirm_merge_via_gh` calls themselves remain untested across all six hooks, per this ADR's and
+`post-pr-merge-project.py`'s own established convention (it shells out to `gh pr view`; the repo avoids
+subprocess mocks).
+
+**What this amendment does not resolve:** dev-env#498's question — whether even
+`post-pr-merge-project.py`'s original, longer-lived fallback is provably firing, versus GitHub's native
+project-automation masking the result — stands independent of this rollout and is not touched here.
+
+**General lesson (continuing Amendments 1, 5, and 6's):** a fix scoped to "the one hook that needs it
+most" is a deliberate, load-bearing decision (Amendment 3 was explicit about this), but it leaves a
+tracked-but-open gap for every sibling hook until a follow-up closes it — dev-env#504 existed
+specifically so that gap wasn't just implied by re-reading Amendment 3's rationale later. A second,
+narrower lesson specific to this amendment: wiring a live-call fallback into a function that already has
+direct synthetic-input test coverage requires checking every existing test case against the new code
+path before assuming "add the fallback the same way as the reference hook" is a safe copy — one of
+`pr-merge-reminder.py`'s own pre-existing tests would have started shelling out to `gh` for real had the
+fallback been added inside `_build_messages` rather than gated in `main()`.


### PR DESCRIPTION
## Summary

- Wires `should_confirm_via_gh` / `confirm_merge_via_gh` (dev-env#489's live `gh pr view` fallback, wired into `post-pr-merge-project.py` only) into the remaining five marker-gated PostToolUse hooks: `usage-snapshot.py`, `post-merge-tile-checkpoint.py`, `post-pr-merge-pull.py`, `post-pr-merge-reclaim.py`, `pr-merge-reminder.py`.
- Motivated by career-playbook PR #635 hitting the identical worktree-cleanup failure shape (`fatal: 'main' is already checked out`) with zero hook output — the first occurrence outside dev-env itself, confirming the gap is a property of the shared global hook architecture (these hooks fire for every repo), not dev-env-repo-specific.
- `pr-merge-reminder.py`'s `_build_messages()` is directly unit-tested with ~20 synthetic inputs, several of which have a non-zero exit code and no marker. A naive wiring would have made those existing tests shell out to a real `gh pr view` call (one stayed accidentally safe only because its synthetic cwd doesn't exist on disk). Instead, the live check is resolved in `main()` and passed in via a new `live_confirmed: bool | None = None` parameter — default `None` reproduces every pre-existing test's behavior exactly; the function itself never shells out.
- Per dev-env#504's own "Scope" section, this takes the simpler of the two named options: accepting up to six independent (redundant) `gh pr view` calls per failed-merge event rather than building a cross-hook shared-result cache.
- Adds [ADR-050 Amendment 8](docs/adr/050-shared-hookio-sibling-hook-fixes.md) documenting the rollout, and updates the `docs/REFERENCE.md` "Secondary effect" note to reflect the completed coverage (dev-env#498's separate "did the original fallback actually fire" question remains open and is untouched by this PR).

Closes #504

## Test plan

- [x] `py -3 -c "import ast,sys; ..."` syntax check on all 6 changed `.py` files
- [x] `py -3 claude/scripts/tests/test_usage_snapshot.py` — 11 passed
- [x] `py -3 claude/scripts/tests/test_post_merge_tile_checkpoint.py` — 4 passed
- [x] `py -3 claude/scripts/tests/test_post_pr_merge_pull.py` — 9 passed
- [x] `py -3 claude/scripts/tests/test_post_pr_merge_reclaim.py` — 4 passed
- [x] `py -3 claude/scripts/tests/test_pr_merge_reminder.py` — 45 passed (3 new: `live_confirmed=True/False/omitted`)
- [x] `py -3 claude/scripts/tests/test_hookio.py` — 44 passed (sanity check, unchanged file)
- [x] `py -3 claude/scripts/tests/test_post_pr_merge_project.py` — 16 passed (sanity check, unchanged file)
- [x] Suppression + test-integrity pre-PR greps — clean, no matches

Tests: 133 passed, 0 skipped, 0 failed (across all 8 files run)

The live `confirm_merge_via_gh` calls themselves remain untested in all 6 hooks, per this repo's established convention (it shells out to `gh pr view`; the repo avoids subprocess mocks) — same boundary `post-pr-merge-project.py`'s own test suite already leaves uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Review findings disposition

- **[maintainability] Dead `merge_pr_number_from_output` call in `usage-snapshot.py`** — fixed in `4b656cc`.
- **[reliability] Cumulative timeout exposure across up to 6 `gh pr view` calls** — accepted, no code change. Deliberate tradeoff named in dev-env#504's own "Scope" section (redundant calls vs. a shared-result cache) and re-confirmed explicitly this session. Worth revisiting only if cumulative latency becomes visible in practice.
- **[reliability] Crude substring merge-detection gate in 3 hooks widens a pre-existing false-positive's cost** — filed [dev-env#529](https://github.com/brownm09/dev-env/issues/529), out of scope for this PR (touches each file's existing tested predicate; needs its own test coverage).
