### PR TITLE
docs(adr): resolve ADR-031 open question — retire auto-merge escape hatch as inert

### DIFF
--- a/docs/adr/031-auto-merge-disabled.md
+++ b/docs/adr/031-auto-merge-disabled.md
@@ -137,3 +137,54 @@ sanctions as the escape hatch. Whether "must never be enabled at the repo level"
 block that too, or was written assuming the non-existent "auto-merge everything by default"
 mechanism addressed above, is a policy question left for whoever revisits this ADR next. This
 addendum documents the mechanical reality and leaves the Decision's toggle instruction unchanged.
+
+---
+
+## Addendum (2026-07-04) — Open question resolved: escape hatch stays inert by design ([dev-env#565](https://github.com/brownm09/dev-env/issues/565))
+
+The question the 2026-07-03 addendum left open is resolved: **`allow_auto_merge` stays `false`
+across every `brownm09/*` repo, with no exceptions, and the Decision's "Per-PR escape hatch"
+clause is permanently inert by design** — not a temporarily-off convenience awaiting activation.
+
+**Survey.** `gh api repos/brownm09/{repo}` was run against all 52 active (non-archived,
+non-fork) `brownm09/*` repos on 2026-07-04. Every one reports `allow_auto_merge: false`. No repo
+has drifted to an accidental opt-in since the Decision was written.
+
+**Why this isn't merely "leave it as-is."** The 2026-07-03 addendum's mechanical correction — that
+GitHub has no distinct "auto-merge everything by default" mechanism, so the fear behind "never
+enable at repo level" targeted something that doesn't exist — is right, but it doesn't make the
+toggle purposeless. With the toggle off, `gh pr merge --auto` cannot be invoked, by anyone or
+anything, before the six in-session rules this ADR protects (`usage-snapshot.py`, the post-merge
+journal stub, ADR-warrant checkpoint 3, doc-reconciliation checkpoint 3, the `/review`
+all-findings gate, project-board automation) have already run in the same session. That is a
+*mechanical* guarantee. Turning the toggle on would not itself break any of the six rules — but
+it would downgrade their protection from "impossible to skip" to "skipped only if the session
+remembers to sequence `--auto` correctly," which is exactly the discipline-only enforcement this
+environment avoids relying on elsewhere (see the canonical-checkout-mutate-guard hook, ADR-071;
+the memory-immortalization issue-pairing rule; the pre-install-freespace-gate hook, ADR-045).
+Rejecting Alternative B in the original Rationale ("per-PR auto-merge without the in-session
+gates... is no different from skipping them on every PR") already made this argument for the
+manual-invocation case; the same logic applies to trusting a session to self-police *when* it
+reaches for `--auto`.
+
+**Evidence there's no real cost to closing this off.** The only concrete attempt to use the
+escape hatch — lifting-logbook PR #664 — failed at the GitHub API (`allow_auto_merge` was, and
+is, `false` there) and the session fell back to the primary path: wait for CI, then plain
+`gh pr merge --squash --delete-branch`. PR #664 merged cleanly through that path with no further
+incident. Combined with the original Rationale's already-accepted cost (CI runs 2–10 minutes;
+"sleeping through CI is not a significant cost"), there is no evidenced case where the escape
+hatch's unavailability blocked real work.
+
+**Operational guidance, updated.** Do not attempt `gh pr merge --auto` on any `brownm09/*` repo.
+A failure from it is expected, permanent behavior, not a bug or a gap to fix — go straight to the
+primary path (poll/wait for CI, then plain `gh pr merge --squash --delete-branch`). The
+"Per-PR escape hatch" paragraph in the Decision above is retained for historical context (it
+explains why `--auto` was once considered sanctioned) but should be read as superseded by this
+addendum: it does not describe an available operation.
+
+**What would change this.** This resolution stands until a *mechanical* pre-check exists that
+verifies, at the moment `--auto` is invoked, that `/review`, ADR-warrant checkpoint 3, and
+doc-reconciliation checkpoint 3 have already completed in the current session — i.e., something
+that restores the "impossible to skip" property this addendum is unwilling to trade away for
+convenience. Absent such a gate, re-opening this question should default to "no" for the same
+reasons given here.

