### PR TITLE
fix(hooks): exclude --help/-h invocations from gh issue/pr create detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,15 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     argument, `--text` field value) for both PR- and issue-create, plus subshell/quote/cd-prefix/chained cases;
     and a `subprocess`-driven end-to-end pair (`_run_hook`, mirroring `test_worktree_path_check.py`'s pattern)
     pinning that the pre-existing `exit_code != 0` gate still short-circuits immediately after the detection
-    swap, without either branch invoking a live `gh` call. Also exercises the dev-env#527 / [ADR-076](docs/adr/076-live-fetch-project-hook-single-select-options.md)
+    swap, without either branch invoking a live `gh` call. Also exercises `is_issue_create_help_only()` /
+    `is_pr_create_help_only()` (thin wrappers over the shared `_hookio.is_help_only()`,
+    [ADR-050 Amendment 15](docs/adr/050-shared-hookio-sibling-hook-fixes.md); dev-env#636 — the identical
+    `--help` false-positive `is_merge_help_only` closes for `gh pr merge`, reproduced here for
+    `gh issue create` / `gh pr create`): bare `--help`/`-h`, a real create, no invocation at all, and —
+    via two `main()` end-to-end subprocess cases — that `gh issue/pr create --help` now exits 0 silently
+    and that a help-only issue-create chained with a REAL pr-create still reaches the exit-2 "no GitHub
+    URL found" path for the real create (proving `main()` downgrades each create-flag independently
+    rather than bailing out wholesale). Also exercises the dev-env#527 / [ADR-076](docs/adr/076-live-fetch-project-hook-single-select-options.md)
     live-fetch of `single_select` field options: the pure `_parse_live_options()` response parser (valid, empty-options,
     null-node, and malformed-JSON shapes), the pure `_resolve_required_fields()` legacy-config normalization shared
     between rendering and live-fetch target discovery, `fetch_live_required_field_options()`'s field-selection logic
@@ -179,8 +187,17 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     `scan_top_level()` — the stack-based top-level-statement parser shared with `pr-merge-reminder.py` and
     `post-tool-use.py` ([ADR-050 Amendment 5](docs/adr/050-shared-hookio-sibling-hook-fixes.md)): anchored-match
     semantics, non-splitting inside single/double quotes, `$()` subshells, and heredoc bodies, and correct
-    splitting on `&&`, `;`, `||`, and newline. `_hookio` is imported by all five PostToolUse Bash hooks plus
-    `pr-merge-reminder.py` ([ADR-050](docs/adr/050-shared-hookio-sibling-hook-fixes.md)). `confirm_merge_via_gh()`
+    splitting on `&&`, `;`, `||`, and newline. Also exercises `is_merge_help_only()` ([ADR-050 Amendment 13](docs/adr/050-shared-hookio-sibling-hook-fixes.md);
+    dev-env#557 — a `gh pr merge --help` invocation must never be mistaken for a real merge attempt): bare
+    `--help`/`-h`, a real merge, no merge invocation at all, chained help-then-real and two-chained-help
+    cases, heredoc/quoted-argument mentions that must not affect a real invocation elsewhere, and
+    case-insensitivity. Also exercises `is_help_only(command, invocation_re)` — the generalized core
+    `is_merge_help_only` now wraps ([ADR-050 Amendment 15](docs/adr/050-shared-hookio-sibling-hook-fixes.md);
+    dev-env#636) — directly, with a non-merge `invocation_re`, proving the extraction is genuinely generic
+    rather than merge-specific (the real second/third caller, `post-tool-use.py`'s
+    `is_issue_create_help_only()` / `is_pr_create_help_only()`, is covered in item 12 above). `_hookio` is
+    imported by all five PostToolUse Bash hooks plus `pr-merge-reminder.py`
+    ([ADR-050](docs/adr/050-shared-hookio-sibling-hook-fixes.md)). `confirm_merge_via_gh()`
     itself is not covered (it shells out to `gh pr view`).
 
     ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,11 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     [ADR-050 Amendment 15](docs/adr/050-shared-hookio-sibling-hook-fixes.md); dev-env#636 — the identical
     `--help` false-positive `is_merge_help_only` closes for `gh pr merge`, reproduced here for
     `gh issue create` / `gh pr create`): bare `--help`/`-h`, a real create, no invocation at all, and —
-    via two `main()` end-to-end subprocess cases — that `gh issue/pr create --help` now exits 0 silently
-    and that a help-only issue-create chained with a REAL pr-create still reaches the exit-2 "no GitHub
-    URL found" path for the real create (proving `main()` downgrades each create-flag independently
-    rather than bailing out wholesale). Also exercises the dev-env#527 / [ADR-076](docs/adr/076-live-fetch-project-hook-single-select-options.md)
+    via three `main()` end-to-end subprocess cases — that `gh issue create --help` and `gh pr create
+    --help` each exit 0 silently, and that a help-only issue-create chained with a REAL pr-create still
+    reaches the exit-2 "no GitHub URL found" path **and names the PR specifically** (`"PR created"`, not
+    `"Issue created"`) — proving `main()` downgrades each create-flag independently rather than bailing
+    out wholesale. Also exercises the dev-env#527 / [ADR-076](docs/adr/076-live-fetch-project-hook-single-select-options.md)
     live-fetch of `single_select` field options: the pure `_parse_live_options()` response parser (valid, empty-options,
     null-node, and malformed-JSON shapes), the pure `_resolve_required_fields()` legacy-config normalization shared
     between rendering and live-fetch target discovery, `fetch_live_required_field_options()`'s field-selection logic

