### PR TITLE
docs: document bare --force after rebase auto-closes open PRs

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -148,6 +148,27 @@ gh api -X DELETE "repos/{owner}/{repo}/git/refs/heads/<branch>"   # pure REST re
 
 Confirmed as a **general git-worktree mechanic**, not a quirk of any one repo's worktree count: [dev-env#575](https://github.com/brownm09/dev-env/pull/575) (canonical correctly on `main`) and [lifting-logbook#664](https://github.com/brownm09/lifting-logbook/pull/664) (an idle worktree left squatting `main` by an earlier merge; that repo's CLAUDE.md "Standard Issue Workflow" step 8 carries its own copy of this same two-step pattern). Full detection, root cause, and non-destructive auto-correction (parking idle squatters instead of removing them): dev-env [ADR-058](../docs/adr/058-worktree-squatting-main-detection-correction.md); complete runbook: dev-env [`docs/REFERENCE.md` → Git Workflow Runbooks](../docs/REFERENCE.md#git-workflow-runbooks).
 
+### Bare `--force` after rebase auto-closes any open PR on the target branch
+
+**Pattern:** After `git rebase origin/main`, `--force-with-lease` rejects with `(stale info)` because the rebase rewrote local commits without refreshing the remote-tracking ref. Falling back to bare `git push origin HEAD:<branch> --force` (or `--force`) succeeds at the network level — but GitHub interprets it as a branch-delete + branch-recreate. **Any open PR targeting that branch is auto-closed** with `mergedAt: null`, `mergeCommit: null`, and `gh pr reopen` fails with "Could not open the pull request."
+
+**Symptom:** `! [rejected] HEAD -> <branch> (stale info)` from `--force-with-lease`, then a bare `--force` push succeeds, and the PR shows `state: CLOSED` with no merge commit.
+
+**Fix:** After any rebase, run `git fetch origin` *before* retrying `--force-with-lease` — never fall back to bare `--force`:
+```bash
+git rebase origin/main
+git fetch origin              # refreshes the stale remote-tracking ref
+git push --force-with-lease   # now succeeds without closing the PR
+```
+
+**Recovery (PR already auto-closed):** `gh pr reopen` fails with "Could not open the pull request." Create a replacement PR:
+```bash
+gh pr create --head <branch> --base main --title "..." \
+  --body "Replaces #N (auto-closed by bare --force after rebase; [context](https://github.com/.../pull/N))"
+```
+
+Motivating incident: [win11-init-tools PR #46](https://github.com/brownm09/win11-init-tools/pull/46) — PR #34 was auto-closed and replaced. Full runbook: [`docs/REFERENCE.md` → Git Workflow Runbooks](../docs/REFERENCE.md#git-workflow-runbooks).
+
 ---
 
 ## Dev-Env & Project Boards

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -876,6 +876,82 @@ Motivating incident: career-playbook [#587](https://github.com/brownm09/career-p
 (Step 4.7) / [#591](https://github.com/brownm09/career-playbook/pull/591) (Step 4.8, which superseded
 the orphaned #588).
 
+### Bare `--force` after rebase auto-closes any open PR on the target branch
+
+**Trigger.** A `git rebase origin/main` rewrites local commits but does **not** refresh the remote-tracking
+ref (`refs/remotes/origin/<branch>`). Running `git push --force-with-lease` immediately after rejects
+with `(stale info)` because the lease comparison — local tracking ref vs. what the remote actually
+holds — finds a mismatch (the rebase changed local SHAs; the tracking ref still shows pre-rebase SHAs).
+Falling back to bare `git push origin HEAD:<branch> --force` (or `git push --force`) succeeds at the
+wire level, but GitHub treats a force-push whose new tip does not descend from the old tip as a
+**branch-delete + branch-recreate**. Any open PR targeting that branch is **auto-closed** with
+`mergedAt: null` and `mergeCommit: null`.
+
+**Symptom.**
+
+```
+! [rejected]  HEAD -> <branch> (stale info)
+error: failed to push some refs
+```
+
+followed by a bare `--force` push that exits 0, and then:
+
+```bash
+gh pr view <N> --json state,mergedAt,mergeCommit
+# {"state":"CLOSED","mergedAt":null,"mergeCommit":null}
+gh pr reopen <N>
+# Could not open the pull request: <N>
+```
+
+**Diagnosis.** The `(stale info)` variant of a `--force-with-lease` rejection is distinct from a real
+concurrent push. A concurrent push leaves `(fetch first)` in the rejection message; `(stale info)` means
+the *local* tracking ref is out of date — the remote-tracking ref was never refreshed after the rebase.
+The safe test before resorting to bare `--force`:
+
+```bash
+git fetch origin                  # update the tracking ref
+git log origin/<branch>..HEAD     # should show only your rebased commits; empty = nothing to push
+git push --force-with-lease       # retry now — should succeed
+```
+
+**Fix (always use this sequence after a rebase).**
+
+```bash
+git rebase origin/main            # rewrites history; tracking ref becomes stale
+git fetch origin                  # refreshes the remote-tracking ref to match the actual remote
+git push --force-with-lease       # now the lease check passes; push succeeds; PR stays open
+```
+
+Never use bare `git push --force` / `git push origin HEAD:<branch> --force` as a fallback for a
+`--force-with-lease` stale-info rejection. The stale-info rejection is a solvable local state problem,
+not a signal to bypass the safety check.
+
+**Recovery — PR already auto-closed.**
+
+`gh pr reopen <N>` fails unconditionally when the PR was auto-closed by a branch-delete (GitHub does
+not allow reopening a PR whose base branch was deleted and recreated). Steps:
+
+1. Confirm the PR is truly auto-closed (not intentionally closed):
+   ```bash
+   gh pr view <N> --json state,closedAt,mergedAt,mergeCommit,timelineItems
+   # state=CLOSED, mergedAt=null, mergeCommit=null confirms the auto-close
+   ```
+2. The branch itself is fine — the commits are still intact on the pushed branch; only the PR object
+   is unrecoverable. Create a replacement PR:
+   ```bash
+   gh pr create --head <branch> --base main \
+     --title "<same title>" \
+     --body "<same body>\n\nReplaces #N (auto-closed by bare --force after rebase; see <original PR URL>)"
+   ```
+3. Reference the original PR number in the new body to preserve review history context. The old PR
+   number is permanently gone — do not try to reuse it.
+
+Motivating incident: win11-init-tools [PR #34](https://github.com/brownm09/win11-init-tools/pull/34)
+was auto-closed and replaced by [PR #46](https://github.com/brownm09/win11-init-tools/pull/46)
+(2026-07-11). Tracking issue: [dev-env#724](https://github.com/brownm09/dev-env/issues/724). Summary
+rule in [`claude/CLAUDE.md`](../claude/CLAUDE.md) → Git Workflow → "Bare `--force` after rebase
+auto-closes any open PR on the target branch".
+
 ### Separate clones for fully independent parallel work
 
 Worktrees share the `.git` ref database (branches, stash, FETCH_HEAD, packed-refs). When two sessions


### PR DESCRIPTION
## Summary

- Adds `### Bare \`--force\` after rebase auto-closes any open PR on the target branch` to `claude/CLAUDE.md` → Git Workflow section
- Adds a matching detailed runbook entry to `docs/REFERENCE.md` → Git Workflow Runbooks (between the stacked-PR section and "Separate clones")

## What this documents

**Failure mode (incident: win11-init-tools PR #34 → PR #46, 2026-07-11):**

After `git rebase origin/main`, `git push --force-with-lease` rejects with `(stale info)` because the rebase rewrote local commits without refreshing the remote-tracking ref. Falling back to bare `git push origin HEAD:<branch> --force` succeeds at the network level — but GitHub interprets it as a branch-delete + branch-recreate, **auto-closing any open PR** targeting that branch (`mergedAt: null`, `mergeCommit: null`, `gh pr reopen` fails).

**Root cause:** `--force-with-lease` is working correctly — the tracking ref is genuinely stale. The fix is `git fetch origin` after the rebase to refresh it, then `git push --force-with-lease` again.

## Testing

No automated test suite. Manual verification:
- Parse check: both files are Markdown; no parse tool applies.
- Content review: confirmed both the `## Git Workflow` H3 and the REFERENCE.md runbook landed at the correct positions, with accurate symptom/fix/recovery information matching the incident.

Tests: N/A — documentation-only change.

## ADR-warrant check

This change adds a new documented failure mode and recovery runbook — no new rule, skill, hook, or settings change. No ADR warranted.

## Suppression/test-integrity check

Documentation-only. No suppressions, no test changes.

Closes #724