### PR TITLE
docs(adr): document that repo-level auto-merge setting gates the ADR-031 escape hatch

### DIFF
--- a/docs/adr/031-auto-merge-disabled.md
+++ b/docs/adr/031-auto-merge-disabled.md
@@ -82,3 +82,54 @@ Auto-merge must never be enabled at the repo level (no default branch protection
 - [ADR-028 — All-Findings Merge Gate](028-all-findings-merge-gate.md)
 - GitHub Docs — [Automatically merging a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
 - GitHub Docs — [Managing auto-merge for pull requests in your repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository)
+
+---
+
+## Addendum (2026-07-03) — the repo-level toggle and the escape hatch are the same switch
+
+The Decision above treats "auto-merge disabled at the repo level" and the "per-PR escape hatch"
+(`gh pr merge --auto`) as independent controls. They are not: GitHub exposes exactly one
+repo-level control for this feature — **Settings → General → Pull Requests → "Allow auto-merge"**
+(API field `allow_auto_merge`) — and it gates *every* per-PR auto-merge request, CLI escape hatch
+included. Per GitHub's docs:
+
+> "If you allow auto-merge for pull requests in your repository, people with write permissions
+> can configure individual pull requests in the repository to merge automatically when all merge
+> requirements are met."
+
+There is no separate "auto-merge everything by default" branch-protection mechanism distinct from
+this toggle — auto-merge is always requested per-PR (via the web UI or `--auto`), and this one
+setting is the only gate on that request. So the Decision's parenthetical ("no default branch
+protection rule that auto-merges on green CI") was guarding against a mechanism GitHub doesn't
+actually have; the real, single toggle also happens to be the escape hatch's prerequisite.
+
+**Observed:** lifting-logbook PR #664 (2026-07-03) — `gh pr merge 664 --squash --delete-branch
+--auto` failed immediately with `GraphQL: Auto merge is not allowed for this repository
+(enablePullRequestAutoMerge)`. `gh api repos/brownm09/lifting-logbook` confirmed
+`allow_auto_merge: false` at the repo-settings level. This is the deterministic, expected result
+of the Decision as literally written — not a bug — but the ADR never previously said so, so a
+session hitting this error had no way to tell from this document alone.
+
+**Consequence the Decision didn't spell out:** with the toggle off, the "Per-PR escape hatch"
+clause describes an operation that cannot be invoked in that repo, full stop — it fails at the
+GitHub API before any in-session judgment about whether the gates have passed even comes into
+play. No `brownm09/*` repo has deliberately opted in, so treat the escape hatch as **currently
+inert everywhere**, not as a case-by-case convenience.
+
+**Operational guidance:** don't rediscover this per-PR.
+
+- The primary path — wait in-session for CI, then run plain `gh pr merge --squash
+  --delete-branch` — is the only path that works today, not merely the preferred one. Plain
+  `gh pr merge` still requires all required status checks to have already completed and passed
+  (GitHub rejects the merge call otherwise), so the session's job is to poll/wait for checks
+  (e.g. `gh pr checks --watch`), not to reach for `--auto` as a way to avoid waiting.
+- To confirm the setting before ever attempting `--auto` on an unfamiliar repo:
+  `gh api repos/{owner}/{repo}` and read the `allow_auto_merge` field (parse with `node -e`, not
+  `jq` — see `claude/CLAUDE.md`).
+
+**Open question, not resolved here:** enabling `allow_auto_merge` at the repo level does not, by
+itself, cause any PR to merge — it only unlocks the per-PR opt-in request the Decision already
+sanctions as the escape hatch. Whether "must never be enabled at the repo level" was meant to
+block that too, or was written assuming the non-existent "auto-merge everything by default"
+mechanism addressed above, is a policy question left for whoever revisits this ADR next. This
+addendum documents the mechanical reality and leaves the Decision's toggle instruction unchanged.

--- a/docs/adr/031-auto-merge-disabled.md
+++ b/docs/adr/031-auto-merge-disabled.md
@@ -85,7 +85,7 @@ Auto-merge must never be enabled at the repo level (no default branch protection
 
 ---
 
-## Addendum (2026-07-03) — the repo-level toggle and the escape hatch are the same switch
+## Addendum (2026-07-03) — The repo-level toggle and the escape hatch are the same switch
 
 The Decision above treats "auto-merge disabled at the repo level" and the "per-PR escape hatch"
 (`gh pr merge --auto`) as independent controls. They are not: GitHub exposes exactly one
@@ -113,8 +113,12 @@ session hitting this error had no way to tell from this document alone.
 **Consequence the Decision didn't spell out:** with the toggle off, the "Per-PR escape hatch"
 clause describes an operation that cannot be invoked in that repo, full stop — it fails at the
 GitHub API before any in-session judgment about whether the gates have passed even comes into
-play. No `brownm09/*` repo has deliberately opted in, so treat the escape hatch as **currently
-inert everywhere**, not as a case-by-case convenience.
+play. `allow_auto_merge: false` was confirmed for lifting-logbook this session (`gh api
+repos/brownm09/lifting-logbook`); no repo-by-repo survey was run across the rest of `brownm09/*`.
+ADR-031's Decision sets the toggle-off posture as the repo-wide default with no documented
+exceptions, so absent evidence of a deliberate opt-in elsewhere, treat the escape hatch as
+**currently inert everywhere** — but a session on an unfamiliar repo should still verify rather
+than assume (see Operational guidance below).
 
 **Operational guidance:** don't rediscover this per-PR.
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -35,7 +35,7 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [028](028-all-findings-merge-gate.md) | All-Findings Merge Gate: Address Blocking and Non-Blocking Before Merge | 2026-05-27 | Accepted | review, workflow, git, pr, blocking-rule, non-blocking |
 | [029](029-test-integrity-policy.md) | Test Integrity Policy: No Silent Degradation of Existing Tests | 2026-05-27 (amended 2026-07-01) | Accepted | testing, quality, review, suppression-parallel, workflow, pre-pr, regex-false-positive |
 | [030](030-baseline-test-failure-policy.md) | Pre-existing Test Failure Policy: Baseline + Fix-on-Touch | 2026-05-27 | Accepted | testing, quality, pre-pr, baseline, fix-on-touch, workflow |
-| [031](031-auto-merge-disabled.md) | Auto-Merge Disabled Across All Repos | 2026-05-28 | Accepted | git, pr, merge, workflow, hooks, post-merge |
+| [031](031-auto-merge-disabled.md) | Auto-Merge Disabled Across All Repos | 2026-05-28 (amended 2026-07-03) | Accepted | git, pr, merge, workflow, hooks, post-merge |
 | [032](032-journal-start-here-dashboard.md) | Top-of-README "Start here" Dashboard in journal-compose | 2026-05-28 | Accepted | journal, composition, skill, readme, manifest, dashboard |
 | [033](033-prevent-system-sleep-while-processing.md) | Prevent System Sleep While Claude Is Processing | 2026-05-29 | Accepted | hooks, windows, sleep, UserPromptSubmit, Stop, Notification, background-process |
 | [034](034-error-message-diligence.md) | Error Message Diligence | 2026-06-01 | Accepted | workflow, diagnosis, ci, error-handling, claude-behavior, global-rule |


### PR DESCRIPTION
## Summary
- ADR-031's Decision directs the repo-level "Allow auto-merge" GitHub setting to stay off, while separately describing a per-PR `gh pr merge --auto` escape hatch — without noting these are gated by the *same* toggle. Adds a dated Addendum documenting the mechanical dependency, citing GitHub's docs, and giving sessions the correct fallback (wait/poll for CI, use plain `gh pr merge`).
- Bumps `docs/adr/INDEX.md`'s ADR-031 row to `(amended 2026-07-03)`, matching the convention used by ADR-024/ADR-029/ADR-056.
- No change to the Decision itself — this closes a documentation-completeness gap, not a policy change (see the addendum's "Open question, not resolved here" for the one unresolved policy nuance, left for a future ADR owner).

## How this surfaced
While merging lifting-logbook PR #664, `gh pr merge 664 --squash --delete-branch --auto` failed with `GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)`. Verified via `gh api repos/brownm09/lifting-logbook` that `allow_auto_merge: false` at the repo-settings level — expected per ADR-031's Decision as written, but not previously documented as a consequence.

## Testing
N/A — pure documentation diff (two markdown files: `docs/adr/031-auto-merge-disabled.md`, `docs/adr/INDEX.md`). Checked dev-env's `## Testing` section in `CLAUDE.md`: all 39 items are conditioned on changes to `claude/scripts/*`, `claude/hooks/*`, or shell scripts — none apply here. Suppression-policy and test-integrity greps run against `origin/main` and returned clean (expected for a markdown-only diff; recorded for rigor, not because either policy meaningfully applies to prose).

## Doc reconciliation / ADR-warrant
This PR *is* the ADR update — no separate new ADR needed for amending an existing one (established pattern: ADR-024, ADR-028, ADR-056 addenda). No skill/hook/script/routine behavior changed, so the Documentation Maintenance table in `CLAUDE.md` has no other required updates.

## Review findings disposition
`/review` posted (0 blocking, 2 non-blocking). Both fixed in-PR:
- Overclaimed "inert everywhere" verification scope → fixed in `9f4a02f`
- Addendum heading capitalization → fixed in `9f4a02f`

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