--- a/claude/scripts/_hookio.py
+++ b/claude/scripts/_hookio.py
@@ -38,12 +38,15 @@ predicates (it *is* a ``gh pr merge`` invocation), so a hook's marker-absent /
 non-zero-exit fallback pays a live ``gh pr view`` confirmation with no PR
 number — which resolves against cwd's checked-out branch and can misattribute
 an unrelated already-merged PR to the harmless ``--help`` call. Callers treat a
-True result exactly like "not a merge command at all".
+True result exactly like "not a merge command at all". Generalized (dev-env#636)
+into ``is_help_only(command, invocation_re)`` so ``post-tool-use.py``'s
+``gh issue create`` / ``gh pr create`` detectors — which had the identical
+``--help`` false-positive — reuse the same segment-scan instead of a copy of it.
 
 Usage:
     from _hookio import read_command_output, output_has_merge_marker
     from _hookio import effective_merge_dir, scan_top_level, split_top_level
-    from _hookio import is_merge_help_only
+    from _hookio import is_help_only, is_merge_help_only
 
 See ADR-049 (root cause + canonical read) and ADR-050 (shared helper + sibling
 hook fixes).  See ADR-067 for the merge-dir scoping.
@@ -567,7 +570,7 @@ def mask_quoted_spans(command: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# is_merge_help_only  (dev-env#557)
+# is_help_only / is_merge_help_only  (dev-env#557, generalized dev-env#636)
 #
 # `gh pr merge --help` textually satisfies every `is_pr_merge_command` /
 # `_check_merge_stmt` predicate in this hook family — it *is* a `gh pr merge`
@@ -577,8 +580,17 @@ def mask_quoted_spans(command: str) -> str:
 # which resolves against cwd's checked-out branch and can misattribute an
 # unrelated already-merged PR to the --help invocation (confirmed incident:
 # dev-env#557). --help/-h can *categorically never* attempt a real merge, so
-# a command consisting only of --help/-h `gh pr merge` invocations should
+# a command consisting only of --help/-h invocations of a given kind should
 # short-circuit before any of that marker/exit-code logic runs at all.
+#
+# `post-tool-use.py`'s `is_issue_create_command` / `is_pr_create_command` have
+# the identical shape of bug: `gh issue create --help` (run per this repo's own
+# CLI Scripting Checklist, which prescribes checking `--help` before writing gh
+# automation) textually matches, so the hook proceeds as if a real issue had
+# been created (dev-env#636). `is_help_only` extracts the reusable core so a
+# second/third caller doesn't need a near-verbatim copy of the same
+# segment-scan + all() logic; `is_merge_help_only` becomes a thin wrapper over
+# it with its pre-existing signature/behavior unchanged.
 # ---------------------------------------------------------------------------
 
 _GH_MERGE_INVOCATION_RE = re.compile(r"gh(?:\.exe)?\s+pr\s+merge\b", re.IGNORECASE)
@@ -609,34 +621,43 @@ def _first_line(segment: str) -> str:
     return segment.split("\n", 1)[0].split("\r", 1)[0]
 
 
-def is_merge_help_only(command: str) -> bool:
-    """True iff every top-level `gh pr merge` segment in *command* is a
-    --help/-h invocation.
+def is_help_only(command: str, invocation_re: re.Pattern) -> bool:
+    """True iff every top-level segment of *command* matched by
+    *invocation_re* is a --help/-h invocation.
 
-    Callers already gate on their own `is_pr_merge_command` /
-    `_check_merge_stmt` check first, so the "no merge segments at all" case
-    returns False here too — this predicate only ever needs to answer "given
-    that at least one segment matched, were ALL of them --help-only?".
+    Callers already gate on their own "is this the command at all" check
+    first (e.g. `is_pr_merge_command`, `is_issue_create_command`), so the
+    "no matching segments at all" case returns False here too — this
+    predicate only ever needs to answer "given that at least one segment
+    matched, were ALL of them --help-only?".
 
-    A chained ``gh pr merge --help && gh pr merge 380 --squash`` therefore
-    correctly returns False: a real merge attempt elsewhere in the same
-    command must never be suppressed just because an earlier segment was a
-    harmless flag check.
+    A chained ``<cmd> --help && <cmd> 380 --squash`` therefore correctly
+    returns False: a real invocation elsewhere in the same command must
+    never be suppressed just because an earlier segment was a harmless flag
+    check.
 
     Each segment's --help/-h check is scoped to its own first physical line
     (`_first_line()`) so a heredoc/`$()` body that merely *mentions*
     "--help" as prose cannot be mistaken for a real flag on this segment's
-    own invocation. The merge-invocation match itself is anchored at the
-    (lstripped) start of that first line — mirroring every sibling
-    `_check_merge_stmt`'s ``.match(token.lstrip())`` convention — so a `gh pr
-    merge` phrase appearing mid-segment (e.g. inside an earlier quoted
-    argument on the same segment, such as `git commit -m "reminder: gh pr
-    merge later" && gh pr merge --help`) is never mistaken for a genuine
-    invocation on that segment.
+    own invocation. *invocation_re* itself is matched at the (lstripped)
+    start of that first line — mirroring every sibling `_check_*_stmt`'s
+    ``.match(token.lstrip())`` convention — so a phrase appearing mid-segment
+    (e.g. inside an earlier quoted argument on the same segment) is never
+    mistaken for a genuine invocation.
     """
-    merge_segments = [
-        seg for seg in split_top_level(command) if _GH_MERGE_INVOCATION_RE.match(_first_line(seg).lstrip())
+    matching_segments = [
+        seg for seg in split_top_level(command)
+        if invocation_re.match(_first_line(seg).lstrip())
     ]
-    if not merge_segments:
+    if not matching_segments:
         return False
-    return all(_HELP_FLAG_RE.search(_first_line(seg)) for seg in merge_segments)
+    return all(_HELP_FLAG_RE.search(_first_line(seg)) for seg in matching_segments)
+
+
+def is_merge_help_only(command: str) -> bool:
+    """True iff every top-level `gh pr merge` segment in *command* is a
+    --help/-h invocation. Thin wrapper over `is_help_only` (see its docstring
+    for the full rationale) preserving this function's pre-existing name and
+    signature; see dev-env#557 (this module's header docstring) for the
+    motivating incident."""
+    return is_help_only(command, _GH_MERGE_INVOCATION_RE)

--- a/claude/scripts/post-tool-use.py
+++ b/claude/scripts/post-tool-use.py
@@ -4,7 +4,9 @@ and automatically adds the item to the configured GitHub project.
 
 Detection matches only a top-level CLI invocation (via _hookio.scan_top_level),
 not the string appearing inside commit messages, heredocs, grep patterns, or
-other quoted arguments (dev-env#499).
+other quoted arguments (dev-env#499). A --help/-h-only invocation (e.g. `gh
+issue create --help`, run per this repo's own CLI Scripting Checklist) is
+excluded too (dev-env#636) -- see is_issue_create_help_only / is_pr_create_help_only.
 
 Project opt-in: add .claude/hook-config.json to the project root. That file is
 gitignored by dev-env's own convention (.gitignore ignores all of .claude/),
@@ -61,7 +63,7 @@ import subprocess
 import sys
 
 from _gh_project import add_to_project
-from _hookio import read_command_output, scan_top_level, split_top_level
+from _hookio import is_help_only, read_command_output, scan_top_level, split_top_level
 from _worktree_canon import canonical_root_from_worktree
 
 CONFIG_FILE = ".claude/hook-config.json"
@@ -94,6 +96,24 @@ def is_issue_create_command(command: str) -> bool:
 def is_pr_create_command(command: str) -> bool:
     """Return True only when *command* contains a top-level `gh pr create`."""
     return scan_top_level(command, _check_pr_create_stmt)
+
+
+def is_issue_create_help_only(command: str) -> bool:
+    """True iff every top-level `gh issue create` segment in *command* is a
+    --help/-h invocation (dev-env#636) -- e.g. `gh issue create --help`, run
+    per this repo's own CLI Scripting Checklist ("run <command> --help first
+    to confirm flag names"), textually matches `is_issue_create_command` but
+    creates nothing. Mirrors `_hookio.is_merge_help_only`'s fix for the
+    identical `gh pr merge --help` false-positive (dev-env#557); reuses
+    `_ISSUE_CREATE_RE` so this stays byte-for-byte consistent with
+    `is_issue_create_command`'s own matching."""
+    return is_help_only(command, _ISSUE_CREATE_RE)
+
+
+def is_pr_create_help_only(command: str) -> bool:
+    """True iff every top-level `gh pr create` segment in *command* is a
+    --help/-h invocation (dev-env#636). See `is_issue_create_help_only`."""
+    return is_help_only(command, _PR_CREATE_RE)
 
 
 _REPO_FLAG_RE = re.compile(r"(?:--repo|-R)[\s=]+(\"[^\"]+\"|'[^']+'|\S+)")
@@ -521,6 +541,15 @@ def main() -> None:
 
     is_issue_create = is_issue_create_command(command)
     is_pr_create = is_pr_create_command(command)
+
+    # A --help/-h invocation can never actually create anything (dev-env#636,
+    # mirrors _hookio.is_merge_help_only's dev-env#557 fix) -- downgrade each
+    # create-flag independently so a real create chained with an unrelated
+    # help-only invocation of the OTHER type is still processed correctly.
+    if is_issue_create and is_issue_create_help_only(command):
+        is_issue_create = False
+    if is_pr_create and is_pr_create_help_only(command):
+        is_pr_create = False
 
     if not (is_issue_create or is_pr_create):
         sys.exit(0)

--- a/claude/scripts/tests/test_hookio.py
+++ b/claude/scripts/tests/test_hookio.py
@@ -14,6 +14,7 @@ Usage:
 Exit 0 = all pass.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -24,6 +25,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 
 from _hookio import (  # noqa: E402
     effective_merge_dir,
+    is_help_only,
     is_merge_help_only,
     mask_quoted_spans,
     merge_pr_number_from_output,
@@ -663,6 +665,42 @@ def test_is_merge_help_only_case_insensitive() -> str:
     return "GH.EXE PR MERGE --HELP -> True (case-insensitive)"
 
 
+# ---------------------------------------------------------------------------
+# is_help_only  (dev-env#636)
+#
+# is_merge_help_only is now a thin wrapper over this generalized core (the
+# tests above already pin its externally-visible behavior unchanged). These
+# tests exercise is_help_only directly with a NON-merge invocation_re, proving
+# the extraction is genuinely generic rather than merge-specific -- the real
+# motivating second caller is post-tool-use.py's is_issue_create_help_only /
+# is_pr_create_help_only (test_post_tool_use.py), which reuse this exact core.
+# ---------------------------------------------------------------------------
+
+_ISSUE_CREATE_INVOCATION_RE = re.compile(r"gh(?:\.exe)?\s+issue\s+create\b", re.IGNORECASE)
+
+
+def test_is_help_only_generic_help_invocation_is_true() -> str:
+    assert is_help_only("gh issue create --help", _ISSUE_CREATE_INVOCATION_RE)
+    return "is_help_only with a non-merge invocation_re: --help invocation -> True (dev-env#636)"
+
+
+def test_is_help_only_generic_real_invocation_is_false() -> str:
+    assert not is_help_only('gh issue create --title "x"', _ISSUE_CREATE_INVOCATION_RE)
+    return "is_help_only: a real (non-help) invocation of the custom invocation_re -> False"
+
+
+def test_is_help_only_generic_no_matching_segment_is_false() -> str:
+    assert not is_help_only("git status", _ISSUE_CREATE_INVOCATION_RE)
+    return "is_help_only: no segment matches invocation_re at all -> False"
+
+
+def test_is_help_only_generic_chained_help_then_real_is_false() -> str:
+    assert not is_help_only(
+        'gh issue create --help && gh issue create --title "x"', _ISSUE_CREATE_INVOCATION_RE
+    )
+    return "is_help_only: real invocation elsewhere in the chain is not suppressed -> False"
+
+
 def main() -> int:
     tests = [
         ("reads command output from stdout", test_reads_stdout),
@@ -735,6 +773,10 @@ def main() -> int:
         ("is_merge_help_only: --help not confused with similar flag", test_is_merge_help_only_help_flag_not_confused_with_similar_flag),
         ("is_merge_help_only: cd-prefixed --help -> True", test_is_merge_help_only_cd_prefixed_help_is_true),
         ("is_merge_help_only: case-insensitive match", test_is_merge_help_only_case_insensitive),
+        ("is_help_only: generic --help invocation -> True (dev-env#636)", test_is_help_only_generic_help_invocation_is_true),
+        ("is_help_only: generic real invocation -> False", test_is_help_only_generic_real_invocation_is_false),
+        ("is_help_only: generic no matching segment -> False", test_is_help_only_generic_no_matching_segment_is_false),
+        ("is_help_only: generic chained help-then-real -> False", test_is_help_only_generic_chained_help_then_real_is_false),
     ]
     failed = 0
     for name, fn in tests:

--- a/claude/scripts/tests/test_post_tool_use.py
+++ b/claude/scripts/tests/test_post_tool_use.py
@@ -82,6 +82,8 @@ _canonical_root_from_common_dir = post_tool_use._canonical_root_from_common_dir
 load_config = post_tool_use.load_config
 is_issue_create_command = post_tool_use.is_issue_create_command
 is_pr_create_command = post_tool_use.is_pr_create_command
+is_issue_create_help_only = post_tool_use.is_issue_create_help_only
+is_pr_create_help_only = post_tool_use.is_pr_create_help_only
 extract_repo_flag = post_tool_use.extract_repo_flag
 _sibling_repo_config = post_tool_use._sibling_repo_config
 _read_config = post_tool_use._read_config
@@ -597,6 +599,54 @@ def test_pr_create_in_double_quotes_not_matched() -> str:
 
 
 # ---------------------------------------------------------------------------
+# is_issue_create_help_only / is_pr_create_help_only  (dev-env#636)
+#
+# `gh issue create --help` (run per this repo's own CLI Scripting Checklist,
+# which prescribes checking `--help` before writing gh automation) textually
+# matches is_issue_create_command -- the identical false-positive shape
+# is_merge_help_only was written to close for `gh pr merge --help`
+# (dev-env#557). These reuse the shared _hookio.is_help_only core.
+# ---------------------------------------------------------------------------
+
+def test_issue_create_help_only_bare_help_is_true() -> str:
+    assert is_issue_create_help_only("gh issue create --help")
+    return "gh issue create --help -> True (dev-env#636)"
+
+
+def test_issue_create_help_only_short_flag_is_true() -> str:
+    assert is_issue_create_help_only("gh issue create -h")
+    return "gh issue create -h -> True"
+
+
+def test_issue_create_help_only_real_create_is_false() -> str:
+    assert not is_issue_create_help_only('gh issue create --title "x" --body "y"')
+    return "real gh issue create (no --help) -> False"
+
+
+def test_issue_create_help_only_no_invocation_at_all_is_false() -> str:
+    assert not is_issue_create_help_only("git status")
+    return "no gh issue create invocation anywhere -> False"
+
+
+def test_issue_create_help_only_chained_with_real_pr_create_still_processes() -> str:
+    # The exact main()-level scenario this fix protects: a help-only issue-create
+    # chained with a REAL pr-create must not suppress the real one.
+    assert is_issue_create_help_only('gh issue create --help && gh pr create --title "x"')
+    assert not is_pr_create_help_only('gh issue create --help && gh pr create --title "x"')
+    return "chained help-only issue-create + real pr-create -> only the help-only one downgrades"
+
+
+def test_pr_create_help_only_bare_help_is_true() -> str:
+    assert is_pr_create_help_only("gh pr create --help")
+    return "gh pr create --help -> True (dev-env#636)"
+
+
+def test_pr_create_help_only_real_create_is_false() -> str:
+    assert not is_pr_create_help_only("gh pr create --fill")
+    return "real gh pr create (no --help) -> False"
+
+
+# ---------------------------------------------------------------------------
 # extract_repo_flag (dev-env#542) -- feeds load_config's cross-repo
 # resolution. Shares is_issue_create_command's top-level-statement scoping:
 # only the segment that itself matched the create predicate is searched.
@@ -706,6 +756,63 @@ def test_main_exit_code_zero_proceeds_past_gate_to_no_url_advisory() -> str:
         )
         assert "no GitHub URL found" in result.stderr, f"got {result.stderr!r}"
     return "genuine top-level create + exitCode==0, no URL in output -> exit 2 advisory (detection fired)"
+
+
+def test_main_help_only_issue_create_is_silent() -> str:
+    # The dev-env#636 regression, end-to-end: before the fix, this exact
+    # payload reached the "no GitHub URL found" exit-2 advisory (reproduced
+    # live via `gh issue create --help` during this fix's own development).
+    with tempfile.TemporaryDirectory() as tmp_root:
+        cwd = _hook_config_cwd(tmp_root)
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh issue create --help"},
+            "tool_response": {"stdout": "USAGE\n  gh issue create [flags]\n...", "stderr": "", "exitCode": 0},
+            "cwd": cwd,
+        }
+        result = _run_hook(payload)
+        assert result.returncode == 0, (
+            f"expected exit 0 (help-only, not a real create), got {result.returncode}: "
+            f"stderr={result.stderr!r}"
+        )
+        assert result.stderr == "", f"expected no stderr output, got {result.stderr!r}"
+    return "gh issue create --help -> exit 0, silent (dev-env#636 fix)"
+
+
+def test_main_help_only_pr_create_is_silent() -> str:
+    with tempfile.TemporaryDirectory() as tmp_root:
+        cwd = _hook_config_cwd(tmp_root)
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr create --help"},
+            "tool_response": {"stdout": "USAGE\n  gh pr create [flags]\n...", "stderr": "", "exitCode": 0},
+            "cwd": cwd,
+        }
+        result = _run_hook(payload)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}: stderr={result.stderr!r}"
+        assert result.stderr == "", f"expected no stderr output, got {result.stderr!r}"
+    return "gh pr create --help -> exit 0, silent (dev-env#636 fix)"
+
+
+def test_main_chained_help_only_issue_create_and_real_pr_create_still_processes() -> str:
+    # A real gh pr create chained with an unrelated help-only gh issue create
+    # must still be processed as a PR create (the reason main() downgrades
+    # each create-flag independently rather than bailing out wholesale).
+    with tempfile.TemporaryDirectory() as tmp_root:
+        cwd = _hook_config_cwd(tmp_root)
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'gh issue create --help && gh pr create --fill'},
+            "tool_response": {"stdout": "done", "stderr": "", "exitCode": 0},
+            "cwd": cwd,
+        }
+        result = _run_hook(payload)
+        assert result.returncode == 2, (
+            f"expected exit 2 (real pr-create still detected), got {result.returncode}: "
+            f"stderr={result.stderr!r}"
+        )
+        assert "no GitHub URL found" in result.stderr, f"got {result.stderr!r}"
+    return "help-only issue-create chained with a real pr-create -> the real create still processed"
 
 
 # ---------------------------------------------------------------------------
