### PR TITLE
docs(reference): fix stale tiles-do-not-track paragraph per ADR-094

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1045,10 +1045,14 @@ follow-ups, not speculative musings, so the tile surface stays signal-rich. (`sp
 names other good moments too — right after verification passes, right before summarizing completed
 work; ADR-046 formalizes the merge boundary specifically.)
 
-**Tiles capture; they do not track.** A tile is *ephemeral* — chip IDs are not persisted across app
-restarts, and a tile becomes real work only when the user clicks it. For a follow-up that must be
-durably tracked, still file a GitHub issue; the tile's spawned session is a natural place to do that.
-The tile and the issue are complementary, not redundant.
+**Every genuine tile also gets a tracking issue.** A tile is still *ephemeral* — chip IDs are not
+persisted across app restarts, and a tile becomes real work only when the user clicks it. Under
+[ADR-046](adr/046-post-merge-followup-tiles.md)'s original default, a GitHub issue was filed only for
+a follow-up that "must" be tracked; [ADR-094](adr/094-tile-tables-and-issue-per-tile.md) overrides
+that — every genuine tile now gets a tracking issue filed alongside it, in the same repo, referenced
+in the tile prompt, giving the ephemeral chip a durable, linkable, status-trackable anchor. The
+session also closes with an end-of-session table of the tiles spawned (the third checkpoint below);
+the tile, the issue, and the table are complementary, not redundant.
 
 **Fallback where `spawn_task` is unavailable.** The tool is not present in every session (e.g. some
 terminal CLI sessions). There, file a follow-up issue instead, so the capture still happens.


### PR DESCRIPTION
## Summary
- Fixes the "**Tiles capture; they do not track**" paragraph in `docs/REFERENCE.md` (Post-merge follow-up tiles section), which still described the pre-ADR-094 default (issue filed only for follow-ups that "must" be tracked).
- This directly contradicted the "**A third, independent checkpoint: tiles spawned without a table**" paragraph a few lines below it in the same file, which already correctly describes ADR-094's issue-per-tile override (added in #674).
- Rewrote the paragraph to state the current model — every genuine tile also gets a tracking issue filed alongside it, referenced in the tile prompt — citing ADR-094 alongside the existing ADR-046 citation, and forward-referencing the end-of-session table checkpoint instead of duplicating it.
- Checked the surrounding "Fallback where `spawn_task` is unavailable" and "Enforcement" paragraphs per the issue's request: both are already accurate under ADR-094 and needed no changes.

Closes #680

## Test plan
Docs-only change — no test command applies (per this repo's `## Testing` section). Verified by:
- [x] Confirmed via `git log`/`git show origin/main` that ADR-094 and the "third checkpoint" enforcement paragraph were already merged (PRs #663, #674), so this fix only needed to touch the one stale paragraph, not re-add already-present content.
- [x] Grepped the repo for other echoes of the stale "tiles don't track" claim (`claude/CLAUDE.md`, `docs/REFERENCE.md` hooks table) — all other occurrences already correctly describe the override, not the stale default.
- [x] Re-read the full updated section for internal consistency and accurate ADR citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)