### PR TITLE
fix(hooks): converge stub-push-archive-reminder.py onto scan_top_level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,8 +213,13 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
 16. **stub-push-archive-reminder test** — required when changing
     `claude/scripts/stub-push-archive-reminder.py`. Exercises the pure `has_push_error()` guard offline: a
     successful push output arms the archive reminder, while an `error:` / `fatal:` line (case-insensitive)
-    blocks it. The pre-#380 read of the legacy `output` field was always empty, so this guard was a no-op
-    ([ADR-050](docs/adr/050-shared-hookio-sibling-hook-fixes.md)).
+    blocks it. The pre-#380 read of the legacy `output` field was always empty, so this guard was a no-op.
+    Also exercises the pure `is_git_push_command()` predicate (dev-env#532): a bare top-level `git push`
+    matches, while `git push` text mentioned only inside a heredoc body, a quoted argument, or a `$()`
+    subshell does not — the command-shape check is `scan_top_level`-anchored, not a raw substring test,
+    mirroring `pr-merge-reminder.py`'s identical `is_git_push_command()`
+    ([ADR-050](docs/adr/050-shared-hookio-sibling-hook-fixes.md), incl. Amendment 10 for the command-shape
+    anchoring).
 
     ```bash
     py -3 claude/scripts/tests/test_stub_push_archive_reminder.py

--- a/claude/scripts/stub-push-archive-reminder.py
+++ b/claude/scripts/stub-push-archive-reminder.py
@@ -3,7 +3,9 @@
 engineering-journal so the Stop hook can remind Claude to archive the session.
 
 Fires on every Bash tool call. Most calls are skipped quickly:
-  1. Command must contain "git push"
+  1. Command must contain a top-level `git push` invocation (scan_top_level-
+     anchored — not text inside a heredoc body, a quoted argument, or a $()
+     subshell)
   2. Command must reference the engineering-journal repo
   3. Push must have succeeded (no error output)
   4. Most-recent commit in engineering-journal must touch a .stub.md file
@@ -25,14 +27,36 @@ Stdin JSON shape (PostToolUse):
 """
 import _winsubp  # noqa: F401  -- suppress console windows on Windows
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
 
-from _hookio import read_command_output
+from _hookio import read_command_output, scan_top_level
 
 JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
 SENTINEL = Path.home() / ".claude" / "scratch" / "stub-pushed.flag"
+
+# Anchored top-level match — identical to pr-merge-reminder.py's
+# _check_push_stmt / is_git_push_command (ADR-050 Amendments 5/6/10).
+_PUSH_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?git\s+push\b")
+
+
+def _check_push_stmt(token: str) -> bool:
+    return bool(_PUSH_RE.match(token.lstrip()))
+
+
+def is_git_push_command(command: str) -> bool:
+    """Return True only when *command* contains a top-level `git push`.
+
+    Anchored via `scan_top_level` rather than a raw substring test, so
+    `git push` text inside a heredoc body, a quoted argument, or a `$()`
+    subshell does not count as an invocation — matching the pattern used in
+    usage-snapshot.py / pr-merge-reminder.py / post-pr-merge-project.py /
+    post-merge-tile-checkpoint.py / post-pr-merge-pull.py /
+    post-pr-merge-reclaim.py (dev-env#532, ADR-050 Amendment 10).
+    """
+    return scan_top_level(command, _check_push_stmt)
 
 
 def most_recent_commit_has_stub(repo: Path) -> bool:
@@ -79,7 +103,7 @@ def main() -> None:
     output = read_command_output(data)
 
     # Must be a git push
-    if "git push" not in command:
+    if not is_git_push_command(command):
         sys.exit(0)
 
     # Must reference engineering-journal

--- a/claude/scripts/stub-push-archive-reminder.py
+++ b/claude/scripts/stub-push-archive-reminder.py
@@ -38,7 +38,8 @@ JOURNAL_REPO = Path.home() / "Git" / "engineering-journal"
 SENTINEL = Path.home() / ".claude" / "scratch" / "stub-pushed.flag"
 
 # Anchored top-level match — identical to pr-merge-reminder.py's
-# _check_push_stmt / is_git_push_command (ADR-050 Amendments 5/6/10).
+# _check_push_stmt / is_git_push_command (ADR-050 Amendment 5 and this
+# Amendment 10).
 _PUSH_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?git\s+push\b")
 
 
@@ -51,10 +52,9 @@ def is_git_push_command(command: str) -> bool:
 
     Anchored via `scan_top_level` rather than a raw substring test, so
     `git push` text inside a heredoc body, a quoted argument, or a `$()`
-    subshell does not count as an invocation — matching the pattern used in
-    usage-snapshot.py / pr-merge-reminder.py / post-pr-merge-project.py /
-    post-merge-tile-checkpoint.py / post-pr-merge-pull.py /
-    post-pr-merge-reclaim.py (dev-env#532, ADR-050 Amendment 10).
+    subshell does not count as an invocation — identical to
+    pr-merge-reminder.py's own `is_git_push_command()`, the only other hook
+    with a git-push-detection need (dev-env#532, ADR-050 Amendment 10).
     """
     return scan_top_level(command, _check_push_stmt)
 

--- a/claude/scripts/tests/test_stub_push_archive_reminder.py
+++ b/claude/scripts/tests/test_stub_push_archive_reminder.py
@@ -91,6 +91,11 @@ def test_bare_push_matched() -> str:
     return "bare git push -> matched (sanity baseline)"
 
 
+def test_push_with_cd_prefix_matched() -> str:
+    assert is_git_push_command("cd /Git/engineering-journal && git push")
+    return "cd <dir> && git push -> matched (_PUSH_RE's optional cd-prefix branch)"
+
+
 def test_push_text_in_heredoc_body_not_matched() -> str:
     command = "git commit -F - <<'EOF'\ngit push origin main\nEOF"
     assert not is_git_push_command(command)
@@ -121,6 +126,7 @@ def main() -> int:
         ("case-insensitive match", test_case_insensitive),
         ("empty output has no error", test_empty_output_no_error),
         ("bare git push matched", test_bare_push_matched),
+        ("cd-prefixed git push matched", test_push_with_cd_prefix_matched),
         ("'git push' text in heredoc body ignored (dev-env#532)", test_push_text_in_heredoc_body_not_matched),
         ("'git push' text in double quotes ignored (dev-env#532)", test_push_text_inside_double_quotes_not_matched),
         ("'git push' text in $() subshell ignored (dev-env#532)", test_push_text_inside_subshell_not_matched),

--- a/claude/scripts/tests/test_stub_push_archive_reminder.py
+++ b/claude/scripts/tests/test_stub_push_archive_reminder.py
@@ -8,6 +8,16 @@ payload), so it was a no-op — a failed push could still arm the reminder. The
 guard is now the pure `has_push_error()` predicate fed by the shared
 `read_command_output` helper, exercised offline here.
 
+dev-env#532 (ADR-050 Amendment 10) converged the "is this a git push?" check
+itself from a raw `"git push" not in command` substring test onto a new pure
+`is_git_push_command()` predicate, built on the same `scan_top_level` engine
+already used by usage-snapshot.py / pr-merge-reminder.py /
+post-pr-merge-project.py / post-merge-tile-checkpoint.py /
+post-pr-merge-pull.py / post-pr-merge-reclaim.py (dev-env#529, ADR-050
+Amendment 9). The three heredoc/quote/subshell tests below pin the
+false-positive shapes that substring test was blind to (dev-env#499's
+original repro class) but the anchored predicate correctly rejects.
+
 `most_recent_commit_has_stub` (a git call) is intentionally not tested.
 
 Usage:
@@ -33,6 +43,7 @@ assert _spec and _spec.loader, f"cannot load module spec from {SCRIPT}"
 spar = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(spar)  # safe: main() is guarded by __main__
 has_push_error = spar.has_push_error
+is_git_push_command = spar.is_git_push_command
 
 
 def test_clean_push_no_error() -> str:
@@ -66,6 +77,42 @@ def test_empty_output_no_error() -> str:
     return "empty output -> no error"
 
 
+# ---------------------------------------------------------------------------
+# is_git_push_command — command-shape anchoring (dev-env#532, ADR-050 Amendment 10)
+#
+# Each command below contains the literal substring "git push" but not as a
+# genuine top-level invocation. The old crude `"git push" not in command`
+# substring test would have matched all three; the scan_top_level-anchored
+# predicate correctly rejects them.
+# ---------------------------------------------------------------------------
+
+def test_bare_push_matched() -> str:
+    assert is_git_push_command("git push -u origin draft/2026-06-21")
+    return "bare git push -> matched (sanity baseline)"
+
+
+def test_push_text_in_heredoc_body_not_matched() -> str:
+    command = "git commit -F - <<'EOF'\ngit push origin main\nEOF"
+    assert not is_git_push_command(command)
+    return "'git push' text inside a heredoc body -> no match (dev-env#532)"
+
+
+def test_push_text_inside_double_quotes_not_matched() -> str:
+    # The && inside the quoted commit message would, without quote-tracking,
+    # wrongly carve out a second top-level segment starting with "git push"
+    # -- the dev-env#499 false-positive class scan_top_level exists to
+    # prevent.
+    command = 'git commit -m "document the git push workflow && git push origin main"'
+    assert not is_git_push_command(command)
+    return "'git push' text inside a double-quoted commit message -> no match (dev-env#532)"
+
+
+def test_push_text_inside_subshell_not_matched() -> str:
+    command = "echo $(git log --oneline -1 && git push origin main)"
+    assert not is_git_push_command(command)
+    return "'git push' text inside a $() subshell -> no match (dev-env#532)"
+
+
 def main() -> int:
     tests = [
         ("clean push has no error", test_clean_push_no_error),
@@ -73,6 +120,10 @@ def main() -> int:
         ("git fatal: detected", test_git_fatal_detected),
         ("case-insensitive match", test_case_insensitive),
         ("empty output has no error", test_empty_output_no_error),
+        ("bare git push matched", test_bare_push_matched),
+        ("'git push' text in heredoc body ignored (dev-env#532)", test_push_text_in_heredoc_body_not_matched),
+        ("'git push' text in double quotes ignored (dev-env#532)", test_push_text_inside_double_quotes_not_matched),
+        ("'git push' text in $() subshell ignored (dev-env#532)", test_push_text_inside_subshell_not_matched),
     ]
     failed = 0
     for name, fn in tests:

--- a/docs/adr/050-shared-hookio-sibling-hook-fixes.md
+++ b/docs/adr/050-shared-hookio-sibling-hook-fixes.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-21
 **Status:** Accepted
-**Amended:** 2026-07-01, 2026-07-02 (nine amendments — see Amendment sections below)
+**Amended:** 2026-07-01, 2026-07-02 (ten amendments — see Amendment sections below)
 **Tags:** hooks, post-tool-use, tool_response, payload, github-project, automation, reliability, dry, usage-snapshot, pr-merge-reminder, gh-pr-view, api-fallback, message-dispatch, top-level-statement-scan, issue-create, false-positive, command-parsing, heredoc, regex, quote-tracking, canonical-mutate-guard, pre-tool-use
 
 ---
@@ -613,3 +613,54 @@ nor Amendment 6's sweep enumerated. A durable mechanical proxy going forward: gr
 left untouched here as out of scope for this issue) before declaring any future `scan_top_level`
 convergence sweep complete — a textual grep catches what a conceptual "which hooks need this kind of
 detection" sweep can miss, as it did three times running.
+
+## Amendment 10 (2026-07-02) — converging `stub-push-archive-reminder.py`'s command-shape check onto `scan_top_level` (dev-env#532)
+
+Amendment 9's own "General lesson" named the exact gap this amendment closes: its durable mechanical grep
+proxy explicitly listed `stub-push-archive-reminder.py`'s `git push`-only check as "left untouched here as
+out of scope for this issue." This amendment is that named follow-up, not a new discovery — a repo-wide
+grep for `"gh pr create" not in command` and `"gh pr merge" not in command` immediately before this fix
+confirmed both were already zero matches in `claude/scripts/*.py` (closed by Amendment 5's
+`post-tool-use.py` fix and Amendment 9 respectively); `"git push" not in command` had exactly one, this
+file's line 82.
+
+**Shape difference from Amendment 9's three files:** `post-merge-tile-checkpoint.py`,
+`post-pr-merge-pull.py`, and `post-pr-merge-reclaim.py` each already exposed their substring check as a
+separate, pre-tested pure predicate (`is_successful_merge()`), so Amendment 9 only needed to swap the
+check's implementation. `stub-push-archive-reminder.py`'s `if "git push" not in command` lived inline in
+`main()` with no equivalent — per this repo's own convention that `main()`'s stdin/exit-code I/O is
+untested by design (`test_stub_push_archive_reminder.py`'s own docstring already noted `main()` is out of
+scope), there was nothing pure to attach regression coverage to. This amendment therefore also extracts a
+new named predicate, `is_git_push_command(command)`, mirroring the role `is_successful_merge()` plays in
+the three Amendment 9 hooks.
+
+**Not new regex design — a port.** `pr-merge-reminder.py` already defines the exact predicate this file
+needs: `_PUSH_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?git\s+push\b")`, `_check_push_stmt`, and a wrapper
+`is_git_push_command(command)` (added under Amendment 5, for its own `git push`-triggered journal-update
+reminder). `stub-push-archive-reminder.py` gains an identical, independently-defined trio — consistent
+with this ADR's established scope decision (Amendment 5: "only the engine is shared, not the wrapper
+functions") — rather than a newly-authored regex.
+
+**Fix:** added the `_PUSH_RE` / `_check_push_stmt` / `is_git_push_command()` trio to
+`stub-push-archive-reminder.py`; replaced the sole occurrence of `if "git push" not in command:` in
+`main()` with `if not is_git_push_command(command):`. Behavior-preserving for every real invocation (a
+bare or `cd`-prefixed `git push` still matches identically); the only behavior change is that `git push`
+text inside a heredoc body, a quoted argument, or a `$()` subshell no longer counts as an invocation. A
+repo-wide grep for `"git push" not in command` after the fix returns zero matches in
+`claude/scripts/*.py` — combined with the pre-fix state confirmed above, all three `"X" not in command`
+analogs Amendment 9's "General lesson" named are now closed.
+
+**Coverage:** `test_stub_push_archive_reminder.py` gains four new cases: a bare top-level `git push`
+sanity baseline (this predicate had no pre-existing positive-match test to inherit, unlike the three
+Amendment 9 hooks' already-tested `is_successful_merge()`), plus the same three dev-env#499
+false-positive shapes Amendment 9 covered — a heredoc body, a double-quoted `&&`-embedded argument, and a
+`$()` subshell. Unlike Amendment 9's tests, these don't pair the false-match command with a
+marker-bearing output to isolate the command-shape check from a second gate — `is_git_push_command()` is
+a single-argument, single-purpose predicate with no downstream marker check to isolate from.
+
+**General lesson (continuing Amendments 1, 6, and 9's):** a sweep's own written-down "out of scope" note
+is a checklist, not a closed door — Amendment 9 named this file and this fix by hand; this amendment is
+the mechanical act of doing what was already written down. The three-times-repeated lesson from
+Amendments 1/6/9 (a sweep is only as complete as the list it started from) has a corollary: when a sweep
+*does* write down what it deliberately left out, that note is the cheapest possible seed for the next
+sweep — cheaper than re-deriving the gap from a fresh grep.

--- a/docs/adr/050-shared-hookio-sibling-hook-fixes.md
+++ b/docs/adr/050-shared-hookio-sibling-hook-fixes.md
@@ -620,9 +620,11 @@ Amendment 9's own "General lesson" named the exact gap this amendment closes: it
 proxy explicitly listed `stub-push-archive-reminder.py`'s `git push`-only check as "left untouched here as
 out of scope for this issue." This amendment is that named follow-up, not a new discovery — a repo-wide
 grep for `"gh pr create" not in command` and `"gh pr merge" not in command` immediately before this fix
-confirmed both were already zero matches in `claude/scripts/*.py` (closed by Amendment 5's
-`post-tool-use.py` fix and Amendment 9 respectively); `"git push" not in command` had exactly one, this
-file's line 82.
+confirmed both were already zero matches in `claude/scripts/*.py` (the `"gh pr merge"` shape closed by
+Amendment 9; the `"gh pr create"` shape appears to have never existed in that literal form —
+`post-tool-use.py`'s pre-Amendment-5 bug was a differently-shaped unanchored `re.search`, not this literal
+substring test, so the zero-match count isn't evidence any amendment specifically "closed" it); `"git push"
+not in command` had exactly one match, this file's line 82.
 
 **Shape difference from Amendment 9's three files:** `post-merge-tile-checkpoint.py`,
 `post-pr-merge-pull.py`, and `post-pr-merge-reclaim.py` each already exposed their substring check as a


### PR DESCRIPTION
## Summary

- Converges `stub-push-archive-reminder.py`'s inline "is this a git push?" check in `main()` from the crude `"git push" not in command` substring test onto `scan_top_level`-anchored detection — the pattern already established by `usage-snapshot.py` / `pr-merge-reminder.py` / `post-pr-merge-project.py` / `post-merge-tile-checkpoint.py` / `post-pr-merge-pull.py` / `post-pr-merge-reclaim.py`. This is the file PR #530's own description and ADR-050 Amendment 9's "General lesson" both explicitly named as the one remaining out-of-scope case for #529.
- Adds a local `_PUSH_RE` / `_check_push_stmt` pair, identical to the one `pr-merge-reminder.py` already defines for its own `git push` detection — a port, not new regex design.
- Unlike the three files #530 fixed, this file's check had no separate pre-existing testable predicate (it lived inline in `main()`). Extracts a new `is_git_push_command(command)` pure function — mirroring `is_successful_merge()`'s role in the other hooks — so the new heredoc/quote/subshell coverage has something pure to call, consistent with the repo's `main()`-I/O-is-untested convention.
- Closes the false-positive gap: `git push` text inside a heredoc body, a quoted argument, or a `$()` subshell no longer counts as an invocation.
- Documents the convergence as **ADR-050 Amendment 10**, including a repo-wide grep confirming the pre-fix state (only this file's check remained; the `"gh pr create"` and `"gh pr merge"` analogs were already at zero matches).
- Updates the `## Testing` item #16 description in `CLAUDE.md` to note the new `is_git_push_command()` coverage, mirroring #530's item #10/15/23 update style.

## Test plan

- [x] `py -3 -c "import ast,sys; ..."` syntax check over every `claude/scripts/*.py` — clean
- [x] `py -3 claude/scripts/tests/test_stub_push_archive_reminder.py` — **Tests: 10 passed, 0 skipped, 0 failed** (5 pre-existing `has_push_error()` cases + 5 `is_git_push_command()` cases: bare-push and cd-prefixed-push sanity baselines plus the 3 heredoc/quote/subshell false-positive shapes)
- [x] All 3 new false-positive regression cases verified directly against the extracted pre-fix predicate logic (`"git push" not in command`) to confirm they reproduce the old bug (old code would NOT skip — i.e., treats each as a genuine push) before writing the fix, confirming the new tests are real regressions, not vacuously-true assertions
- [x] Repo-wide grep confirms zero remaining `"git push" not in command` (or `"gh pr create"` / `"gh pr merge"` analogs) in `claude/scripts/*.py`

No automated tests were skipped or degraded; no suppressions were added.

Closes #532

## Review findings disposition

`/review` posted 0 blocking / 4 non-blocking findings (all documentation/comment-accuracy nits found during self-review, no functional issues). All 4 fixed in [`2425d0d`](https://github.com/brownm09/dev-env/pull/533/commits/2425d0d):

1. **[documentation]** ADR-050 Amendment 10 overclaimed that Amendment 5 specifically "closed" a `"gh pr create" not in command` substring shape that never existed in that literal form (Amendment 5's actual fix was a differently-shaped unanchored `re.search`) — **fixed in `2425d0d`**, softened to state only the verified fact.
2. **[documentation]** `is_git_push_command()`'s docstring listed all 6 `scan_top_level` consumers as sharing "the pattern," but only `pr-merge-reminder.py` does git-push detection specifically — **fixed in `2425d0d`**, scoped to `pr-merge-reminder.py` alone.
3. **[documentation]** The `_PUSH_RE` comment cited "ADR-050 Amendments 5/6," but Amendment 6 is unrelated (usage-snapshot.py/post-pr-merge-project.py merge-detection convergence) — **fixed in `2425d0d`**, dropped the "6" citation.
4. **[maintainability]** `_PUSH_RE`'s optional `cd <dir> &&` prefix branch had no direct test in this file or in `pr-merge-reminder.py`'s pre-existing suite — **fixed in `2425d0d`**, added `test_push_with_cd_prefix_matched`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