@@ -930,6 +1037,13 @@ def main() -> int:
         ("pr-create in $() subshell -> no match", test_pr_create_in_subshell_not_matched),
         ("issue-create in $() subshell -> no match", test_issue_create_in_subshell_not_matched),
         ("pr-create in double quotes -> no match", test_pr_create_in_double_quotes_not_matched),
+        ("issue-create-help-only: bare --help -> True (dev-env#636)", test_issue_create_help_only_bare_help_is_true),
+        ("issue-create-help-only: -h short flag -> True", test_issue_create_help_only_short_flag_is_true),
+        ("issue-create-help-only: real create -> False", test_issue_create_help_only_real_create_is_false),
+        ("issue-create-help-only: no invocation at all -> False", test_issue_create_help_only_no_invocation_at_all_is_false),
+        ("issue-create-help-only: chained with real pr-create still processes", test_issue_create_help_only_chained_with_real_pr_create_still_processes),
+        ("pr-create-help-only: bare --help -> True (dev-env#636)", test_pr_create_help_only_bare_help_is_true),
+        ("pr-create-help-only: real create -> False", test_pr_create_help_only_real_create_is_false),
         ("extract_repo_flag: --repo extracted from top-level create (#542)", test_extract_repo_flag_simple),
         ("extract_repo_flag: -R short flag extracted (#542)", test_extract_repo_flag_short_flag),
         ("extract_repo_flag: --repo=value equals-form extracted (#542)", test_extract_repo_flag_equals_form),
