### PR TITLE
fix: link claude/templates/ into ~/.claude/ (setup.sh + CLAUDE.md + ADR-003)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -942,6 +942,7 @@ When a PR modifies any of the paths below, update the listed reference docs **in
 | `~/.claude/skills/` | `claude/skills/` (directory junction) |
 | `~/.claude/hooks/` | `claude/hooks/` (directory junction) |
 | `~/.claude/routines/` | `claude/routines/` (directory junction) |
+| `~/.claude/templates/` | `claude/templates/` (directory junction) |
 | `~/.claude/settings.json` | `claude/settings.json` |
 
 **Machine-local only — never commit:**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Development environment configuration for cross-device use.
 | `claude/scripts/` | `~/.claude/scripts/` (junction) | Hook scripts and utilities |
 | `claude/skills/` | `~/.claude/skills/` (junction) | Custom slash command skills |
 | `claude/routines/` | `~/.claude/routines/` (junction) | Scheduled-task source definitions — registering a live task is a separate step, see [Routines](#routines) |
-| `claude/templates/` | read at runtime by skills | Document templates |
+| `claude/templates/` | `~/.claude/templates/` (junction) | Document templates, read at runtime by skills |
 
 ## Setup
 

--- a/docs/adr/003-config-in-version-control.md
+++ b/docs/adr/003-config-in-version-control.md
@@ -103,9 +103,10 @@ enumerated `templates` — a day-one gap, not a regression, that both amendments
 forward unnoticed because neither touched this table's completeness against the actual `claude/`
 directory listing.
 
-**This is the third occurrence of this ADR's "documented map doesn't match reality" gap class**
-(scheduled-tasks topology, 2026-07-01; the routine self-reference convention gap, 2026-07-06).
-Fixed by:
+**This is the second occurrence of this ADR's junction-table-itself-is-wrong gap class** — the
+2026-07-01 amendment's scheduled-tasks topology correction is the first. (The 2026-07-06
+amendment is a related but distinct gap: the routine self-reference *convention* not being
+swept across pre-existing routines, not the junction table being incomplete or wrong.) Fixed by:
 
 - Adding `templates` to `setup.sh`'s link loop in both `setup_windows()` and `setup_unix()`.
 - Adding the `templates/` row to the Decision table above and to `claude/CLAUDE.md`'s copy.
