### PR TITLE
test(pr-merge-reminder): cover is_git_push_command's cd-prefix branch

### DIFF
--- a/claude/scripts/tests/test_pr_merge_reminder.py
+++ b/claude/scripts/tests/test_pr_merge_reminder.py
@@ -137,6 +137,11 @@ def test_push_simple() -> str:
     return "bare git push -> match"
 
 
+def test_push_with_cd_prefix_matched() -> str:
+    assert is_git_push_command("cd /Git/engineering-journal && git push")
+    return "cd <dir> && git push -> matched (_PUSH_RE's optional cd-prefix branch)"
+
+
 def test_push_inside_subshell_not_matched() -> str:
     assert not is_git_push_command("echo $(git push)")
     return "git push inside $() -> no match"
@@ -644,6 +649,7 @@ def main() -> int:
         ("bare gh pr merge -> match", test_merge_simple),
         ("gh pr create not a merge", test_create_not_matched_as_merge),
         ("bare git push -> match", test_push_simple),
+        ("cd ... && git push -> match", test_push_with_cd_prefix_matched),
         ("git push in $() -> no match", test_push_inside_subshell_not_matched),
         ("shard step: URL in output", test_shard_step_with_url_in_output),
         ("shard step: no URL -> generic hint", test_shard_step_no_url_in_output),


### PR DESCRIPTION
## Summary
- Adds `test_push_with_cd_prefix_matched`, exercising `is_git_push_command`'s `_PUSH_RE` optional `(?:cd\s+\S+\s+&&\s+)?` prefix branch directly with a `cd <dir> && git push` command — previously only a bare `git push` and a `$()` subshell negative case were covered.
- Mirrors the equivalent test PR #533 added for the same regex/function pair in `stub-push-archive-reminder.py` (`test_push_with_cd_prefix_matched`).

## Context
Flagged as a non-blocking test-coverage finding during `/review` of #533. The behavior itself was verified correct by hand during that review — this closes the coverage gap, no behavior change.

Closes #537

## Test plan
- [x] Testing item 1 (hook-script syntax check): `py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py` — clean parse
- [x] Testing item 28: `py -3 claude/scripts/tests/test_pr_merge_reminder.py`

Tests: 46 passed, 0 skipped, 0 failed (0.036s)

- [x] Suppression + test-integrity grep against `git diff origin/main` — no matches

## Review findings disposition
[Review](https://github.com/brownm09/dev-env/pull/538#issuecomment-4871956156): 0 blocking, 1 non-blocking.
- Non-blocking [maintainability] — Step 2e language-scope coverage note (dev-env#277's designed behavior for non-JS diffs): resolved — manually verified this diff has no Python test-integrity violations (no skip markers, no deleted tests, no bypass flags/threshold changes); no code change needed.
