### PR TITLE
[docs] Generalize the worktree/base-branch gh pr merge --delete-branch workaround into global CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -124,6 +124,25 @@ gh pr view <N> --json mergeable,mergeStateStatus
 
 Motivating incident: [lifting-logbook PR #604](https://github.com/brownm09/lifting-logbook/pull/604).
 
+### Worktree holding the base branch blocks `gh pr merge --delete-branch`'s local step
+
+**Pattern:** `gh pr merge --squash --delete-branch` merges server-side first (a pure API call that always succeeds), then locally checks out the base branch and deletes the merged branch. Git allows a branch to be checked out in at most one worktree at a time, so that local step aborts whenever **any** worktree in the repo — canonical or sibling — already holds the base branch. The abort lands after the remote merge but before the remote branch delete, so **both** the local and the remote branch deletes are silently skipped even though the PR is already merged.
+
+**Symptom:** `failed to run git: fatal: '<base>' is already checked out at '<path>'` immediately after `gh pr merge --squash --delete-branch`, on a PR that nonetheless shows as merged (`gh pr view <N> --json state,mergedAt`).
+
+**Diagnosis:** `git worktree list` from the repo root shows the base branch checked out somewhere other than the checkout the merge ran from. Two distinct causes produce the identical error — the fix is the same either way, but it helps to know which one you hit:
+- The **canonical checkout correctly sitting on the base branch** — its normal, expected state in any repo that keeps its canonical on the default branch by convention. This is the common, "healthy" case, not a bug.
+- An **idle worktree left squatting the base branch** from an earlier merge's `--delete-branch` step.
+
+**Fix — proactive:** split the merge into two pure-API calls that never depend on which worktree currently holds the base branch:
+```bash
+gh pr merge <N> --squash                                          # server-side only; always succeeds
+gh api -X DELETE "repos/{owner}/{repo}/git/refs/heads/<branch>"   # pure REST ref delete
+```
+**Fix — reactive** (already hit the failure): the remote merge already succeeded — delete the ref with the same `gh api -X DELETE` call above, or `git push origin --delete <branch>`.
+
+Confirmed as a **general git-worktree mechanic**, not a quirk of any one repo's worktree count: [dev-env#575](https://github.com/brownm09/dev-env/pull/575) (canonical correctly on `main`) and [lifting-logbook#664](https://github.com/brownm09/lifting-logbook/pull/664) (an idle worktree left squatting `main` by an earlier merge; that repo's CLAUDE.md "Standard Issue Workflow" step 8 carries its own copy of this same two-step pattern). Full detection, root cause, and non-destructive auto-correction (parking idle squatters instead of removing them): dev-env [ADR-058](../docs/adr/058-worktree-squatting-main-detection-correction.md); complete runbook: dev-env [`docs/REFERENCE.md` → Git Workflow Runbooks](../docs/REFERENCE.md#git-workflow-runbooks).
+
 ---
 
 ## Dev-Env & Project Boards


### PR DESCRIPTION
## Summary

- Adds a new "Worktree holding the base branch blocks `gh pr merge --delete-branch`'s local step" subsection to `claude/CLAUDE.md`'s Git Workflow section, mirroring the existing "CI not firing — merge conflict silences GitHub Actions" promoted-gotcha pattern already in that file.
- Generalizes a workaround that was previously documented only in this repo's own [ADR-058](https://github.com/brownm09/dev-env/blob/main/docs/adr/058-worktree-squatting-main-detection-correction.md) / `docs/REFERENCE.md`, and duplicated ad hoc in lifting-logbook's CLAUDE.md — now visible in the one file every project's session actually loads.
- **No new ADR.** ADR-058 already carries the full rationale, detection design, and non-destructive auto-correction (parking) mechanism. This is a documentation-completeness gap, not a new decision — confirmed today by dev-env PR #575 hitting the identical failure with nothing more exotic than the canonical checkout correctly on `main`.

## Testing

dev-env has no automated test suite for prose-only `CLAUDE.md` changes. Per this repo's own `## Observability` section precedent ("pure docs/config changes … answer 'N/A — no runtime'"), none of the numbered `## Testing` items apply — each is scoped to a specific script/hook/config-schema change, and this PR touches zero scripts, hooks, or schemas.

Ran the one blanket pre-PR check:
```bash
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
# → SYNTAX_OK
```

Also ran the global pre-PR suppression and test-integrity greps (both expected-empty on a markdown-only diff, confirmed rather than assumed):
```bash
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'   # no matches
git diff origin/main -- . | grep -E '(it\.skip|\bxit\(|xdescribe\(|test\.skip|describe\.skip|\.todo\(|pending\(|passWithNoTests|--bail|testPathIgnorePatterns)'  # no matches
```

Manually verified both new links resolve to real, already-existing content:
- `docs/adr/058-worktree-squatting-main-detection-correction.md`
- `docs/REFERENCE.md#git-workflow-runbooks`

Tests: N/A — no automated tests apply to a prose-only `CLAUDE.md` change (see above).

## Risk-dimension audit

Testing / Observability / Security / Resilience / Performance / Data integrity: all **N/A — pure prose edit to a markdown instructions file**, no runtime, hook, or schema touched.

## ADR-warrant check

Not warranted. The rule this PR adds cites and defers to [ADR-058](https://github.com/brownm09/dev-env/blob/main/docs/adr/058-worktree-squatting-main-detection-correction.md), which already fully documents the mechanism, root cause, and auto-correction design. No new decision is being made here — only propagating an already-recorded one into the globally-loaded file.

Closes #583