@@ -127,4 +128,4 @@ via an absolute repo path in `claude/scripts/usage-snapshot.py`, not through `~/
 - [dev-env#344](https://github.com/brownm09/dev-env/issues/344) — original diagnosis of the reversed topology
 - [dev-env#464](https://github.com/brownm09/dev-env/issues/464) — the drift incident that surfaced the undocumented consequence
 - [dev-env#597](https://github.com/brownm09/dev-env/issues/597) — second occurrence, in `prune-stale-worktrees` and `reclaim-worktree-disk`
-- [dev-env#606](https://github.com/brownm09/dev-env/issues/606) — third occurrence, `templates/` never linked
+- [dev-env#606](https://github.com/brownm09/dev-env/issues/606) — second occurrence of the junction-table gap class, `templates/` never linked

--- a/docs/adr/003-config-in-version-control.md
+++ b/docs/adr/003-config-in-version-control.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-13  
 **Status:** Accepted  
-**Amended:** 2026-07-01, 2026-07-06 (see Amendment sections below)
+**Amended:** 2026-07-01, 2026-07-06, 2026-07-08 (see Amendment sections below)
 
 ---
 
@@ -26,6 +26,7 @@ All version-controlled Claude Code artifacts are maintained in the `dev-env` rep
 | `skills/` | `claude/skills/` (directory junction) |
 | `hooks/` | `claude/hooks/` (directory junction) |
 | `routines/` | `claude/routines/` (directory junction) |
+| `templates/` | `claude/templates/` (directory junction) |
 
 `~/.claude/scheduled-tasks/` is deliberately **not** in this table — see Amendment below.
 
@@ -86,6 +87,38 @@ done as part of this amendment — flagged as follow-up work, not resolved here.
 
 ---
 
+## Amendment (2026-07-08)
+
+Investigating why `/propose`'s Step 3 and Step 11 reads of `~/.claude/templates/proposal.md` and
+`pr-body.md` were failing on a machine (a `lifting-logbook` session, 2026-07-06) found that
+`templates/` was never in the Decision table above, never in `setup.sh`'s link loop (`setup_windows()`
+and `setup_unix()` both enumerate `scripts skills hooks` plus a separately-linked `routines` —
+`templates` is in neither), and never in `claude/CLAUDE.md`'s copy of this table either — despite
+`claude/templates/` (`proposal.md`, `pr-body.md`, `contributing.md`, `project-claude.md`,
+`propose-config.json`) being fully committed since 2026-04-13 (#10), the same day this ADR was
+written.
+
+`setup.sh`'s cross-platform bootstrap was added 11 days later (2026-04-24) and simply never
+enumerated `templates` — a day-one gap, not a regression, that both amendments above carried
+forward unnoticed because neither touched this table's completeness against the actual `claude/`
+directory listing.
+
+**This is the third occurrence of this ADR's "documented map doesn't match reality" gap class**
+(scheduled-tasks topology, 2026-07-01; the routine self-reference convention gap, 2026-07-06).
+Fixed by:
+
+- Adding `templates` to `setup.sh`'s link loop in both `setup_windows()` and `setup_unix()`.
+- Adding the `templates/` row to the Decision table above and to `claude/CLAUDE.md`'s copy.
+- Creating the junction directly on the affected machine rather than waiting for a future
+  `setup.sh` re-run.
+
+Checked the remaining top-level `claude/` entries for the same gap: `usage-config.json` is read
+via an absolute repo path in `claude/scripts/usage-snapshot.py`, not through `~/.claude/`, and
+`setup-prompt.md` has no programmatic reference at all — neither is a missing-link candidate.
+`templates/` was the only actual gap.
+
+---
+
 ## References
 
 - Engineering journal: `sessions/meta/2026-04-13-post-tool-use-hook-and-settings-into-dev-env.md`
@@ -94,3 +127,4 @@ done as part of this amendment — flagged as follow-up work, not resolved here.
 - [dev-env#344](https://github.com/brownm09/dev-env/issues/344) — original diagnosis of the reversed topology
 - [dev-env#464](https://github.com/brownm09/dev-env/issues/464) — the drift incident that surfaced the undocumented consequence
 - [dev-env#597](https://github.com/brownm09/dev-env/issues/597) — second occurrence, in `prune-stale-worktrees` and `reclaim-worktree-disk`
+- [dev-env#606](https://github.com/brownm09/dev-env/issues/606) — third occurrence, `templates/` never linked

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -7,7 +7,7 @@ Consult the relevant ADR before overriding any rule, hook, skill, or config.
 |---|-------|------|--------|------|
 | [001](001-per-session-stub-files.md) | Per-Session Stub Files for Journal Composition | 2026-03-27 | Accepted | journal, stubs, composition, concurrency |
 | [002](002-journal-compose-session-isolation.md) | Journal-Compose Session Isolation | 2026-04-04 | Accepted | journal, composition, session-isolation, skill |
-| [003](003-config-in-version-control.md) | Config Artifacts in Version Control via Symlinks | 2026-04-13 (amended 2026-07-01, 2026-07-06) | Accepted | config, symlinks, version-control, dev-env, settings, scheduled-tasks, routines |
+| [003](003-config-in-version-control.md) | Config Artifacts in Version Control via Symlinks | 2026-04-13 (amended 2026-07-01, 2026-07-06, 2026-07-08) | Accepted | config, symlinks, version-control, dev-env, settings, scheduled-tasks, routines, templates |
 | [004](004-pr-review-reads-from-remote.md) | PR Review Reads from Remote, Not Local Worktree | 2026-04-17 | Accepted | git, pr-review, worktree, remote, correctness |
 | [005](005-global-core-hooks-path.md) | Global `core.hooksPath` for Cross-Repo Invariants | 2026-04-19 | Accepted | git, hooks, core.hooksPath, cross-repo |
 | [006](006-dev-env-sync-on-every-prompt.md) | UserPromptSubmit Dev-Env Sync on Every Prompt | 2026-04-19 | Accepted | hooks, dev-env-sync, UserPromptSubmit, prompts |

--- a/setup.sh
+++ b/setup.sh
@@ -71,7 +71,7 @@ setup_windows() {
   win_link "$REPO_DIR/claude/settings.json" "$HOME/.claude/settings.json" file
   echo "  Linked settings.json"
 
-  for subdir in scripts skills hooks; do
+  for subdir in scripts skills hooks templates; do
     win_link "$REPO_DIR/claude/$subdir" "$HOME/.claude/$subdir" dir
     echo "  Linked $subdir/"
   done
@@ -136,7 +136,7 @@ setup_unix() {
     echo "  Linked $item"
   done
 
-  for subdir in scripts skills hooks; do
+  for subdir in scripts skills hooks templates; do
     ln -sf "$REPO_DIR/claude/$subdir" "$HOME/.claude/$subdir"
     echo "  Linked $subdir/"
   done


### PR DESCRIPTION
## Summary

- Add `templates` to `setup.sh`'s `~/.claude/` link loop (both `setup_windows()` and `setup_unix()`) — `claude/templates/` has existed since 2026-04-13 (#10) but was never wired into the automated bootstrap, silently breaking `/propose`'s (and `/journal-compose`'s, and `/journal-onboard`'s) required reads of `proposal.md`/`pr-body.md`/`project-claude.md` on any machine.
- Document the fix in `CLAUDE.md` § Dev-Env Architecture's junction table, in `README.md`'s Contents table, and as a new Amendment to [ADR-003](docs/adr/003-config-in-version-control.md) — the second occurrence of that ADR's junction-table-itself-is-wrong gap class (the first: scheduled-tasks topology, 2026-07-01).

## Changes

- `setup.sh` — add `templates` to the `scripts skills hooks` link loop in both platform functions
- `CLAUDE.md` — add `templates/` row to the Dev-Env Architecture junction table
- `README.md` — correct the `claude/templates/` Contents-table row to document the junction, matching its scripts/skills/routines siblings
- `docs/adr/003-config-in-version-control.md` — add `templates/` row to the Decision table, new Amendment (2026-07-08) section (includes a check confirming `usage-config.json` and `setup-prompt.md` are not the same gap), updated References
- `docs/adr/INDEX.md` — update ADR-003's amended-date list and tags

## Test plan

- [x] `bash -n setup.sh` — syntax valid
- [x] `bash claude/scripts/tests/run-shellcheck.sh` — SKIP (shellcheck not installed locally; advisory-only per Testing item 7)
- [x] Created the missing `~/.claude/templates` junction directly on the affected machine (`mklink /D`, same mechanism as `setup.sh`'s `win_link ... dir`) and confirmed `proposal.md` and `pr-body.md` are now readable through it

## Review findings disposition

Per [review](https://github.com/brownm09/dev-env/pull/611#issuecomment-4911915222):

- **[documentation]** (blocking) `README.md:14` stale `claude/templates/` row → fixed in `0a0986e`
- **[documentation]** (non-blocking) ADR-003 amendment overstated "third occurrence" → fixed in `0a0986e`
- **[maintainability]** (non-blocking) no automated test for `setup.sh`'s linking logic → filed [dev-env#614](https://github.com/brownm09/dev-env/issues/614)

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