@@ -938,6 +1052,9 @@ def main() -> int:
         ("extract_repo_flag: unrelated earlier segment not leaked (#542)", test_extract_repo_flag_other_segment_not_leaked),
         ("main(): exitCode!=0 short-circuits even when create detected", test_main_exit_code_nonzero_short_circuits_even_when_create_detected),
         ("main(): exitCode==0 proceeds to no-URL advisory", test_main_exit_code_zero_proceeds_past_gate_to_no_url_advisory),
+        ("main(): gh issue create --help -> silent (dev-env#636)", test_main_help_only_issue_create_is_silent),
+        ("main(): gh pr create --help -> silent (dev-env#636)", test_main_help_only_pr_create_is_silent),
+        ("main(): help-only issue-create chained with real pr-create still processes", test_main_chained_help_only_issue_create_and_real_pr_create_still_processes),
         ("parse live options: valid response", test_parse_live_options_valid),
         ("parse live options: empty options -> {} not None", test_parse_live_options_empty_options_is_empty_dict_not_none),
         ("parse live options: node null -> None", test_parse_live_options_wrong_node_type_is_none),

--- a/claude/scripts/tests/test_post_tool_use.py
+++ b/claude/scripts/tests/test_post_tool_use.py
@@ -812,6 +812,10 @@ def test_main_chained_help_only_issue_create_and_real_pr_create_still_processes(
             f"stderr={result.stderr!r}"
         )
         assert "no GitHub URL found" in result.stderr, f"got {result.stderr!r}"