--- a/docs/adr/031-auto-merge-disabled.md
+++ b/docs/adr/031-auto-merge-disabled.md
@@ -161,7 +161,8 @@ all-findings gate, project-board automation) have already run in the same sessio
 it would downgrade their protection from "impossible to skip" to "skipped only if the session
 remembers to sequence `--auto` correctly," which is exactly the discipline-only enforcement this
 environment avoids relying on elsewhere (see the canonical-checkout-mutate-guard hook, ADR-071;
-the memory-immortalization issue-pairing rule; the pre-install-freespace-gate hook, ADR-045).
+the memory-immortalization issue-pairing rule, ADR-048; the pre-install-freespace-gate hook,
+ADR-045).
 Rejecting Alternative B in the original Rationale ("per-PR auto-merge without the in-session
 gates... is no different from skipping them on every PR") already made this argument for the
 manual-invocation case; the same logic applies to trusting a session to self-police *when* it
@@ -186,5 +187,10 @@ addendum: it does not describe an available operation.
 verifies, at the moment `--auto` is invoked, that `/review`, ADR-warrant checkpoint 3, and
 doc-reconciliation checkpoint 3 have already completed in the current session — i.e., something
 that restores the "impossible to skip" property this addendum is unwilling to trade away for
-convenience. Absent such a gate, re-opening this question should default to "no" for the same
-reasons given here.
+convenience. Only these three are named because they are the only ones a pre-invocation check
+could ever verify: the other three rules (`usage-snapshot.py`, the post-merge journal stub,
+project-board automation) are tied to the physical merge moment itself, which `--auto` always
+defers to an async, out-of-session event — no pre-check, however sophisticated, can make an
+async merge produce an in-session moment to hook. Their loss is inherent to using `--auto` at
+all, not a gap this future gate could close. Absent the three-rule gate, re-opening this question
+should default to "no" for the same reasons given here.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -35,7 +35,7 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 | [028](028-all-findings-merge-gate.md) | All-Findings Merge Gate: Address Blocking and Non-Blocking Before Merge | 2026-05-27 | Accepted | review, workflow, git, pr, blocking-rule, non-blocking |
 | [029](029-test-integrity-policy.md) | Test Integrity Policy: No Silent Degradation of Existing Tests | 2026-05-27 (amended 2026-07-01) | Accepted | testing, quality, review, suppression-parallel, workflow, pre-pr, regex-false-positive |
 | [030](030-baseline-test-failure-policy.md) | Pre-existing Test Failure Policy: Baseline + Fix-on-Touch | 2026-05-27 | Accepted | testing, quality, pre-pr, baseline, fix-on-touch, workflow |
-| [031](031-auto-merge-disabled.md) | Auto-Merge Disabled Across All Repos | 2026-05-28 (amended 2026-07-03) | Accepted | git, pr, merge, workflow, hooks, post-merge |
+| [031](031-auto-merge-disabled.md) | Auto-Merge Disabled Across All Repos | 2026-05-28 (amended 2026-07-03, 2026-07-04) | Accepted | git, pr, merge, workflow, hooks, post-merge |
 | [032](032-journal-start-here-dashboard.md) | Top-of-README "Start here" Dashboard in journal-compose | 2026-05-28 | Accepted | journal, composition, skill, readme, manifest, dashboard |
 | [033](033-prevent-system-sleep-while-processing.md) | Prevent System Sleep While Claude Is Processing | 2026-05-29 | Accepted | hooks, windows, sleep, UserPromptSubmit, Stop, Notification, background-process |
 | [034](034-error-message-diligence.md) | Error Message Diligence | 2026-06-01 | Accepted | workflow, diagnosis, ci, error-handling, claude-behavior, global-rule |


### PR DESCRIPTION
## Summary
- Resolves the open question the 2026-07-03 addendum deliberately left unanswered: whether ADR-031's "must never enable `allow_auto_merge` at the repo level" instruction was also meant to permanently block the Decision's own sanctioned per-PR `gh pr merge --auto` escape hatch, since both are gated by the exact same GitHub toggle.
- Decision: **keep the toggle off everywhere, and retire the escape-hatch clause as permanently inert by design.** A full survey (`gh api repos/brownm09/{repo}` across all 52 active, non-archived, non-fork `brownm09/*` repos, run 2026-07-04) confirms `allow_auto_merge: false` already holds account-wide — this PR changes no live repo setting, only the ADR text.
- Adds a dated Addendum to `docs/adr/031-auto-merge-disabled.md` with the rationale (the toggle is the only mechanical backstop the six merge-time rules have; the one real attempt to use the escape hatch, lifting-logbook PR #664, failed and fell back to the primary path without incident) and updated operational guidance.
- Bumps `docs/adr/INDEX.md`'s ADR-031 row to `(amended 2026-07-03, 2026-07-04)`, matching the ADR-056 multi-amendment convention.

## How this surfaced
Filed via [dev-env#565](https://github.com/brownm09/dev-env/issues/565) as a standalone policy decision, separate from the documentation-completeness fix in dev-env#552 / PR #554 that first surfaced the open question.

## Testing
N/A — pure documentation diff (`docs/adr/031-auto-merge-disabled.md`, `docs/adr/INDEX.md`). Checked dev-env's `## Testing` section in `CLAUDE.md`: all 39 items are conditioned on changes to `claude/scripts/*`, `claude/hooks/*`, or shell scripts — none apply here (same conclusion as PR #554). `baseline_test_failure_tracking` is not enabled for this repo. Suppression-policy and test-integrity greps run against `origin/main` and returned clean (expected for a markdown-only diff).

## Doc reconciliation / ADR-warrant
This PR *is* the ADR update — no separate new ADR needed for amending an existing one (established pattern: ADR-024, ADR-028, ADR-056 addenda). No skill/hook/script/routine behavior changed, so no other `CLAUDE.md` documentation-maintenance table needs an update.

## Review findings disposition
`/review` found 0 blocking, 2 non-blocking findings ([review comment](https://github.com/brownm09/dev-env/pull/568#issuecomment-4880988505)). Both fixed in commit `6623057`:
- Missing ADR-048 number on the memory-immortalization citation (inconsistent with the other two citations in the same sentence) — fixed.
- The "What would change this" paragraph named only 3 of the 6 merge-time rules as gate-able without explaining why the other 3 are excluded — fixed by adding the structural-incompatibility explanation.

