### PR TITLE
[fix] token-report.py: reconfigure stdout to UTF-8 on Windows

### DIFF
--- a/claude/scripts/token-report.py
+++ b/claude/scripts/token-report.py
@@ -16,9 +16,6 @@ import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
-if hasattr(sys.stdout, "reconfigure"):
-    sys.stdout.reconfigure(encoding="utf-8")
-
 TOKEN_LOG = Path.home() / ".claude" / "scratch" / "token-sessions.jsonl"
 CLAUDE_DIR = Path.home() / ".claude"
 
@@ -301,6 +298,12 @@ def render_summary(sessions: list[dict]) -> str:
 
 
 def main() -> None:
+    # Windows falls back to the console codepage on redirected (non-tty) stdout,
+    # silently mangling non-ASCII output (e.g. the ellipsis/em-dash below) instead
+    # of writing valid UTF-8.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
     parser = argparse.ArgumentParser(description="Claude Code token usage report")
     parser.add_argument("--date", help="Filter by YYYY-MM-DD (UTC session start)")
     parser.add_argument("--days", type=int, help="Last N calendar days")

--- a/claude/scripts/token-report.py
+++ b/claude/scripts/token-report.py
@@ -16,6 +16,9 @@ import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
 TOKEN_LOG = Path.home() / ".claude" / "scratch" / "token-sessions.jsonl"
 CLAUDE_DIR = Path.home() / ".claude"
 


### PR DESCRIPTION
## Summary

Fixes a Windows-only encoding bug in `claude/scripts/token-report.py`: when stdout is
redirected to a file, Python falls back to the Windows console's default codepage instead of
UTF-8, so the U+2026 ellipsis (`sid = ... + "…"`, line 237) and U+2014 em dash
(`branch = ... or "—"`, line 239) silently become the replacement character (`�`) in the
output file.

## Root cause

The script never called `sys.stdout.reconfigure(encoding='utf-8')`, so a non-console stdout
(any redirect) used the platform default codepage instead of UTF-8.

## Fix

Add a guarded `sys.stdout.reconfigure(encoding="utf-8")` at the top of `main()` (guarded with
`hasattr` for portability to any stdout that doesn't support reconfigure).

## Impact

This script backs `/journal-compose` Step 4 (Token Usage section), invoked across every
project. Every composed journal entry was affected until now — the mangled character had to be
manually stripped by whichever compose session happened to notice it.

## Testing

- **Item 1 (hook-script syntax check)** — ran the documented `ast.parse` command against all of
  `claude/scripts/*.py`, including the changed file: all parse cleanly.
- **Manual reproduction** (no dedicated automated test exists for this on-demand script):
  ```
  py -3 claude/scripts/token-report.py --days 14 > out.md && file out.md
  ```
  - Before (unfixed, live `~/.claude/scripts/token-report.py`): `Non-ISO extended-ASCII text, with CRLF, NEL line terminators`
  - After (this branch): `Unicode text, UTF-8 text, with CRLF line terminators`, with the ellipsis/em-dash characters rendering correctly in the markdown table.
  - Re-verified after moving the reconfigure call into `main()` (review finding fix): same clean `Unicode text, UTF-8 text, with CRLF line terminators` result.
- No automated test suite covers `token-report.py` specifically (no `test_token_report.py` in
  the dev-env Testing list) — the syntax check plus the manual before/after repro above is the
  full verification surface for this change. Tracked for follow-up: #670.

Tests: N/A — no automated suite for this script; syntax check passed, manual repro confirmed
fixed (see above).

## Checkpoints

- **ADR-warrant**: N/A — pure bugfix in an on-demand utility script's I/O encoding; no rule,
  hook, skill, or settings behavior changes.
- **Doc-reconciliation**: N/A — no add/remove/rename of a skill/hook/script/routine, no
  invocation syntax change (same CLI args, only the stdout encoding changes).
- **Suppression / test-integrity / lockfile policies**: N/A — no suppressions added, no tests
  skipped or modified, no `package.json` touched.

## Review findings disposition

Per [review](https://github.com/brownm09/dev-env/pull/658#issuecomment-4927965999)
(`blocking=0 non_blocking=2`):

- **[maintainability] Module-level side effect on import** — fixed in `24ae853`: moved the
  `reconfigure()` guard from module level into `main()`.
- **[maintainability] No tracking issue for future automated coverage** — filed
  [#670](https://github.com/brownm09/dev-env/issues/670).
- **[style] Missing rationale comment** — fixed in `24ae853`: added a one-line comment naming
  the Windows console-codepage fallback.

Closes #654
