### PR TITLE
fix(routines): apply ADR-003 self-referencing pattern to prune-stale-worktrees and reclaim-worktree-disk

### DIFF
--- a/claude/routines/prune-stale-worktrees/SKILL.md
+++ b/claude/routines/prune-stale-worktrees/SKILL.md
@@ -31,3 +31,19 @@ Prune stale Claude session worktrees across all git repos under `C:/Users/brown/
 - With `--include-named`, a hand-named branch is held to the exact same merged/dirty/liveness bar as a `claude/*` branch — no looser check is applied (ADR-078)
 - Never remove a worktree with an active Claude session — transcript activity within 24h. This routine runs out-of-process and cannot see other sessions via cwd, so the script's transcript-mtime guard is what protects them (ADR-051)
 - Temp files (if needed) go to `C:/Users/brown/.claude/scratch/`
+
+---
+
+> **Dual-copy registration caveat (dev-env#344, [ADR-003 amendment](../../../docs/adr/003-config-in-version-control.md)).**
+> This file is the **canonical, version-controlled** definition
+> (`dev-env/claude/routines/prune-stale-worktrees/`, surfaced at
+> `~/.claude/routines/prune-stale-worktrees/` via the directory junction). The scheduler reads a
+> **separate** live copy at `~/.claude/scheduled-tasks/prune-stale-worktrees/SKILL.md`, materialized
+> by the `create_scheduled_task` MCP tool — the two do **not** auto-sync by default. This routine
+> already drifted once ([dev-env#597](https://github.com/brownm09/dev-env/issues/597)): the live
+> copy ran a stale pre-ADR-078 invocation missing `--include-named`, silently skipping 78 of 88
+> registered worktrees every day despite running successfully. Per the convention ADR-003's
+> amendment establishes, the live copy now reads this file at run time and defers to it when
+> present, falling back to an embedded copy only when it is missing or unreadable — so a future
+> edit here takes effect immediately without a separate re-registration step, though the embedded
+> fallback should still be refreshed when this file's *steps* change materially.

--- a/claude/routines/reclaim-worktree-disk/SKILL.md
+++ b/claude/routines/reclaim-worktree-disk/SKILL.md
@@ -29,3 +29,18 @@ Reclaim regenerable disk artifacts from idle Claude session worktrees across all
 - Dirty worktrees, the primary worktree, the current/protected worktree, worktrees with an active Claude session (transcript activity within 6h — shorter than prune's 24h since stripping is self-healing; ADR-051), and worktrees with unpushed commits ahead of `origin/main` (and not merged) are never touched.
 - Repos with no GitHub remote are silently skipped.
 - Temp files (if needed) go to `C:/Users/brown/.claude/scratch/`.
+
+---
+
+> **Dual-copy registration caveat (dev-env#344, [ADR-003 amendment](../../../docs/adr/003-config-in-version-control.md)).**
+> This file is the **canonical, version-controlled** definition
+> (`dev-env/claude/routines/reclaim-worktree-disk/`, surfaced at
+> `~/.claude/routines/reclaim-worktree-disk/` via the directory junction). The scheduler reads a
+> **separate** live copy at `~/.claude/scheduled-tasks/reclaim-worktree-disk/SKILL.md`, materialized
+> by the `create_scheduled_task` MCP tool — the two do **not** auto-sync by default. This routine was
+> authored with its intended `0 */6 * * *` schedule above but was never actually registered as a
+> live task at all ([dev-env#597](https://github.com/brownm09/dev-env/issues/597)) — its
+> self-healing disk reclamation had, as far as that investigation could tell, never run
+> automatically. Per the convention ADR-003's amendment establishes, the live copy now reads this
+> file at run time and defers to it when present, falling back to an embedded copy only when it is
+> missing or unreadable.

--- a/docs/adr/003-config-in-version-control.md
+++ b/docs/adr/003-config-in-version-control.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-13  
 **Status:** Accepted  
-**Amended:** 2026-07-01 (see Amendment section below)
+**Amended:** 2026-07-01, 2026-07-06 (see Amendment sections below)
 
 ---
 
@@ -59,6 +59,33 @@ This was first correctly diagnosed in [dev-env#344](https://github.com/brownm09/
 
 ---
 
+## Amendment (2026-07-06)
+
+The self-referencing convention adopted 2026-07-01 was applied to `daily-journal-compose-local`
+in the same session that wrote it, but was **not** retroactively swept across the other routines
+already registered at the time. Investigating dev-env#597 (Git Bash fork failures + an 88-worktree
+pileup) found the exact same gap, twice more, in routines that predate the convention:
+
+1. **`prune-stale-worktrees`** — the live copy was a hardcoded, pre-ADR-078 snapshot missing
+   `--include-named`. It ran successfully every day but silently skipped 78 of 88 registered
+   worktrees, since it never picked up the canonical routine's later fix.
+2. **`reclaim-worktree-disk`** — authored with its own intended `0 */6 * * *` schedule in
+   frontmatter, but never actually registered as a live task at all — it had never run
+   automatically.
+
+Both are now fixed to follow the established convention (canonical file read at run time via a
+Step 0.5, embedded fallback only when unreachable) — see their SKILL.md files' own "dual-copy
+registration caveat" notes.
+
+**This is now the second independent occurrence of the same gap** (`daily-journal-compose-local`
+being the first). The convention itself is sound, but relies on each routine's author remembering
+to apply it and remains silent about routines that predate it. A full audit of the remaining
+registered routines (`nightly-cover-letters`, `biweekly-retro`, `nightly-research`,
+`reconcile-project-board`) for the same gap was out of scope for dev-env#597 and has **not** been
+done as part of this amendment — flagged as follow-up work, not resolved here.
+
+---
+
 ## References
 
 - Engineering journal: `sessions/meta/2026-04-13-post-tool-use-hook-and-settings-into-dev-env.md`
@@ -66,3 +93,4 @@ This was first correctly diagnosed in [dev-env#344](https://github.com/brownm09/
 - `claude/CLAUDE.md` § Dev-Env — symlink table and ownership rules
 - [dev-env#344](https://github.com/brownm09/dev-env/issues/344) — original diagnosis of the reversed topology
 - [dev-env#464](https://github.com/brownm09/dev-env/issues/464) — the drift incident that surfaced the undocumented consequence
+- [dev-env#597](https://github.com/brownm09/dev-env/issues/597) — second occurrence, in `prune-stale-worktrees` and `reclaim-worktree-disk`

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -7,7 +7,7 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 |---|-------|------|--------|------|
 | [001](001-per-session-stub-files.md) | Per-Session Stub Files for Journal Composition | 2026-03-27 | Accepted | journal, stubs, composition, concurrency |
 | [002](002-journal-compose-session-isolation.md) | Journal-Compose Session Isolation | 2026-04-04 | Accepted | journal, composition, session-isolation, skill |
-| [003](003-config-in-version-control.md) | Config Artifacts in Version Control via Symlinks | 2026-04-13 (amended 2026-07-01) | Accepted | config, symlinks, version-control, dev-env, settings, scheduled-tasks, routines |
+| [003](003-config-in-version-control.md) | Config Artifacts in Version Control via Symlinks | 2026-04-13 (amended 2026-07-01, 2026-07-06) | Accepted | config, symlinks, version-control, dev-env, settings, scheduled-tasks, routines |
 | [004](004-pr-review-reads-from-remote.md) | PR Review Reads from Remote, Not Local Worktree | 2026-04-17 | Accepted | git, pr-review, worktree, remote, correctness |
 | [005](005-global-core-hooks-path.md) | Global `core.hooksPath` for Cross-Repo Invariants | 2026-04-19 | Accepted | git, hooks, core.hooksPath, cross-repo |
 | [006](006-dev-env-sync-on-every-prompt.md) | UserPromptSubmit Dev-Env Sync on Every Prompt | 2026-04-19 | Accepted | hooks, dev-env-sync, UserPromptSubmit, prompts |


### PR DESCRIPTION
## Summary

Closes #597. Two independent scheduled-task drift bugs, both fixed by applying the
already-established ADR-003 self-referencing convention (canonical file read at run time,
embedded fallback only when unreachable):

1. **`prune-stale-worktrees`** — the live scheduled task was a stale, hardcoded copy missing
   `--include-named` (ADR-078). It ran successfully every day but silently skipped 78 of 88
   registered worktrees, since it never picked up the canonical routine's later fix.
2. **`reclaim-worktree-disk`** — authored with its own intended `0 */6 * * *` schedule in
   frontmatter, but never actually registered as a live task at all.

Both `claude/routines/*/SKILL.md` files now carry the same "dual-copy registration caveat" note
`weekly-memory-audit` already has, so a future edit to either routine's canonical source takes
effect on the live task's next run without a separate re-registration step.

This is the **second** occurrence of this exact gap (`daily-journal-compose-local` was the
first, dev-env#464) — documented as a further amendment to
[ADR-003](docs/adr/003-config-in-version-control.md), which also flags that the remaining
routines (`nightly-cover-letters`, `biweekly-retro`, `nightly-research`,
`reconcile-project-board`) have not been audited for the same gap — out of scope here,
called out as follow-up.

## What's NOT in this PR

The live scheduled tasks themselves (`~/.claude/scheduled-tasks/.../SKILL.md`, materialized via
the `create_scheduled_task`/`update_scheduled_task` MCP tools) are machine-local, not
git-tracked — updating them is a separate, post-merge step per the existing convention
("After merging, separately call create_scheduled_task / update_scheduled_task").

## Testing

No `.py` files changed — this PR only edits `claude/routines/*/SKILL.md` (prompt text) and two
docs files (`docs/adr/003-config-in-version-control.md`, `docs/adr/INDEX.md`). None of the
project's `## Testing` items apply (they all target `claude/scripts/*.py` / shell scripts).
Manually verified: both edited SKILL.md files render as valid markdown with the new caveat
section correctly closing off the existing "Constraints" list; ADR-003's amendment and
INDEX.md's date-column update are internally consistent (checked by re-reading both files after
editing).

## ADR-warrant check

Warranted and done in this PR — amends [ADR-003](docs/adr/003-config-in-version-control.md)
(2026-07-06 Amendment) and updates its `docs/adr/INDEX.md` row.

## Doc-reconciliation check

No skill/hook/routine was added, removed, or renamed (both routines already existed under
these names) — the Documentation Maintenance table's ADD/REMOVE/RENAME triggers don't apply.
Checked `README.md`'s routines table: it already documents `prune-stale-worktrees` as including
`--include-named` behavior and `reclaim-worktree-disk` as running "Every 6 hours" — both claims
were previously aspirational/inaccurate against the live tasks' actual behavior and become
accurate once the post-merge live-task update (above) is applied. No README text change needed.

## Review findings disposition

`/review` posted: https://github.com/brownm09/dev-env/pull/603#issuecomment-4889455734
(blocking=0, non_blocking=1).

- **[documentation]** Caveat notes state the live copy "now" self-references, which isn't true
  until the post-merge live-task update runs. **Disposition:** resolved by that same planned
  post-merge step (`update_scheduled_task`/`create_scheduled_task`), executed immediately after
  merge in this same session — not filed separately, since the fix is already scheduled work in
  this unit of work, not a deferral.