### PR TITLE
fix(prune-routine): guard scheduled run against greet-instead-of-execute (#698)

### DIFF
--- a/claude/routines/prune-stale-worktrees/SKILL.md
+++ b/claude/routines/prune-stale-worktrees/SKILL.md
@@ -2,9 +2,12 @@
 name: prune-stale-worktrees
 description: Remove Claude session worktrees whose branches have been merged into main, across all repos under C:/Users/brown/Git.
 schedule: "0 8 * * *"
+model: claude-opus-4-8
 ---
 
 Prune stale Claude session worktrees across all git repos under `C:/Users/brown/Git`. Run fully autonomously — do not ask the user anything.
+
+> **Autonomous-run guard (do not strip when regenerating the live copy).** This is an unattended scheduled run with no human present. Do **not** open with a greeting, a question, or any "how can I help" / "what would you like to work on" reply — your **first output must be a tool call** (Step 0). The live scheduled-task copy carries this same imperative at the very top *and* bottom of its prompt, because the failure it guards against (see the Autonomous-run reliability caveat below) happens *before* Step 0.5's canonical read-through is ever reached.
 
 **Objective:** For every git repo directly under `C:/Users/brown/Git`, remove all worktrees (both `claude/*` and hand-named branches, e.g. `feat/`/`fix/`/`docs/` — via `--include-named`) whose branches are fully merged into `origin/main` and have no uncommitted changes. Also remove any non-primary worktrees accidentally checked out on `main`. Report the pruned/skipped summary per repo and a combined total.
 
@@ -47,3 +50,22 @@ Prune stale Claude session worktrees across all git repos under `C:/Users/brown/
 > present, falling back to an embedded copy only when it is missing or unreadable — so a future
 > edit here takes effect immediately without a separate re-registration step, though the embedded
 > fallback should still be refreshed when this file's *steps* change materially.
+
+---
+
+> **Autonomous-run reliability caveat (dev-env#698).** On 2026-07-10 the 04:03 run silently
+> no-opped: the model replied *"I'm ready to help. What would you like to work on?"* (0 tool calls)
+> despite receiving the full, well-formed prompt. Root cause was a **silent model switch** — the six
+> prior daily runs (07-04 → 07-09) all ran on `claude-opus-4-8` and executed correctly (9–13 tool
+> calls each); the 07-10 run came up on `claude-sonnet-5` and greeted instead. The scheduler
+> **ignores the project `settings.json` model** and uses the app's global default, which began
+> resolving to Sonnet 5 that day. Sonnet 5 is not deterministically broken (it ran a *different*
+> scheduled task fine the same day) — this is an **intermittent instruction-following lapse** on the
+> XML-wrapped autonomous prompt, and a greeting-instead-of-execute run produces **no error and no
+> notification**. Two mitigations, both applied: (1) an **execute-now / do-not-greet imperative** at
+> the very top and bottom of the *live* scheduled-task prompt — it must live there, not only here,
+> because the greeting happens before Step 0.5 reads this canonical file; and (2) a
+> `model: claude-opus-4-8` **frontmatter pin** (added to both copies). The MCP
+> `update_scheduled_task` / `create_scheduled_task` tools expose no model parameter, so the
+> frontmatter pin is the only per-task model lever available — confirm on the next run whether the
+> scheduler actually honors it; if not, the imperative alone is the model-agnostic backstop.


### PR DESCRIPTION
## Problem

Closes #698. The daily `prune-stale-worktrees` run on 2026-07-10 04:03 EDT silently no-opped — the model replied *"I'm ready to help. What would you like to work on?"* (18 tokens, **0 tool calls**) despite receiving the full, well-formed prompt.

Root cause (from the run transcripts): a **silent model switch**. The six prior daily runs (07-04 → 07-09) ran on `claude-opus-4-8` and executed correctly (9–13 tool calls each); the 07-10 run came up on `claude-sonnet-5` and greeted. The scheduler ignores the project `settings.json` model and uses the app's global default. Sonnet 5 isn't deterministically broken (it ran `reclaim-worktree-disk` fine the same day) — it's an intermittent instruction-following lapse on the XML-wrapped autonomous prompt, and the failed run produces no error/notification.

## Fix

- **Execute-now / do-not-greet imperative** at the top *and* bottom of the machine-local live scheduled-task prompt (`~/.claude/scheduled-tasks/prune-stale-worktrees/SKILL.md`, edited out-of-band — not version-controlled). It must live there because the greeting happens *before* Step 0.5 reads the canonical file.
- **`model: claude-opus-4-8` frontmatter pin** added to both the live and canonical copies (the MCP scheduler tools expose no model parameter, so frontmatter is the only per-task lever — pending next-run confirmation that the scheduler honors it).
- **Canonical routine** (this PR): mirrors the imperative as an "Autonomous-run guard" and documents the incident + the scheduler-ignores-settings.json-model finding in an expanded dual-copy caveat.

## Testing

No automated test covers routine SKILL.md **prompt text** (dev-env `## Testing` items are for `.py`/shell scripts; none changed here). Verified:
- `list_scheduled_tasks` still resolves `prune-stale-worktrees` with its schedule intact after the `model:` frontmatter was added (the key didn't break parsing).
- True confirmation is the next scheduled run (2026-07-11 04:03) — whether it comes up on Opus and executes with a tool call.

Tests: N/A (markdown-only routine-prompt change; no suppressions, skips, or lockfile changes).

## Notes

- **ADR-warrant:** considered — none needed; tactical reliability fix under the existing dual-copy convention (ADR-003 amendment). The model-selection finding is recorded in the caveat + issue.
- **Doc-reconciliation:** Routines table unchanged (prompt-text edit, not add/remove/rename).
- Secondary findings from the investigation (scheduled task runs in the canonical checkout not a worktree; `settings.json` references a not-yet-merged `idle-refresher.py`) are being filed separately.

## Review findings disposition

`/review` completed 2026-07-10 ([review comment](https://github.com/brownm09/dev-env/pull/700#issuecomment-4940179982)) — **0 blocking, 2 non-blocking, 1 question**. All addressed:

- **[non-blocking · documentation] Central home for the cross-cutting model-drift discovery** → **filed #703 (item 1).** The discovery stays version-controlled in this PR's caveat; #703 tracks surfacing it centrally (`docs/REFERENCE.md` / ADR-003 amendment) so it outlives #698, which closes with this PR.
- **[non-blocking · reliability] `model:` pin efficacy unverified + live imperative not restorable from version control** → **filed #703 (items 2–3).** Pin verification is time-gated to the 2026-07-11 04:03 run; imperative restorability is a version-control enhancement.
- **[question] Schedule drift — canonical/docs `0 8` (8am) vs live `0 4` (4am, confirmed via `list_scheduled_tasks`)** → **filed #704.** Not corrected here: the intended direction is a maintainer decision, and silently editing either side would enshrine a possible mistake or hide the contradiction. Pre-existing and orthogonal to the greet fix.

All three are genuine follow-up work (a cross-routine doc placement, a next-run observation, a pre-existing orthogonal drift), so file-and-link is the correct disposition per ADR-028 rather than expanding this tactical fix.
