### PR TITLE
fix(hooks): converge post-merge-tile-checkpoint/pull/reclaim onto scan_top_level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,11 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
 10. **post-pr-merge-reclaim test** — required when changing `claude/scripts/post-pr-merge-reclaim.py`.
     Exercises the pure `is_successful_merge()` predicate offline: a `gh pr merge` whose output carries
     gh's success marker triggers reclamation, regardless of exit code; a non-merge command, a genuinely
-    failed merge, or an exit-0 non-merge invocation like `gh pr merge --help` (dev-env#485) does not. The
-    detached reclaim spawn is not covered (it shells out).
+    failed merge, an exit-0 non-merge invocation like `gh pr merge --help` (dev-env#485), or `gh pr merge`
+    text mentioned only inside a heredoc body, a quoted argument, or a `$()` subshell (dev-env#529, the
+    command-shape check is `scan_top_level`-anchored, not a raw substring test —
+    [ADR-050 Amendment 9](docs/adr/050-shared-hookio-sibling-hook-fixes.md)) does not. The detached reclaim
+    spawn is not covered (it shells out).
 
     ```bash
     py -3 claude/scripts/tests/test_post_pr_merge_reclaim.py
@@ -191,14 +194,17 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
 15. **post-pr-merge-pull test** — required when changing `claude/scripts/post-pr-merge-pull.py`. Exercises
     the pure `is_successful_merge()` predicate offline: a `gh pr merge` whose output carries gh's success
     marker triggers the local-`main` fast-forward regardless of exit code (worktree merges exit non-zero but
-    print the marker — issue #275); a non-merge command, a genuinely failed merge, or an exit-0 non-merge
-    invocation like `gh pr merge --help` (dev-env#485) does not. Also exercises the pure `pull_command()`
+    print the marker — issue #275); a non-merge command, a genuinely failed merge, an exit-0 non-merge
+    invocation like `gh pr merge --help` (dev-env#485), or `gh pr merge` text mentioned only inside a
+    heredoc body, a quoted argument, or a `$()` subshell (dev-env#529 — the command-shape check is
+    `scan_top_level`-anchored, not a raw substring test) does not. Also exercises the pure `pull_command()`
     predicate: a canonical checked out on `main` gets a plain `pull --ff-only` (the fetch-into-ref trick
     fails with 'refusing to fetch into branch ... checked out' there — dev-env#488,
     [ADR-058 amendment](docs/adr/058-worktree-squatting-main-detection-correction.md)); a feature branch
     (or squatting worktree) checked out gets the original fetch-into-ref, unchanged. The `pull_main` /
     `extract_repo` / `list_worktrees` git calls are not covered
-    ([ADR-050](docs/adr/050-shared-hookio-sibling-hook-fixes.md)).
+    ([ADR-050](docs/adr/050-shared-hookio-sibling-hook-fixes.md), incl. Amendment 9 for the command-shape
+    anchoring).
 
     ```bash
     py -3 claude/scripts/tests/test_post_pr_merge_pull.py
@@ -306,9 +312,12 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     `is_successful_merge()` predicate offline (no subprocess, no network, no disk):
     pins that a successful merge (gh's stdout success marker present, regardless of exit
     code) triggers the tile checkpoint reminder, while a non-merge command, a genuinely
-    failed merge (no success marker), or an exit-0 non-merge invocation like
-    `gh pr merge --help` (dev-env#485) does not
-    ([ADR-060](docs/adr/060-post-merge-tile-checkpoint-hook.md)).
+    failed merge (no success marker), an exit-0 non-merge invocation like
+    `gh pr merge --help` (dev-env#485), or `gh pr merge` text mentioned only inside a
+    heredoc body, a quoted argument, or a `$()` subshell (dev-env#529 — the command-shape
+    check is `scan_top_level`-anchored, not a raw substring test) does not
+    ([ADR-060](docs/adr/060-post-merge-tile-checkpoint-hook.md);
+    [ADR-050 Amendment 9](docs/adr/050-shared-hookio-sibling-hook-fixes.md)).
 
     ```bash
     py -3 claude/scripts/tests/test_post_merge_tile_checkpoint.py

--- a/claude/scripts/post-merge-tile-checkpoint.py
+++ b/claude/scripts/post-merge-tile-checkpoint.py
@@ -26,6 +26,7 @@ Exit 0 — not a successful `gh pr merge` call (including a genuinely-failed
 Exit 2 — successful merge detected; tile-checkpoint reminder emitted via stderr.
 """
 import json
+import re
 import sys
 
 from _hookio import (
@@ -33,8 +34,17 @@ from _hookio import (
     effective_merge_dir,
     output_has_merge_marker,
     read_command_output,
+    scan_top_level,
     should_confirm_via_gh,
 )
+
+# Anchored top-level match — mirrors usage-snapshot.py / pr-merge-reminder.py /
+# post-pr-merge-project.py's identical _check_merge_stmt (ADR-050 Amendments 5/6).
+_MERGE_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+merge\b")
+
+
+def _check_merge_stmt(token: str) -> bool:
+    return bool(_MERGE_RE.match(token.lstrip()))
 
 
 def is_successful_merge(command: str, output: str) -> bool:
@@ -46,8 +56,14 @@ def is_successful_merge(command: str, output: str) -> bool:
     #275), while a clean exit 0 is also true for non-merge invocations like
     `gh pr merge --help` or a queued `--auto` — an exit-0-alone gate misfired
     on exactly that shape (dev-env#485).
+
+    The command-shape check itself is `scan_top_level`-anchored rather than a
+    raw substring test, so `gh pr merge` text inside a heredoc body, a quoted
+    argument, or a `$()` subshell no longer counts as an invocation — matching
+    the pattern already used in usage-snapshot.py / pr-merge-reminder.py /
+    post-pr-merge-project.py (dev-env#529, ADR-050 Amendment 9).
     """
-    if "gh pr merge" not in command:
+    if not scan_top_level(command, _check_merge_stmt):
         return False
     return output_has_merge_marker(output)
 
@@ -74,7 +90,7 @@ def main() -> None:
         # when gh exits abruptly right after a worktree's local-cleanup
         # failure (dev-env#489) — fall back to a live `gh pr view` confirmation
         # rather than silently dropping the tile-checkpoint reminder (dev-env#504).
-        if "gh pr merge" not in command:
+        if not scan_top_level(command, _check_merge_stmt):
             sys.exit(0)
         exit_code = data.get("tool_response", {}).get("exitCode", -1)
         if not should_confirm_via_gh(exit_code, output):

--- a/claude/scripts/post-pr-merge-pull.py
+++ b/claude/scripts/post-pr-merge-pull.py
@@ -33,9 +33,19 @@ from _hookio import (
     effective_merge_dir,
     output_has_merge_marker,
     read_command_output,
+    scan_top_level,
     should_confirm_via_gh,
 )
 from _worktree_topology import canonical_on_main, merge_park_target, parse_worktree_porcelain
+
+# Anchored top-level match — mirrors usage-snapshot.py / pr-merge-reminder.py /
+# post-pr-merge-project.py's identical _check_merge_stmt (ADR-050 Amendments 5/6).
+_MERGE_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+merge\b")
+
+
+def _check_merge_stmt(token: str) -> bool:
+    return bool(_MERGE_RE.match(token.lstrip()))
+
 
 # Map GitHub repo slugs to local clone paths.
 # Repos with no local clone (e.g. profile-only repos) map to None.
@@ -213,8 +223,14 @@ def is_successful_merge(command: str, output: str) -> bool:
     is read via the shared `read_command_output` helper — reading the legacy
     `output` field left this fallback dead because the real payload carries
     `stdout`/`stderr` (#380).
+
+    The command-shape check itself is `scan_top_level`-anchored rather than a
+    raw substring test, so `gh pr merge` text inside a heredoc body, a quoted
+    argument, or a `$()` subshell no longer counts as an invocation — matching
+    the pattern already used in usage-snapshot.py / pr-merge-reminder.py /
+    post-pr-merge-project.py (dev-env#529, ADR-050 Amendment 9).
     """
-    if "gh pr merge" not in command:
+    if not scan_top_level(command, _check_merge_stmt):
         return False
     return output_has_merge_marker(output)
 
@@ -241,7 +257,7 @@ def main() -> None:
         # when gh exits abruptly right after a worktree's local-cleanup
         # failure (dev-env#489) — fall back to a live `gh pr view` confirmation
         # rather than silently skipping the local-main fast-forward (dev-env#504).
-        if "gh pr merge" not in command:
+        if not scan_top_level(command, _check_merge_stmt):
             sys.exit(0)
         exit_code = data.get("tool_response", {}).get("exitCode", -1)
         if not should_confirm_via_gh(exit_code, output):

--- a/claude/scripts/post-pr-merge-reclaim.py
+++ b/claude/scripts/post-pr-merge-reclaim.py
@@ -37,6 +37,7 @@ Exit 0 always — informational only; never blocks Claude.
 """
 import _winsubp  # noqa: F401  -- suppress console windows on Windows
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -46,11 +47,20 @@ from _hookio import (
     effective_merge_dir,
     output_has_merge_marker,
     read_command_output,
+    scan_top_level,
     should_confirm_via_gh,
 )
 
 SCAN_DIR = "C:/Users/brown/Git"
 RECLAIM_SCRIPT = Path(__file__).resolve().parent / "reclaim-worktree-disk.py"
+
+# Anchored top-level match — mirrors usage-snapshot.py / pr-merge-reminder.py /
+# post-pr-merge-project.py's identical _check_merge_stmt (ADR-050 Amendments 5/6).
+_MERGE_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+merge\b")
+
+
+def _check_merge_stmt(token: str) -> bool:
+    return bool(_MERGE_RE.match(token.lstrip()))
 
 
 def is_successful_merge(command: str, output: str) -> bool:
@@ -62,8 +72,14 @@ def is_successful_merge(command: str, output: str) -> bool:
     issue #275), while a clean exit 0 is also true for non-merge invocations
     like `gh pr merge --help` or a queued `--auto` — an exit-0-alone gate
     misfired on exactly that shape (dev-env#485).
+
+    The command-shape check itself is `scan_top_level`-anchored rather than a
+    raw substring test, so `gh pr merge` text inside a heredoc body, a quoted
+    argument, or a `$()` subshell no longer counts as an invocation — matching
+    the pattern already used in usage-snapshot.py / pr-merge-reminder.py /
+    post-pr-merge-project.py (dev-env#529, ADR-050 Amendment 9).
     """
-    if "gh pr merge" not in command:
+    if not scan_top_level(command, _check_merge_stmt):
         return False
     return output_has_merge_marker(output)
 
@@ -118,7 +134,7 @@ def main() -> None:
         # when gh exits abruptly right after a worktree's local-cleanup
         # failure (dev-env#489) — fall back to a live `gh pr view` confirmation
         # rather than silently skipping the disk reclaim (dev-env#504).
-        if "gh pr merge" not in command:
+        if not scan_top_level(command, _check_merge_stmt):
             sys.exit(0)
         exit_code = data.get("tool_response", {}).get("exitCode", -1)
         if not should_confirm_via_gh(exit_code, output):

--- a/claude/scripts/tests/test_post_merge_tile_checkpoint.py
+++ b/claude/scripts/tests/test_post_merge_tile_checkpoint.py
@@ -12,6 +12,14 @@ marker` fired on any exit-0 command matching "gh pr merge" as a substring,
 including `gh pr merge --help`. The predicate now gates solely on the success
 marker, matching post-pr-merge-project.py's `merge_succeeded()`.
 
+dev-env#529 (ADR-050 Amendment 9) converged the command-shape check itself
+from a raw `"gh pr merge" not in command` substring test onto the
+`scan_top_level`-anchored predicate already used by usage-snapshot.py /
+pr-merge-reminder.py / post-pr-merge-project.py. The three
+heredoc/quote/subshell tests below pin the false-positive shapes that
+substring test was blind to (dev-env#499's original repro class) but the
+anchored predicate correctly rejects.
+
 The main() I/O (stdin read, stderr write, sys.exit) is not covered — pure-helper
 convention.
 
@@ -79,12 +87,49 @@ def test_help_invocation_no_marker_ignored() -> str:
     return "gh pr merge --help (exit 0, no marker) -> no-op (dev-env#485)"
 
 
+# ---------------------------------------------------------------------------
+# command-shape anchoring (dev-env#529, ADR-050 Amendment 9)
+#
+# Each command below contains the literal substring "gh pr merge" but not as
+# a genuine top-level invocation. Paired with an output that DOES carry a
+# real success marker, isolating the command-shape check: the old crude
+# `"gh pr merge" not in command` substring test would have proceeded past
+# this check straight to the (passing) marker check and fired -- a false
+# positive. The scan_top_level-anchored check returns False before the
+# marker is ever consulted.
+# ---------------------------------------------------------------------------
+
+def test_merge_text_in_heredoc_body_not_matched() -> str:
+    command = "git commit -F - <<'EOF'\ngh pr merge --squash --delete-branch\nEOF"
+    assert not is_successful_merge(command, "Squashed and merged pull request #415")
+    return "'gh pr merge' text inside a heredoc body -> no match (dev-env#529)"
+
+
+def test_merge_text_inside_double_quotes_not_matched() -> str:
+    # The && inside the quoted commit message would, without quote-tracking,
+    # wrongly carve out a second top-level segment starting with "gh pr
+    # merge" -- the dev-env#499 false-positive class scan_top_level exists
+    # to prevent.
+    command = 'git commit -m "gh pr create --fill && gh pr merge --auto"'
+    assert not is_successful_merge(command, "Squashed and merged pull request #415")
+    return "'gh pr merge' text inside a double-quoted commit message -> no match (dev-env#529)"
+
+
+def test_merge_text_inside_subshell_not_matched() -> str:
+    command = "echo $(gh pr create --fill && gh pr merge --auto)"
+    assert not is_successful_merge(command, "Squashed and merged pull request #415")
+    return "'gh pr merge' text inside a $() subshell -> no match (dev-env#529)"
+
+
 def main() -> int:
     tests = [
         ("merge marker present -> fires", test_clean_merge_with_marker_fires),
         ("failed merge with no marker ignored", test_failed_merge_no_marker_ignored),
         ("non-merge commands ignored", test_non_merge_commands_ignored),
         ("gh pr merge --help (no marker) ignored (dev-env#485)", test_help_invocation_no_marker_ignored),
+        ("'gh pr merge' text in heredoc body ignored (dev-env#529)", test_merge_text_in_heredoc_body_not_matched),
+        ("'gh pr merge' text in double quotes ignored (dev-env#529)", test_merge_text_inside_double_quotes_not_matched),
+        ("'gh pr merge' text in $() subshell ignored (dev-env#529)", test_merge_text_inside_subshell_not_matched),
     ]
     failed = 0
     for name, fn in tests:

--- a/claude/scripts/tests/test_post_pr_merge_pull.py
+++ b/claude/scripts/tests/test_post_pr_merge_pull.py
@@ -14,6 +14,14 @@ marker` fired on any exit-0 command matching "gh pr merge" as a substring,
 including `gh pr merge --help`. The predicate now gates solely on the success
 marker, matching post-pr-merge-project.py's `merge_succeeded()`.
 
+dev-env#529 (ADR-050 Amendment 9) converged the command-shape check itself
+from a raw `"gh pr merge" not in command` substring test onto the
+`scan_top_level`-anchored predicate already used by usage-snapshot.py /
+pr-merge-reminder.py / post-pr-merge-project.py. The three
+heredoc/quote/subshell tests below pin the false-positive shapes that
+substring test was blind to (dev-env#499's original repro class) but the
+anchored predicate correctly rejects.
+
 `pull_command()` (dev-env#488) is the pure decision of which git invocation
 fast-forwards local main: `git fetch origin main:main` fails ('refusing to fetch
 into branch ... checked out') whenever main is the branch currently checked out
@@ -89,6 +97,40 @@ def test_help_invocation_no_marker_ignored() -> str:
 
 
 # ---------------------------------------------------------------------------
+# command-shape anchoring (dev-env#529, ADR-050 Amendment 9)
+#
+# Each command below contains the literal substring "gh pr merge" but not as
+# a genuine top-level invocation. Paired with an output that DOES carry a
+# real success marker, isolating the command-shape check: the old crude
+# `"gh pr merge" not in command` substring test would have proceeded past
+# this check straight to the (passing) marker check and fired -- a false
+# positive. The scan_top_level-anchored check returns False before the
+# marker is ever consulted.
+# ---------------------------------------------------------------------------
+
+def test_merge_text_in_heredoc_body_not_matched() -> str:
+    command = "git commit -F - <<'EOF'\ngh pr merge --squash --delete-branch\nEOF"
+    assert not is_successful_merge(command, "Squashed and merged pull request #380")
+    return "'gh pr merge' text inside a heredoc body -> no match (dev-env#529)"
+
+
+def test_merge_text_inside_double_quotes_not_matched() -> str:
+    # The && inside the quoted commit message would, without quote-tracking,
+    # wrongly carve out a second top-level segment starting with "gh pr
+    # merge" -- the dev-env#499 false-positive class scan_top_level exists
+    # to prevent.
+    command = 'git commit -m "gh pr create --fill && gh pr merge --auto"'
+    assert not is_successful_merge(command, "Squashed and merged pull request #380")
+    return "'gh pr merge' text inside a double-quoted commit message -> no match (dev-env#529)"
+
+
+def test_merge_text_inside_subshell_not_matched() -> str:
+    command = "echo $(gh pr create --fill && gh pr merge --auto)"
+    assert not is_successful_merge(command, "Squashed and merged pull request #380")
+    return "'gh pr merge' text inside a $() subshell -> no match (dev-env#529)"
+
+
+# ---------------------------------------------------------------------------
 # extract_repo — pure-string resolution paths (dev-env#446 / ADR-067)
 #
 # The git-remote subprocess fallback is not tested (repo convention: no mocks).
@@ -142,6 +184,9 @@ def main() -> int:
         ("non-merge command ignored", test_non_merge_command_ignored),
         ("failed merge with no marker ignored", test_failed_merge_no_marker_ignored),
         ("gh pr merge --help (no marker) ignored (dev-env#485)", test_help_invocation_no_marker_ignored),
+        ("'gh pr merge' text in heredoc body ignored (dev-env#529)", test_merge_text_in_heredoc_body_not_matched),
+        ("'gh pr merge' text in double quotes ignored (dev-env#529)", test_merge_text_inside_double_quotes_not_matched),
+        ("'gh pr merge' text in $() subshell ignored (dev-env#529)", test_merge_text_inside_subshell_not_matched),
         ("extract_repo: GitHub URL in command -> owner/repo", test_extract_repo_from_url_in_command),
         ("extract_repo: URL for different repo", test_extract_repo_from_url_other_repo),
         ("extract_repo: --repo flag beats URL", test_extract_repo_repo_flag_takes_precedence),

--- a/claude/scripts/tests/test_post_pr_merge_reclaim.py
+++ b/claude/scripts/tests/test_post_pr_merge_reclaim.py
@@ -13,6 +13,14 @@ marker` fired on any exit-0 command matching "gh pr merge" as a substring,
 including `gh pr merge --help`. The predicate now gates solely on the success
 marker, matching post-pr-merge-project.py's `merge_succeeded()`.
 
+dev-env#529 (ADR-050 Amendment 9) converged the command-shape check itself
+from a raw `"gh pr merge" not in command` substring test onto the
+`scan_top_level`-anchored predicate already used by usage-snapshot.py /
+pr-merge-reminder.py / post-pr-merge-project.py. The three
+heredoc/quote/subshell tests below pin the false-positive shapes that
+substring test was blind to (dev-env#499's original repro class) but the
+anchored predicate correctly rejects.
+
 The detached spawn (`_spawn_reclaim`) is intentionally not tested — it shells out
 and the repo avoids subprocess mocks.
 
@@ -78,12 +86,49 @@ def test_help_invocation_no_marker_ignored() -> str:
     return "gh pr merge --help (exit 0, no marker) -> no-op (dev-env#485)"
 
 
+# ---------------------------------------------------------------------------
+# command-shape anchoring (dev-env#529, ADR-050 Amendment 9)
+#
+# Each command below contains the literal substring "gh pr merge" but not as
+# a genuine top-level invocation. Paired with an output that DOES carry a
+# real success marker, isolating the command-shape check: the old crude
+# `"gh pr merge" not in command` substring test would have proceeded past
+# this check straight to the (passing) marker check and fired -- a false
+# positive. The scan_top_level-anchored check returns False before the
+# marker is ever consulted.
+# ---------------------------------------------------------------------------
+
+def test_merge_text_in_heredoc_body_not_matched() -> str:
+    command = "git commit -F - <<'EOF'\ngh pr merge --squash --delete-branch\nEOF"
+    assert not is_successful_merge(command, "Squashed and merged pull request #364")
+    return "'gh pr merge' text inside a heredoc body -> no match (dev-env#529)"
+
+
+def test_merge_text_inside_double_quotes_not_matched() -> str:
+    # The && inside the quoted commit message would, without quote-tracking,
+    # wrongly carve out a second top-level segment starting with "gh pr
+    # merge" -- the dev-env#499 false-positive class scan_top_level exists
+    # to prevent.
+    command = 'git commit -m "gh pr create --fill && gh pr merge --auto"'
+    assert not is_successful_merge(command, "Squashed and merged pull request #364")
+    return "'gh pr merge' text inside a double-quoted commit message -> no match (dev-env#529)"
+
+
+def test_merge_text_inside_subshell_not_matched() -> str:
+    command = "echo $(gh pr create --fill && gh pr merge --auto)"
+    assert not is_successful_merge(command, "Squashed and merged pull request #364")
+    return "'gh pr merge' text inside a $() subshell -> no match (dev-env#529)"
+
+
 def main() -> int:
     tests = [
         ("merge marker present -> reclaims", test_clean_merge_with_marker_reclaims),
         ("non-merge command ignored", test_non_merge_command_ignored),
         ("failed merge with no marker ignored", test_failed_merge_no_marker_ignored),
         ("gh pr merge --help (no marker) ignored (dev-env#485)", test_help_invocation_no_marker_ignored),
+        ("'gh pr merge' text in heredoc body ignored (dev-env#529)", test_merge_text_in_heredoc_body_not_matched),
+        ("'gh pr merge' text in double quotes ignored (dev-env#529)", test_merge_text_inside_double_quotes_not_matched),
+        ("'gh pr merge' text in $() subshell ignored (dev-env#529)", test_merge_text_inside_subshell_not_matched),
     ]
     failed = 0
     for name, fn in tests:

--- a/docs/adr/050-shared-hookio-sibling-hook-fixes.md
+++ b/docs/adr/050-shared-hookio-sibling-hook-fixes.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-21
 **Status:** Accepted
-**Amended:** 2026-07-01, 2026-07-02 (seven amendments — see Amendment sections below)
+**Amended:** 2026-07-01, 2026-07-02 (nine amendments — see Amendment sections below)
 **Tags:** hooks, post-tool-use, tool_response, payload, github-project, automation, reliability, dry, usage-snapshot, pr-merge-reminder, gh-pr-view, api-fallback, message-dispatch, top-level-statement-scan, issue-create, false-positive, command-parsing, heredoc, regex, quote-tracking, canonical-mutate-guard, pre-tool-use
 
 ---
@@ -547,3 +547,69 @@ direct synthetic-input test coverage requires checking every existing test case 
 path before assuming "add the fallback the same way as the reference hook" is a safe copy — one of
 `pr-merge-reminder.py`'s own pre-existing tests would have started shelling out to `gh` for real had the
 fallback been added inside `_build_messages` rather than gated in `main()`.
+
+## Amendment 9 (2026-07-02) — converging the 3 remaining marker-gated hooks' command-shape check onto `scan_top_level` (dev-env#529)
+
+Amendments 5 and 6 converged `pr-merge-reminder.py`, `post-tool-use.py`, `usage-snapshot.py`, and
+`post-pr-merge-project.py` onto the shared `scan_top_level` engine for command-shape detection. Three
+siblings sharing the identical `is_successful_merge(command, output)` predicate shape —
+`post-merge-tile-checkpoint.py`, `post-pr-merge-pull.py`, `post-pr-merge-reclaim.py` — were left on the
+original crude `if "gh pr merge" not in command: return False` substring test, missed by both sweeps for
+the same reason Amendment 6 named its own two misses: their need (merge detection only) didn't visually
+match the `gh pr create`-detection shape either sweep was scoped to look for.
+
+**Concrete consequence, surfaced during dev-env#504's rollout review ([PR #528](https://github.com/brownm09/dev-env/pull/528)):**
+before #528 wired `confirm_merge_via_gh` into these three hooks, a false substring match — literal
+`gh pr merge` text inside a heredoc body or a quoted argument, not a real invocation — combined with a
+missing `exitCode` (defaulting to `-1`, per this ADR's own Context section noting the real payload often
+omits the field entirely) and no success marker was harmless: the hook just exited 0 after
+`is_successful_merge` returned `False`. After #528, that same false match now reaches
+`should_confirm_via_gh(-1, output)` — `True`, since `-1 != 0` and no marker is present — and pays a real
+`gh pr view` subprocess call before exiting 0.
+
+**Symptom, live-reproduced during this very fix's own session (dev-env#529):** a Bash command that wrote
+and ran a Python fixture script containing the literal text `"gh pr merge --squash --delete-branch"`
+inside a heredoc (test data for this fix's own regression tests, below) false-triggered the *canonical*,
+not-yet-fixed `post-merge-tile-checkpoint.py`: `should_confirm_via_gh` saw the substring-matched command,
+the absent `exitCode`, and no marker in the fixture script's own stdout, so it proceeded to a live
+`confirm_merge_via_gh` call — which found a real `MERGED` PR against the session's actual checked-out
+branch (unrelated to the Bash command that triggered the check) and fired the tile-checkpoint reminder for
+a merge that did not happen in that Bash call at all. The blast radius: a misattributed reminder, plus a
+paid `gh pr view` network round-trip, for a command that never invoked `gh` — reproducing the "Concrete
+consequence" paragraph above firsthand rather than only by inspection.
+
+**Fix:** for each of the three files — added a local `_MERGE_RE` / `_check_merge_stmt` pair, identical to
+the one already defined in `usage-snapshot.py` / `pr-merge-reminder.py` / `post-pr-merge-project.py`
+(`(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+merge\b`, anchored via `.match()` on the lstripped token); replaced both
+occurrences of `if "gh pr merge" not in command` — one inside each file's `is_successful_merge()`, one
+inside `main()`'s live-confirmation fallback gate — with `if not scan_top_level(command,
+_check_merge_stmt)`. Behavior-preserving for every pre-existing test case (a real `gh pr merge`
+invocation, bare or `--help`-flagged, is still matched or rejected identically); the only behavior change
+is that a `gh pr merge`-shaped substring inside a heredoc body, a quoted argument, or a `$()` subshell no
+longer counts as an invocation. A repo-wide grep for `"gh pr merge" not in command` after the fix returns
+zero matches in `claude/scripts/*.py` — the pattern survives only in this ADR's own history and in the
+new tests' explanatory comments describing the pre-fix behavior.
+
+**Coverage:** each file's existing `is_successful_merge()` test suite — marker-detection only before this
+amendment, per the issue's own framing — gains three new cases mirroring the dev-env#499 false-positive
+shapes `test_hookio.py`'s own `scan_top_level` suite already covers at the engine level: a heredoc body, a
+double-quoted argument (the `&&`-inside-quotes shape that would otherwise carve out a second top-level
+segment starting with `gh pr merge`), and a `$()` subshell. Each new case pairs the false-match command
+with an output string that DOES carry a genuine success marker, isolating the command-shape check from the
+marker check — the old substring test would have proceeded past a false match straight to the (passing)
+marker check and returned `True`. Verified directly against the extracted pre-fix predicate logic before
+writing the fix (re-running the three new command/output pairs through a standalone
+`if "gh pr merge" not in command: return False` implementation) that all three genuinely reproduce the old
+bug (`True`), confirming the new tests are real regressions, not vacuously-true assertions. 26 total tests
+across the three files (7 + 12 + 7), up from 17 (4 + 9 + 4) pre-amendment.
+
+**General lesson (continuing Amendments 1 and 6's):** a sweep is only as complete as the list it started
+from, a third time. Amendment 6 already drew this lesson from missing `usage-snapshot.py` and
+`post-pr-merge-project.py`; this amendment is the same lesson applied to a *different* narrow-need shape
+(marker-gated merge detection with no `gh pr create`/`git push` sibling need) that neither Amendment 5's
+nor Amendment 6's sweep enumerated. A durable mechanical proxy going forward: grep the whole
+`claude/scripts/` tree for the literal string `"gh pr merge" not in command` (and its `"gh pr create"` /
+`"git push"` analogs, still live in `stub-push-archive-reminder.py`'s unrelated `git push`-only check,
+left untouched here as out of scope for this issue) before declaring any future `scan_top_level`
+convergence sweep complete — a textual grep catches what a conceptual "which hooks need this kind of
+detection" sweep can miss, as it did three times running.


### PR DESCRIPTION
## Summary

- Converges `is_successful_merge()`'s command-shape check in `post-merge-tile-checkpoint.py`, `post-pr-merge-pull.py`, and `post-pr-merge-reclaim.py` from the crude `"gh pr merge" not in command` substring test onto `scan_top_level(command, _check_merge_stmt)` — the anchored predicate already used by `usage-snapshot.py` / `pr-merge-reminder.py` / `post-pr-merge-project.py` (ADR-050 Amendments 5/6). These 3 files were missed by both prior convergence sweeps, per #529.
- Adds a local `_MERGE_RE` / `_check_merge_stmt` pair to each file, identical to the established pattern. Both occurrences of the old check — inside `is_successful_merge()` and inside `main()`'s live-`gh pr view`-fallback gate — are replaced.
- Closes the false-positive gap: `gh pr merge` text inside a heredoc body, a quoted argument, or a `$()` subshell no longer counts as an invocation. Since PR #528 wired `confirm_merge_via_gh` into these hooks, a false match on this shape paid a real `gh pr view` network round-trip before exiting 0.
- Documents the convergence as **ADR-050 Amendment 9**, including a false positive I live-reproduced during this session's own testing: my scratch verification script's heredoc fixture data (containing literal `"gh pr merge --squash --delete-branch"` text as test input) false-triggered the *canonical*, not-yet-fixed `post-merge-tile-checkpoint.py` hook mid-session.
- Lightly updates the 3 corresponding `## Testing` item descriptions in `CLAUDE.md` (items #10, #15, #23) to note the anchored check, mirroring item #24's existing wording style.

## Test plan

- [x] `py -3 -c "import ast,sys; ..."` syntax check over every `claude/scripts/*.py` — clean
- [x] All 32 test files under `claude/scripts/tests/` run individually — **Tests: 511 passed, 0 skipped, 0 failed**
- [x] 9 new heredoc/quote/subshell regression tests added (3 per file) to the 3 target test suites, each verified directly against the extracted pre-fix predicate logic to confirm they reproduce the old bug (`True`) — not vacuously-true assertions
- [x] Repo-wide grep confirms zero remaining `"gh pr merge" not in command` occurrences in `claude/scripts/*.py` (the one remaining similarly-shaped check, `stub-push-archive-reminder.py`'s unrelated `git push` check, is out of scope for #529 and left untouched)

No automated tests were skipped or degraded; no suppressions were added.

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)