### PR TITLE
docs(claude-md): document PostToolUse hook firing on gh pr create

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1112,14 +1112,14 @@ All new dev-env issues must be added to the **Dev Env** project and given an Imp
 | Medium | Recurs periodically or silently degrades correctness over time |
 | Low | Nice-to-have; low frequency or easily worked around |
 
-**Workflow — automated via PostToolUse hook:** After `gh issue create` succeeds, `post-tool-use.py` adds the issue to project #3 and exits code 2, printing the exact `gh project item-edit` commands to set Impact and Why. **Run those commands immediately — before any file edits.**
+**Workflow — automated via PostToolUse hook:** After `gh issue create` or `gh pr create` succeeds, `post-tool-use.py` adds the issue or PR to project #3 and exits code 2, printing the exact `gh project item-edit` commands to set Impact and Why. **Run those commands immediately — before any file edits.** The hook treats both identically ([ADR-023](docs/adr/023-generic-required-fields-issue-hook.md)).
 
-**Fallback (if the hook did not fire or the item-add failed):** run the three steps manually. Requires project scope — add once if needed: `gh auth refresh -s project`. A *wholesale* non-fire — no `[project-hook]` output at all after `gh issue create`, and `spawn_task` chips also not rendering — most often means the session was launched as a background task / via `spawn_task`, where **every** PostToolUse hook is silently inert ([ADR-053](docs/adr/053-posttooluse-hooks-inert-in-background-sessions.md)); these manual steps are the recovery.
+**Fallback (if the hook did not fire or the item-add failed):** run the three steps manually (substitute the PR URL for the issue URL when the item is a PR). Requires project scope — add once if needed: `gh auth refresh -s project`. A *wholesale* non-fire — no `[project-hook]` output at all after `gh issue create` or `gh pr create`, and `spawn_task` chips also not rendering — most often means the session was launched as a background task / via `spawn_task`, where **every** PostToolUse hook is silently inert ([ADR-053](docs/adr/053-posttooluse-hooks-inert-in-background-sessions.md)); these manual steps are the recovery.
 
 ```bash
-# 1. Add issue to project, capture item ID
+# 1. Add issue/PR to project, capture item ID
 TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_$$.json"
-gh project item-add 3 --owner brownm09 --url <issue-url> --format json > "$TMPFILE"
+gh project item-add 3 --owner brownm09 --url <issue-or-pr-url> --format json > "$TMPFILE"
 ITEM_ID=$(node -e "const d=JSON.parse(require('fs').readFileSync('$TMPFILE','utf8')); console.log(d.id);")
 rm -f "$TMPFILE"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1090,7 +1090,7 @@ When a PR modifies any of the paths below, update the listed reference docs **in
 
 ## GitHub Project
 
-All new dev-env issues must be added to the **Dev Env** project and given an Impact rating and Why description before work begins. The general single-select option-mutation hazard that applies to **every** project is documented in the global `claude/CLAUDE.md` → Dev-Env & Project Boards section; the dev-env-specific IDs and procedures are below.
+All new dev-env issues and PRs must be added to the **Dev Env** project and given an Impact rating and Why description before work begins. The general single-select option-mutation hazard that applies to **every** project is documented in the global `claude/CLAUDE.md` → Dev-Env & Project Boards section; the dev-env-specific IDs and procedures are below.
 
 **Project IDs:**
 - Project number: `3`, owner: `brownm09`
@@ -1132,7 +1132,7 @@ gh project item-edit --project-id PVT_kwHOAjEKvM4BWKFe --id "$ITEM_ID" \
   --field-id PVTF_lAHOAjEKvM4BWKFezhRgkN0 --text "<why this matters>"
 ```
 
-To look up an item ID by issue number `<N>` (e.g., to move status in a later session):
+To look up an item ID by issue or PR number `<N>` (e.g., to move status in a later session):
 
 ```bash
 TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_$$.json"


### PR DESCRIPTION
## Summary
- The "## GitHub Project" section's Workflow/Fallback paragraphs described `post-tool-use.py` as firing only on `gh issue create`. It fires identically on `gh pr create` (confirmed directly in `post-tool-use.py`: `is_issue_create_command`/`is_pr_create_command` lines 91-98 feed a single shared gate in `main()` lines 542-555, and the add-to-project + `format_reminder` flow at lines 590-599 is byte-identical between the two — the only difference anywhere in the script is one interpolated word, `item_type = "Issue" if is_issue_create else "PR"` at line 566). This is also the documented, accepted design in [ADR-023](docs/adr/023-generic-required-fields-issue-hook.md).
- Updates the Workflow paragraph, Fallback paragraph, and the fallback code block's comment/placeholder to mention `gh pr create` alongside `gh issue create`, so a future session isn't caught off guard by PR-creation hook output or skips setting Impact/Why on a PR's project item.
- No behavior change — `post-tool-use.py` itself is correct and unchanged; only the CLAUDE.md prose needed to catch up.

Closes #643

## ADR-warrant check
Not warranted — see `docs/adr/011-adr-warrant-check.md`. Checked against all four criteria:
1. Changes a rule/hook/skill/settings value documented in `claude/` — No, corrects prose to match existing, unchanged hook behavior.
2. Introduces or restructures a directory under `claude/` — No.
3. Establishes or changes a workflow rule other CLAUDE.md files reference — No, no new rule.
4. Rationale hard to recover from `git log` alone — No, fully recoverable: the hook already treats both identically per the existing, accepted ADR-023.

Same reasoning pattern as the precedent PR #633 for an analogous one-line CLAUDE.md prose addition.

## Doc reconciliation
Checked `README.md` (line 82) and `docs/REFERENCE.md` (line 239) — both already describe the hook's trigger generically as "issues/PRs" / "`gh issue create` or `gh pr create`". No updates needed there; the staleness was isolated to the root `CLAUDE.md` GitHub Project section.

## Testing
N/A — prose-only edit to the root CLAUDE.md GitHub Project section; no script/hook/skill/routine touched, and none of this repo's 50 `## Testing` items are conditioned on this file (item 4's docs-only guard is scoped specifically to `claude/CLAUDE.md`, a different file). Manually verified the updated text against `claude/scripts/post-tool-use.py`'s actual behavior (lines 91-98, 542-599, 566). Also ran the pre-PR suppression and test-integrity greps per the global workflow — both clean (expected, no code touched).

## Review findings disposition
Per `/review`: 0 blocking, 2 non-blocking `[documentation]` findings, both fixed in `8fedeb5`:
- `CLAUDE.md:1093` opening sentence extended to "issues and PRs" for consistency with the updated Workflow paragraph.
- `CLAUDE.md:1135` item-lookup snippet reworded to "issue or PR number" for consistency with the Move-status block, which already applies to PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)