### PR TITLE
docs(claude-md): Glob/git status skip gitignored files (#632)

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -55,6 +55,7 @@ Before writing a `gh` or other CLI automation script:
 2. Confirm which JSON tools are available (`jq` is NOT available — use `node -e`)
 3. Write temp files to `C:/Users/brown/.claude/scratch/`, not `/tmp/` or a project repo directory
 4. Check whether any additional `gh` auth scopes are needed
+5. `Glob` and plain `git status`/`git ls-tree` silently skip gitignored files — before declaring a directory empty or fully processed, verify with `ls -la` / `Get-ChildItem -Force` or `git status --ignored` instead.
 
 ---
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -55,7 +55,7 @@ Before writing a `gh` or other CLI automation script:
 2. Confirm which JSON tools are available (`jq` is NOT available — use `node -e`)
 3. Write temp files to `C:/Users/brown/.claude/scratch/`, not `/tmp/` or a project repo directory
 4. Check whether any additional `gh` auth scopes are needed
-5. `Glob` and plain `git status`/`git ls-tree` silently skip gitignored files — before declaring a directory empty or fully processed, verify with `ls -la` / `Get-ChildItem -Force` or `git status --ignored` instead.
+5. `Glob` and plain `git status` silently skip gitignored files, and `git ls-tree` only shows committed content (never untracked files, ignored or not) — before declaring a directory empty or fully processed, verify with `ls -la` / `Get-ChildItem -Force` or `git status --ignored` instead.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add item 5 to the CLI Scripting Checklist (claude/CLAUDE.md): before declaring a directory empty/cleared/fully processed, verify with a raw listing or `git status --ignored` — Glob and plain git status/ls-tree silently skip gitignored files.
- Prevents a repeat of the career-playbook incident where a gitignored drop-zone directory was wrongly reported as empty, nearly masking a real batch-pipeline bug (career-playbook #664 / PR #665).

Closes #632. Related: #602 (same checklist section, different gotcha).

ADR-warrant check: not warranted — see docs/adr/011-adr-warrant-check.md. This adds one checklist line; no new rule/hook/skill/settings change, no claude/ directory restructure, no new cross-referenced workflow rule.

Testing: docs-only guard run (`grep -n 'date -u' claude/CLAUDE.md`) — zero matches, unaffected by this change.

## Review findings disposition
- **[correctness]** `git ls-tree --ignored` is not a valid flag; grouping `git ls-tree` with `git status --ignored` implied a nonexistent remediation — fixed in `9483763` (reworded to describe `git ls-tree`'s actual blind spot instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