+        # Not just "some create reached the advisory" -- specifically the PR
+        # create (is_pr_create), proving the downgrade logic didn't flip
+        # item_type to "Issue" for this chained command (review of PR #637).
+        assert "PR created" in result.stderr, f"got {result.stderr!r}"
     return "help-only issue-create chained with a real pr-create -> the real create still processed"
 
 

--- a/docs/adr/050-shared-hookio-sibling-hook-fixes.md
+++ b/docs/adr/050-shared-hookio-sibling-hook-fixes.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-06-21
 **Status:** Accepted
-**Amended:** 2026-07-01, 2026-07-02, 2026-07-04, 2026-07-08 (fifteen amendments — see Amendment sections below)
-**Tags:** hooks, post-tool-use, tool_response, payload, github-project, automation, reliability, dry, usage-snapshot, pr-merge-reminder, gh-pr-view, api-fallback, message-dispatch, top-level-statement-scan, issue-create, false-positive, command-parsing, heredoc, regex, quote-tracking, canonical-mutate-guard, pre-tool-use, ast, regression-test, allowlist, gh-pr-merge-help, misattribution, live-confirmation-fallback, repo-flag-shorthand, quote-masking
+**Amended:** 2026-07-01, 2026-07-02, 2026-07-04, 2026-07-08 (sixteen amendments — see Amendment sections below)
+**Tags:** hooks, post-tool-use, tool_response, payload, github-project, automation, reliability, dry, usage-snapshot, pr-merge-reminder, gh-pr-view, api-fallback, message-dispatch, top-level-statement-scan, issue-create, false-positive, command-parsing, heredoc, regex, quote-tracking, canonical-mutate-guard, pre-tool-use, ast, regression-test, allowlist, gh-pr-merge-help, misattribution, live-confirmation-fallback, repo-flag-shorthand, quote-masking, gh-create-help
 
 ---
 
