### PR TITLE
config: enable inputNeededNotifEnabled push notification setting

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -256,7 +256,8 @@
     ]
   },
   "effortLevel": "medium",
+  "tui": "fullscreen",
   "theme": "dark",
   "agentPushNotifEnabled": true,
-  "tui": "fullscreen"
+  "inputNeededNotifEnabled": true
 }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -576,6 +576,7 @@ The active defaults in `claude/settings.json`:
 | `permissions.defaultMode` | `plan` | **Fresh local CLI sessions** start in plan mode — no edits until the user approves a plan; override per-session with Shift+Tab. **This does not apply to Desktop/web-app or spawn-task / SDK-launched sessions:** the platform starts those in `bypassPermissions` with a startup flag that overrides `defaultMode` *by design*, so they begin off-plan regardless of this setting — `settings.json` has no lever over it, and restarting does not change it. This is expected, not a broken hook; the `session-mode-prompt` hook and `session-mode-report.py` (above) audit it. To start such a session in plan, Shift+Tab at the first prompt. See [ADR-025](adr/025-default-plan-mode.md). |
 | `effortLevel` | `medium` | Applies to all model tiers. Increase to `high` or `xhigh` for intelligence-sensitive sessions (e.g., full cover letter workflow). |
 | `agentPushNotifEnabled` | `true` | Fires a push notification when an agent session completes. |
+| `inputNeededNotifEnabled` | `true` | Fires a push notification when an agent session is blocked waiting on user input (e.g., a permission prompt or a question). |
 
 ---
 


### PR DESCRIPTION
## Summary

Recovers a settings.json preference that had been sitting uncommitted in the
canonical dev-env checkout since before this session, which was blocking
`dev-env-sync.py`'s automatic `git pull --ff-only` (origin/main had since
advanced 7 commits, 3 of which also touched `claude/settings.json`, so git
refused to fast-forward over the local edit). Confirmed with the user
whether to keep or discard the tweak before proceeding; they chose to keep
it.

- Adds `"inputNeededNotifEnabled": true` to `claude/settings.json` (fires a
  push notification when an agent session is blocked waiting on user input).
- Reorders `"tui": "fullscreen"` earlier in the object (cosmetic, carried
  over from the original uncommitted diff).
- Documents the new key in `docs/REFERENCE.md`'s "Configured defaults"
  table, alongside its existing sibling `agentPushNotifEnabled`.

No GitHub issue was filed — this is a single-line settings change, and per
the Git Workflow rule ("Single-line change: ask first") the user was asked
directly instead.

## Testing

This PR only touches `claude/settings.json` (a declarative JSON value) and
`docs/REFERENCE.md` (prose) — no hook script logic changed, so none of the
numbered items in dev-env's `## Testing` section apply as a required gate.
As a general sanity check anyway:

- `node -e "JSON.parse(...)"` — settings.json parses as valid JSON.
- Item 1 (hook-script syntax check) — all `claude/scripts/*.py` still parse
  cleanly: `Tests: all hook scripts parse OK`.

No automated tests exist for settings.json content itself (no `## Testing`
item covers plain config-value additions).

## Risk-dimension audit (Pass 3)

1. **Testing** — N/A, covered above.
2. **Observability** — N/A, this is a client-side Claude Code notification
   preference, not dev-env hook/script behavior.
3. **Security** — N/A, no secrets, no authz surface.
4. **Resilience / failure modes** — N/A, additive boolean flag with no
   downstream code path in this repo; reversible by flipping it back to
   `false`.
5. **Performance** — N/A.
6. **Data integrity & migrations** — N/A.

## ADR-warrant check

N/A — this is a personal notification-preference toggle, structurally
identical to the pre-existing, ADR-less `agentPushNotifEnabled` sibling
entry. It doesn't set a new workflow rule other CLAUDE.md files reference,
and its full rationale (recovering a blocked sync) is captured in this PR
description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)