### PR TITLE
docs(claude-md): remove stale test-count tally from Testing item 48

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1032,8 +1032,7 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     suppresses a second fire. The pre-filter also reuses the real `_ISSUE_CREATE_STMT_RE` detection
     regex (`.search()`) rather than a hand-written substring, so it can't drift from what the detector
     actually matches (a literal single-space `"issue create"` check would miss a tab/multi-space
-    invocation — review of PR #639, confirmed independently by two reviewers). 76 tests total, up from
-    39 pre-ADR-092.
+    invocation — review of PR #639, confirmed independently by two reviewers).
 
     The tiles-spawned-without-a-table trigger (ADR-094 addendum, dev-env#656) adds a third fully
     independent pure-helper suite, mirroring the shape of the two above: `session_spawned_tiles`


### PR DESCRIPTION
## Summary
- Removes the stale "76 tests total, up from 39 pre-ADR-092" tally line from `CLAUDE.md`'s Testing item 48 (covering `test_stop_tile_enumeration_gate.py`)
- The count had already drifted stale once before this PR (dev-env#650 added ~12 tests without updating it), and the line wasn't even at the end of the item — a third trigger's worth of tests (the ADR-094 addendum, dev-env#656) was documented *after* it with no update either
- Verified the actual current count by running the test file directly: **112**, not 76
- Removed the tally rather than correcting it to 112, per the issue's own suggested alternative — a hand-maintained running total buried mid-paragraph in a heavily and frequently edited item has now proven unmaintainable twice over; the item's prose already describes each addition's scope in detail, so the count added no information not already present

## Testing
Ran the specific test file this documentation item describes, from the repo root:
```
py -3 claude/scripts/tests/test_stop_tile_enumeration_gate.py
```
Tests: 112 passed, 0 skipped, 0 failed (6.2s)

Docs-only change (no code/script modified). Suppression-policy and test-integrity greps were run against `git diff origin/main` and are both clean. `baseline_test_failure_tracking` is not enabled for this repo (no `.claude/hook-config.json` baseline flag) — N/A.

## Risk-dimension audit
1. **Testing** — N/A, docs-only; verified via the test run above.
2. **Observability** — N/A, no runtime behavior changed (dev-env has no application runtime; see project `## Observability`).
3. **Security** — N/A, no code touched.
4. **Resilience/failure modes** — N/A.
5. **Performance** — N/A.
6. **Data integrity/migrations** — N/A.

Closes #681