@@ -1138,3 +1138,75 @@ either an unsafe refactor or an unenforced comment. A second, narrower lesson: a
 (`_REPO_FLAG_RE`) for a fix inevitably surfaces adjacent, structurally different instances of a *related* bug
 class — the right response is the same "grep for the shape, note what's out of scope, file it" discipline this
 ADR has used since Amendment 9, not scope creep into a single oversized PR.
+
+## Amendment 16 (2026-07-08) — generalizing `is_merge_help_only` into `is_help_only`; fixing the identical `gh issue/pr create --help` false-positive in `post-tool-use.py` (dev-env#636)
+
+**The gap.** Amendment 13 fixed `gh pr merge --help`'s false-positive across eight files, but the
+identical shape of bug survived, unfixed, in the two functions Amendment 5 introduced for
+`post-tool-use.py`'s own create-side detection: `is_issue_create_command()` / `is_pr_create_command()`.
+Running `gh issue create --help` (or `gh pr create --help`) — exactly the step this repo's own CLI
+Scripting Checklist prescribes ("run `<command> --help` first to confirm flag names and syntax" before
+writing any `gh` automation script) — textually satisfies `is_issue_create_command`'s `_ISSUE_CREATE_RE`
+match, so `main()` proceeds as though a real issue had been created. Since `--help` output contains no
+GitHub URL, this reaches the de-silenced "successful create but no URL found" branch Amendment 5's own
+predecessor (dev-env#377/#499) intentionally surfaces rather than swallows, and the hook emits a
+blocking (exit 2) "Issue created but no GitHub URL found in output" message for a command that created
+nothing.
+
+**Live reproduction.** Confirmed firsthand during this fix's own research session: `gh issue create
+--help` (chained after an unrelated command, as a normal exploratory `gh ... --help` check per the CLI
+Scripting Checklist) produced exactly this message.
+
+**Why generalize rather than duplicate `is_merge_help_only`'s logic a second time.**
+`is_merge_help_only`'s existing implementation was already hardcoded to `_GH_MERGE_INVOCATION_RE` —
+copying its segment-scan-plus-`all()` body into `post-tool-use.py` for a second and third invocation
+regex (`_ISSUE_CREATE_RE`, `_PR_CREATE_RE`) would have been the exact kind of near-verbatim duplication
+this ADR exists to prevent (Amendment 6's "grep for the engine, not the call pattern" lesson, applied
+one level up: this time the engine is the *help-only* check itself, not the top-level-statement scanner
+it's built on). `is_help_only(command, invocation_re)` extracts the reusable core; `is_merge_help_only`
+becomes a thin wrapper (`is_help_only(command, _GH_MERGE_INVOCATION_RE)`) with its pre-existing name,
+signature, and behavior completely unchanged — every one of Amendment 13's 13 `is_merge_help_only` tests
+continues to pass unmodified against the refactored implementation.
+
+**Fix.** `post-tool-use.py` gains `is_issue_create_help_only(command)` / `is_pr_create_help_only(command)`,
+each a thin `is_help_only(command, <its own existing _ISSUE_CREATE_RE / _PR_CREATE_RE>)` wrapper —
+reusing the exact regex `is_issue_create_command` / `is_pr_create_command` already match against, so the
+help-only check can never diverge from the create-detection it's meant to override. `main()` downgrades
+each create-flag *independently*:
+
+```python
+if is_issue_create and is_issue_create_help_only(command):
+    is_issue_create = False
+if is_pr_create and is_pr_create_help_only(command):
+    is_pr_create = False
+```
+
+rather than a single combined bail-out — mirroring Amendment 4's "gate each side effect on its own
+confirming signal" lesson: a real `gh pr create` chained with an unrelated help-only `gh issue create`
+(or vice versa) must still be processed as the create it actually is, not suppressed because *some*
+create-shaped segment in the same command happened to be a harmless flag check.
+
+**Coverage.** `test_hookio.py` gains four new tests exercising `is_help_only` directly with a non-merge
+`invocation_re` (a `gh issue create` pattern), proving the extraction is genuinely generic rather than
+merge-specific, alongside the unmodified pre-existing `is_merge_help_only` suite (74 total, up from 70 —
+Amendment 15's `mask_quoted_spans` work landed first and already brought this file from 57 to 70; this
+amendment's four tests are the delta on top of that, not on top of Amendment 13's original 57).
+`test_post_tool_use.py` gains seven pure-helper tests (bare `--help`/`-h`, a real create, no invocation
+at all, and the chained-independent-downgrade case for both `is_issue_create_help_only` and
+`is_pr_create_help_only`) plus three `main()` end-to-end subprocess tests: `gh issue create --help` and
+`gh pr create --help` each now exit 0 silently (reproducing this fix's own live incident, inverted), and
+a help-only issue-create chained with a real pr-create still reaches the exit-2 "no GitHub URL found"
+path for the real create — proving the independent-downgrade fix, not just the single-command case
+(87 total, up from 77).
+
+**General lesson (continuing Amendments 1, 6, 9, 10, 12, and 14's).** The "a fix scoped to one hook is a
+standing invitation to check every sibling doing the same kind of thing" lesson, drawn several times
+already in this ADR for output-reading, `scan_top_level`-anchoring, and repo-flag-shorthand bugs,
+applies just as directly to a further kind of drifted duplication: a fix landed for one
+command-detection predicate (`is_pr_merge_command`) and never checked against the structurally
+identical predicates one file over (`is_issue_create_command` / `is_pr_create_command`) despite both
+living in `_hookio`-adjacent code and sharing the exact same `scan_top_level`-based detection shape
+Amendment 5 itself introduced. The mechanical proxy here is narrower and cheaper than a fresh grep: any
+new `is_*_command`-style top-level-statement predicate introduced into this hook family should be
+paired, at introduction, with the question "does a `--help`/`-h`-only invocation of this same CLI verb
+need the identical exclusion `is_merge_help_only` already established the pattern for?"


### PR DESCRIPTION
## Summary

- `gh issue create --help` (or `gh pr create --help`) textually matched `post-tool-use.py`'s `is_issue_create_command()`/`is_pr_create_command()`, so the hook proceeded as if a real issue/PR had been created and emitted a misleading blocking "no GitHub URL found" message. Discovered live during research for #630/#631's follow-up work.
- Identical false-positive shape `_hookio.is_merge_help_only()` already closes for `gh pr merge --help` (dev-env#557) -- never ported to the create-side detectors.
- Generalized `is_merge_help_only` into `is_help_only(command, invocation_re)` in `_hookio.py` (thin wrapper preserves its exact pre-existing signature/behavior -- all 57 pre-existing tests pass unmodified), and added `is_issue_create_help_only()`/`is_pr_create_help_only()` in `post-tool-use.py`, each reusing the existing `_ISSUE_CREATE_RE`/`_PR_CREATE_RE`.
- `main()` downgrades each create-flag independently (not a combined bail-out) so a real create chained with an unrelated help-only invocation of the *other* type still processes correctly.
- Documented as Amendment 15 to [ADR-050](docs/adr/050-shared-hookio-sibling-hook-fixes.md) (the "sibling hook fixes" ADR that already tracks the identical `gh-pr-merge-help` precedent as Amendment 13) rather than a new ADR -- no new rationale, just the same fix applied to sibling functions.

Closes #636

## Testing

Ran per `CLAUDE.md` items 12 and 13 (both updated in this PR to describe the new coverage):

```
py -3 claude/scripts/tests/test_hookio.py        # 61 passed, 0 skipped, 0 failed (up from 57)
py -3 claude/scripts/tests/test_post_tool_use.py # 87 passed, 0 skipped, 0 failed (up from 77)
py -3 claude/scripts/tests/test_no_crude_command_substring_checks.py  # 13 passed, 0 skipped, 0 failed
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py  # clean
```

Also ran the required pre-PR suppression and test-integrity greps (`CLAUDE.md` Code Quality section) -- both exit 1 (no matches), clean.

**Tests: 174 passed, 0 skipped, 0 failed** (combined, across the two directly-touched suites).

## Test plan

- [x] `gh issue create --help` and `gh pr create --help` now exit 0 silently (new e2e subprocess tests, reproducing the live incident inverted)
- [x] A real `gh pr create` chained with an unrelated help-only `gh issue create` still reaches the exit-2 "no GitHub URL found" path (proves independent per-flag downgrade, not a wholesale bail-out)
- [x] All pre-existing `is_merge_help_only` behavior unchanged (thin-wrapper refactor)
- [x] ADR-050 amended (Amendment 15); no new ADR needed (rationale already established by Amendment 13/dev-env#557)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review findings disposition

Both findings from [the /review comment](https://github.com/brownm09/dev-env/pull/637#issuecomment-4919988645) fixed in `c5b1f15`:
- **[maintainability]** Chained test didn't assert item_type specifically → added `assert "PR created" in result.stderr` — fixed in c5b1f15
- **[documentation]** CLAUDE.md item 12 undercounted new `main()` e2e tests ("two" vs actual three) → corrected wording, matches ADR-050 Amendment 15's own accurate count — fixed in c5b1f15
