### PR TITLE
[fix] Mask extract_pr_number_from_command's own URL fallback (dev-env#664)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,11 +218,13 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     PR #572 — mirroring `_effective_merge_repo`'s flag-first precedence in `pr-merge-reminder.py`), and
     also recognizes gh's `-R` shorthand for `--repo` (dev-env#616 — the shorthand previously fell through
     to `None` and silently resolved against cwd's own config instead of the command's actual target repo).
-    `extract_pr_number_from_command`'s own positional-number match now runs against a
+    `extract_pr_number_from_command`'s own positional-number match runs against a
     `mask_quoted_spans`-masked copy of `args` (dev-env#650, ADR-050 Amendment 19), so a `--subject`/`--body`
     value containing a bare decoy number ("resolves 42 items") can't be mistaken for the real merged PR
-    number when the command names no real positional number; its `_PR_URL_RE` fallback is a separate,
-    still-unmasked gap tracked in dev-env#664, deliberately out of dev-env#650's own bare-number scope.
+    number when the command names no real positional number; its `_PR_URL_RE` fallback runs against a
+    `mask_prose_flag_values`-masked copy of `args` instead (dev-env#664, ADR-050 Amendment 21), so a
+    `--subject`/`--body` value containing a URL-shaped decoy can't false-match either — mirroring
+    `extract_repo_from_command`'s own `_PR_URL_REPO_RE` fix immediately below (dev-env#634, Amendment 17).
     `main()` skips the whole operation when the parsed repo doesn't match cwd's config — cwd's
     project-board fields don't apply to a different repo regardless of which PR's body gets fetched —
     but that gate itself is not separately unit-tested, consistent with this file's pure-helper-only

--- a/claude/scripts/post-pr-merge-project.py
+++ b/claude/scripts/post-pr-merge-project.py
@@ -52,7 +52,6 @@ CONFIG_FILE = ".claude/hook-config.json"
 
 _MERGE_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+merge\b")
 _CLOSES_RE = re.compile(r"(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
-_PR_URL_RE = re.compile(r"https://github\.com/\S+/pull/(\d+)")
 # Used two ways: (1) extract_pr_number's scan of `gh pr merge` OUTPUT text,
 # which needs no masking (gh's own output, not attacker-shaped command
 # prose); and (2) extract_pr_number_from_command's own URL fallback, which
@@ -65,6 +64,7 @@ _PR_URL_RE = re.compile(r"https://github\.com/\S+/pull/(\d+)")
 # repo-name one. A BARE quoted PR-URL positional argument (test_cmd_url) is
 # never preceded by --subject/--body, so mask_prose_flag_values leaves it
 # untouched while blanket mask_quoted_spans would have blinded it too.
+_PR_URL_RE = re.compile(r"https://github\.com/\S+/pull/(\d+)")
 # Same PR-URL shape as _PR_URL_RE but capturing the owner/repo segment instead
 # of discarding it — used to detect when a merge command names a DIFFERENT
 # repo than cwd's own config (dev-env#559). extract_repo_from_command runs

--- a/claude/scripts/post-pr-merge-project.py
+++ b/claude/scripts/post-pr-merge-project.py
@@ -53,6 +53,18 @@ CONFIG_FILE = ".claude/hook-config.json"
 _MERGE_RE = re.compile(r"(?:cd\s+\S+\s+&&\s+)?gh\s+pr\s+merge\b")
 _CLOSES_RE = re.compile(r"(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
 _PR_URL_RE = re.compile(r"https://github\.com/\S+/pull/(\d+)")
+# Used two ways: (1) extract_pr_number's scan of `gh pr merge` OUTPUT text,
+# which needs no masking (gh's own output, not attacker-shaped command
+# prose); and (2) extract_pr_number_from_command's own URL fallback, which
+# runs this against a mask_prose_flag_values-masked copy of `args`
+# (dev-env#664, ADR-050 Amendment 21), so a --subject/--body value
+# containing a URL-shaped decoy (e.g. "see https://github.com/other/repo
+# /pull/99 for context") can't false-match either — mirrors
+# _PR_URL_REPO_RE's own mask_prose_flag_values fix below (dev-env#634,
+# Amendment 17), just for the PR-NUMBER extraction path instead of the
+# repo-name one. A BARE quoted PR-URL positional argument (test_cmd_url) is
+# never preceded by --subject/--body, so mask_prose_flag_values leaves it
+# untouched while blanket mask_quoted_spans would have blinded it too.
 # Same PR-URL shape as _PR_URL_RE but capturing the owner/repo segment instead
 # of discarding it — used to detect when a merge command names a DIFFERENT
 # repo than cwd's own config (dev-env#559). extract_repo_from_command runs
@@ -167,10 +179,18 @@ def extract_pr_number_from_command(command: str) -> int | None:
     These two fixes are complementary, not overlapping: Amendment 20 ensures
     `args` itself is not prematurely truncated before this search ever runs;
     Amendment 19 ensures the search WITHIN `args` isn't hijacked by a decoy.
-    The `_PR_URL_RE` fallback below is unaffected by the Amendment 19 masking
-    (it runs on the original, unmasked `args`) — a still-open, structurally
-    distinct gap for a URL-shaped decoy tracked separately, not part of
-    dev-env#650's scope.
+
+    The `_PR_URL_RE` fallback below runs against a `mask_prose_flag_values`-
+    masked copy of `args` instead (dev-env#664, ADR-050 Amendment 21), so a
+    `--subject`/`--body` value containing a URL-shaped decoy (e.g. "see
+    https://github.com/other/repo/pull/99 for context") can't false-match
+    either — mirrors `extract_repo_from_command`'s own `_PR_URL_REPO_RE` fix
+    (dev-env#634, Amendment 17), just for the PR-number extraction path
+    instead of the repo-name one. A bare quoted PR-URL positional argument
+    (`gh pr merge "https://github.com/o/r/pull/380"`, never preceded by
+    `--subject`/`--body`, see `test_cmd_url`) is a legitimate, already-
+    supported shape that `mask_prose_flag_values` leaves untouched, unlike
+    blanket `mask_quoted_spans`.
     """
     args = _merge_args(command)
     if args is None:
@@ -181,7 +201,7 @@ def extract_pr_number_from_command(command: str) -> int | None:
     num = re.search(r"(?<!\S)(\d+)(?=\s|$)", mask_quoted_spans(args))
     if num:
         return int(num.group(1))
-    url = _PR_URL_RE.search(args)
+    url = _PR_URL_RE.search(mask_prose_flag_values(args))
     if url:
         return int(url.group(1))
     return None

--- a/claude/scripts/tests/test_post_pr_merge_project.py
+++ b/claude/scripts/tests/test_post_pr_merge_project.py
@@ -52,6 +52,15 @@ operation when that parsed repo does not match cwd's config, since
 (`project_number`/`project_node_id`/etc.), which do not apply to a different
 repo regardless of which PR's body was fetched.
 
+dev-env#664: `extract_pr_number_from_command`'s own `_PR_URL_RE` fallback (checked
+when no positional number matches) ran on the raw, unmasked args even after
+dev-env#650/ADR-050 Amendment 19 masked the positional-number search above it — a
+`--subject`/`--body` value containing a URL-shaped decoy (e.g. "see
+https://github.com/other/repo/pull/99 for context") could hijack the extracted PR
+number when the command named no real PR. Fixed by running the fallback against a
+`mask_prose_flag_values`-masked copy of `args` (ADR-050 Amendment 21), mirroring
+`extract_repo_from_command`'s own `_PR_URL_REPO_RE` fix (dev-env#634, Amendment 17).
+
 These tests exercise the pure helpers offline (no network, no gh). The live gh
 calls (`get_pr_body`, `find_project_item`, `move_to_done`, `confirm_merge_via_gh`)
 are intentionally not tested.
@@ -152,6 +161,39 @@ def test_cmd_real_number_survives_alongside_bare_number_decoy() -> str:
     cmd = 'gh pr merge 380 --subject "resolves 42 items" --squash'
     assert extract_pr_number_from_command(cmd) == 380
     return "real positional number resolves correctly alongside a quoted bare-number decoy (dev-env#650)"
+
+
+def test_cmd_url_decoy_in_subject_not_hijacked() -> str:
+    # dev-env#664, ADR-050 Amendment 21: the _PR_URL_RE fallback (checked when
+    # no positional number matches) previously ran on the raw, unmasked args --
+    # a --subject/--body value containing a URL-shaped decoy ("see
+    # https://github.com/other/repo/pull/99 for context") must not be mistaken
+    # for the real merged PR number when no real number or URL is present. This
+    # is the fallback's own analog of dev-env#650's bare-number-decoy fix above,
+    # for a URL shape instead of a bare digit.
+    cmd = 'gh pr merge --squash --subject "see https://github.com/other/repo/pull/99 for context"'
+    assert extract_pr_number_from_command(cmd) is None
+    return "URL-shaped decoy inside quoted --subject -> None, not falsely matched (dev-env#664)"
+
+
+def test_cmd_real_number_survives_alongside_url_decoy() -> str:
+    cmd = 'gh pr merge 380 --squash --subject "see https://github.com/other/repo/pull/99 for context"'
+    assert extract_pr_number_from_command(cmd) == 380
+    return "real positional number resolves correctly alongside a quoted URL-shaped decoy (dev-env#664)"
+
+
+def test_cmd_real_url_survives_alongside_url_decoy() -> str:
+    # No positional number here, so this is the only case that actually drives
+    # execution into the _PR_URL_RE fallback branch itself (the two tests above
+    # both short-circuit on the earlier positional-number match) -- proving the
+    # fix's mask_prose_flag_values doesn't blind the legitimate bare-URL case
+    # even when a decoy is also present elsewhere in the same command.
+    cmd = (
+        'gh pr merge https://github.com/brownm09/dev-env/pull/380 --subject '
+        '"see https://github.com/other/repo/pull/99 for context" --squash'
+    )
+    assert extract_pr_number_from_command(cmd) == 380
+    return "real bare PR URL resolves correctly alongside a quoted URL-shaped decoy (dev-env#664)"
 
 
 # --- extract_repo_from_command (dev-env#559) ------------------------------
@@ -442,6 +484,9 @@ def main() -> int:
         ("command: branch name -> None", test_cmd_branch_name_no_number),
         ("command: bare number decoy inside quoted --subject not hijacked (dev-env#650)", test_cmd_bare_number_decoy_in_subject_not_hijacked),
         ("command: real number survives alongside bare-number decoy (dev-env#650)", test_cmd_real_number_survives_alongside_bare_number_decoy),
+        ("command: URL-shaped decoy inside quoted --subject not hijacked (dev-env#664)", test_cmd_url_decoy_in_subject_not_hijacked),
+        ("command: real number survives alongside URL-shaped decoy (dev-env#664)", test_cmd_real_number_survives_alongside_url_decoy),
+        ("command: real bare URL survives alongside URL-shaped decoy (dev-env#664)", test_cmd_real_url_survives_alongside_url_decoy),
         ("repo: cross-repo URL parsed (dev-env#559)", test_repo_from_cross_repo_url),
         ("repo: bare number -> None", test_repo_from_bare_number_is_none),
         ("repo: bare form -> None", test_repo_from_bare_form_is_none),

--- a/docs/adr/050-shared-hookio-sibling-hook-fixes.md
+++ b/docs/adr/050-shared-hookio-sibling-hook-fixes.md
@@ -1717,9 +1717,9 @@ independently before this fix):
 99   # should be None -- no real PR number in this command at all
 ```
 
-This is `_PR_URL_RE` (declared at this file's line 55, used both by `extract_pr_number`'s output scan and by this
-fallback), a **different regex object** from `_PR_URL_REPO_RE` (line 67, used inside `extract_repo_from_command`)
-— the latter was already fixed by Amendment 17's `mask_prose_flag_values`. `extract_pr_number_from_command`'s
+This is `_PR_URL_RE` (declared at this file's module scope, used both by `extract_pr_number`'s output scan and by
+this fallback), a **different regex object** from `_PR_URL_REPO_RE` (used inside `extract_repo_from_command`) —
+the latter was already fixed by Amendment 17's `mask_prose_flag_values`. `extract_pr_number_from_command`'s
 return value is the primary PR-number source `main()` uses to resolve the merged PR before fetching its body and
 moving the linked issue to Done — a false number from this decoy could fetch and act on the wrong PR's body,
 potentially moving an unrelated issue to Done on this repo's board.

--- a/docs/adr/050-shared-hookio-sibling-hook-fixes.md
+++ b/docs/adr/050-shared-hookio-sibling-hook-fixes.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-21
 **Status:** Accepted
-**Amended:** 2026-07-01, 2026-07-02, 2026-07-04, 2026-07-08, 2026-07-09 (twenty amendments — see Amendment sections below)
+**Amended:** 2026-07-01, 2026-07-02, 2026-07-04, 2026-07-08, 2026-07-09 (twenty-one amendments — see Amendment sections below)
 **Tags:** hooks, post-tool-use, tool_response, payload, github-project, automation, reliability, dry, usage-snapshot, pr-merge-reminder, gh-pr-view, api-fallback, message-dispatch, top-level-statement-scan, issue-create, false-positive, command-parsing, heredoc, regex, quote-tracking, canonical-mutate-guard, pre-tool-use, ast, regression-test, allowlist, gh-pr-merge-help, misattribution, live-confirmation-fallback, repo-flag-shorthand, quote-masking, gh-create-help, prose-flag-masking, pr-create, bare-number-masking, args-boundary, truncation
 
 ---
@@ -1702,3 +1702,71 @@ independently in the same function — fixing the first (Amendment 17, for sites
 URL searches) does not imply the second is also fixed, even though both defects are patched with the literal
 same primitive (`mask_quoted_spans`) applied at a different pipeline stage. A fix landing for one doesn't
 retroactively prove the other was ever audited.
+
+## Amendment 21 (2026-07-09) — masking the PR-number extraction's own URL fallback (dev-env#664)
+
+**The gap.** Amendment 19's own "Out of scope, not fixed here" section named this gap in advance: masking
+`extract_pr_number_from_command`'s positional-number search (dev-env#650) left its own `_PR_URL_RE` fallback —
+checked only when the positional-number match finds nothing — running on the raw, unmasked `args`. A
+`--subject`/`--body` value containing a URL-shaped decoy could hijack the extracted PR number when the command
+named no real positional number. Confirmed live (post dev-env#650/dev-env#660 fixes, reproduced again
+independently before this fix):
+
+```python
+>>> extract_pr_number_from_command('gh pr merge --squash --subject "see https://github.com/other/repo/pull/99 for context"')
+99   # should be None -- no real PR number in this command at all
+```
+
+This is `_PR_URL_RE` (declared at this file's line 55, used both by `extract_pr_number`'s output scan and by this
+fallback), a **different regex object** from `_PR_URL_REPO_RE` (line 67, used inside `extract_repo_from_command`)
+— the latter was already fixed by Amendment 17's `mask_prose_flag_values`. `extract_pr_number_from_command`'s
+return value is the primary PR-number source `main()` uses to resolve the merged PR before fetching its body and
+moving the linked issue to Done — a false number from this decoy could fetch and act on the wrong PR's body,
+potentially moving an unrelated issue to Done on this repo's board.
+
+**Fix.** One line: `url = _PR_URL_RE.search(args)` → `url = _PR_URL_RE.search(mask_prose_flag_values(args))` in
+`extract_pr_number_from_command`, mirroring `extract_repo_from_command`'s own `_PR_URL_REPO_RE` fix immediately
+below it in the same file (Amendment 17) — `mask_prose_flag_values`, not blanket `mask_quoted_spans`, is the
+correct helper for the identical reason Amendment 17 established: a bare quoted positional PR-URL argument
+(`gh pr merge "https://github.com/o/r/pull/380"`, never preceded by `--subject`/`--body`, `test_cmd_url`) is a
+legitimate, already-tested shape that `mask_prose_flag_values` leaves untouched, unlike blanket `mask_quoted_spans`,
+which would blind it too. `mask_prose_flag_values` was already imported in this file (Amendment 17's own
+`extract_repo_from_command` fix) — no new import needed. Both the `_PR_URL_RE` module-scope comment and
+`extract_pr_number_from_command`'s own docstring are updated to document the new masking scope, matching this
+file's established per-regex documentation convention.
+
+**Coverage.** `test_post_pr_merge_project.py` gains 3 new `test_cmd_*`-pattern cases — 43 total, up from 40: the
+exact dev-env#664 repro (decoy alone -> `None`), a real positional number surviving alongside the same decoy (the
+existing masked positional-number search already handled this case, unaffected by this fix), and — the case that
+actually exercises the fixed `_PR_URL_RE` fallback branch itself, since the previous two both short-circuit on the
+earlier positional-number match — a real *bare URL* (no positional number at all) surviving alongside the same
+quoted decoy. Each new "decoy alone" assertion was verified against the pre-fix code first (reproducing `99`
+instead of `None`) before landing, per this ADR's established regression-test discipline (Amendments 15, 17, 19).
+All previously-passing suites were re-run in full and pass unchanged: `test_hookio.py` (86, `mask_prose_flag_values`'s
+own source is untouched by this amendment), the repo-wide AST-based crude-substring-check gate (13), and — as an
+extra sanity check, since neither file was touched — `test_posttooluse_inert_advisory.py` (32) and
+`test_stop_tile_enumeration_gate.py` (112).
+
+**Out of scope, filed as a follow-up.** Auditing the wider hook family for the same shape surfaced a separate,
+previously undiscovered-as-its-own-issue gap: `stop-tile-enumeration-gate.py` has its own independent `_PR_URL_RE`
+and `_ISSUE_URL_RE` regex objects, used unmasked in `_target_pr`, `_explicit_repo`, and `_closed_issue_number` —
+explicitly named and deliberately deferred twice already (Amendment 17's and this amendment's own predecessor,
+Amendment 19) without ever getting a dedicated tracking issue. Confirmed live to be a **more severe** variant than
+this amendment's own fix: because `_target_pr` and `_closed_issue_number` check their URL regex *before* their
+masked positional-number fallback (the reverse order from `extract_pr_number_from_command`), a decoy wins even
+when a real positional number is also present in the same command, not only when no real number exists at all.
+Filed as [dev-env#685](https://github.com/brownm09/dev-env/issues/685) rather than folded in here — a third,
+independent file with its own regex objects and its own test suite is a materially larger scope than this
+amendment's single-line fix, the same proportionality judgment Amendment 17 made when it deferred dev-env#650 and
+this very gap in the first place.
+
+**General lesson (continuing Amendments 9, 11, 15, 17, and 19's).** Amendment 19 predicted this exact fix down to
+the code shape, in its own "Out of scope, not fixed here" section, before any reproduction was attempted here —
+the same discipline that made Amendment 20's investigation fast applied again. What's new this time: the
+"Out of scope" audit this amendment's own fix triggered surfaced a gap that TWO prior amendments had each already
+individually noticed and deferred (Amendments 17 and 19), yet neither converted into a standalone tracking issue
+— a documented deferral in an ADR's prose is not the same as a filed issue a future session's search will actually
+find. `gh issue list --search` against this exact gap's shape returned nothing before this amendment filed
+dev-env#685, despite two separate amendments describing it in detail. The practical takeaway: "note it, file it"
+means an actual issue number, not just a prose paragraph in an ADR amendment that happens to be the third
+occurrence of the same accepted gap.


### PR DESCRIPTION
## Summary

`extract_pr_number_from_command`'s `_PR_URL_RE` fallback (checked when no positional number
matches) ran on raw, unmasked `args` even after dev-env#650/ADR-050 Amendment 19 masked the
positional-number search above it — a `--subject`/`--body` value containing a URL-shaped decoy
(e.g. `"see https://github.com/other/repo/pull/99 for context"`) could hijack the extracted PR
number when the command named no real PR.

**Fix:** `url = _PR_URL_RE.search(args)` → `url = _PR_URL_RE.search(mask_prose_flag_values(args))`,
mirroring `extract_repo_from_command`'s own `_PR_URL_REPO_RE` fix (dev-env#634, ADR-050 Amendment 17).
`mask_prose_flag_values` (not blanket `mask_quoted_spans`) is the correct helper: a bare quoted
positional PR-URL argument (`gh pr merge "https://github.com/o/r/pull/380"`, `test_cmd_url`) is a
legitimate, already-tested shape that `mask_prose_flag_values` leaves untouched.

Documented as [ADR-050 Amendment 21](docs/adr/050-shared-hookio-sibling-hook-fixes.md).

## Verified live

```python
>>> extract_pr_number_from_command('gh pr merge --squash --subject "see https://github.com/other/repo/pull/99 for context"')
99   # pre-fix: hijacked. post-fix: None
```

## Out of scope, filed as a follow-up

Auditing the wider hook family for the same shape surfaced `stop-tile-enumeration-gate.py`'s own
independent `_PR_URL_RE`/`_ISSUE_URL_RE` regex objects (unmasked in `_target_pr`, `_explicit_repo`,
`_closed_issue_number`) — explicitly named and deferred twice already (ADR-050 Amendments 17 and 19)
without ever getting a dedicated tracking issue. Confirmed live to be a **more severe** variant
(the decoy wins even alongside a real positional number, since the URL check runs first there).
Filed as #685 — a separate file with its own regex objects and test suite is a materially larger
scope than this PR's single-line fix.

## Testing

Ran from the repo root:

```bash
py -3 -c "import ast,sys; [ast.parse(open(f,encoding='utf-8').read(),f) for f in sys.argv[1:]]" claude/scripts/*.py
py -3 claude/scripts/tests/test_post_pr_merge_project.py
py -3 claude/scripts/tests/test_hookio.py
py -3 claude/scripts/tests/test_no_crude_command_substring_checks.py
py -3 claude/scripts/tests/test_posttooluse_inert_advisory.py
py -3 claude/scripts/tests/test_stop_tile_enumeration_gate.py
```

Tests: 43 passed, 0 skipped, 0 failed (`test_post_pr_merge_project.py` — 3 new `test_cmd_*` cases,
up from 40; each new "decoy alone" assertion verified against the pre-fix code first to confirm it's
a genuine regression test, not vacuously true). All other suites above pass unchanged (86 / 13 / 32 / 112).
Syntax check clean across all `claude/scripts/*.py`.

No suppressions or test-integrity violations introduced (pre-PR greps clean). This repo's Python
test suites use a bespoke runner, not pytest, so pytest-specific skip idioms (`@pytest.mark.skip`,
etc.) don't apply here regardless — manually confirmed none were introduced and no test blocks were
deleted (the diff only adds 3 new test functions).

## Review findings disposition

Self-reviewed via `/review` (see PR comment). 1 non-blocking [maintainability] finding (Step 2e's
language-scope note, since this diff touches `.py` files the JS/TS-oriented automated scanners can't
inspect) — resolved by the manual verification documented in the Testing section above; no code
change required.

Closes #664
