### PR TITLE
fix(hooks): route PostToolUse advisories through _hookout (PR5 of #717)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,13 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
    success marker present, exit code non-zero) confirms despite the exit code, while a queued
    `--auto` (no marker yet) and a non-merge command do not — the exit-code-only gate this replaced
    silently dropped the snapshot on every worktree merge
-   ([dev-env#474](https://github.com/brownm09/dev-env/issues/474), ADR-049/ADR-050 amendment). The
+   ([dev-env#474](https://github.com/brownm09/dev-env/issues/474), ADR-049/ADR-050 amendment). Also
+   (PR5 of dev-env#717, [dev-env#736](https://github.com/brownm09/dev-env/issues/736)) pins
+   `status_emoji()` and `format_snapshot()` output as `.isascii()`: the emoji and `≤` were ASCII-ified
+   (OVER/NEAR/OK tokens, `<=`) and all four emissions moved onto `_hookout.emit_block` (exit-2 stderr,
+   `ascii_sanitize` backstop + exit-code-safe `finally`), so a cp1252 encode crash can no longer flip
+   exit 2→0 and silently drop the snapshot (the #670 pattern); `status_emoji`/`format_snapshot` were
+   previously unexercised. The
    live usage API call is not covered (the repo avoids urllib mocks).
 
    ```bash
@@ -126,8 +132,12 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     failed merge, an exit-0 non-merge invocation like `gh pr merge --help` (dev-env#485), or `gh pr merge`
     text mentioned only inside a heredoc body, a quoted argument, or a `$()` subshell (dev-env#529, the
     command-shape check is `scan_top_level`-anchored, not a raw substring test —
-    [ADR-050 Amendment 9](docs/adr/050-shared-hookio-sibling-hook-fixes.md)) does not. The detached reclaim
-    spawn is not covered (it shells out).
+    [ADR-050 Amendment 9](docs/adr/050-shared-hookio-sibling-hook-fixes.md)) does not. Also (PR5 of
+    dev-env#717, [dev-env#736](https://github.com/brownm09/dev-env/issues/736)) pins the `RECLAIM_MSG`
+    constant (content + `.isascii()`): the post-merge status now emits via
+    `_hookout.emit_advisory(audience="user")` (a systemMessage toast) rather than a raw exit-0 stderr
+    print (invisible on PostToolUse); the channel itself is enforced by the output-contract gate
+    (item 61). The detached reclaim spawn is not covered (it shells out).
 
     ```bash
     py -3 claude/scripts/tests/test_post_pr_merge_reclaim.py
@@ -272,8 +282,16 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     [ADR-058 amendment](docs/adr/058-worktree-squatting-main-detection-correction.md)); a feature branch
     (or squatting worktree) checked out gets the original fetch-into-ref, unchanged. Also exercises the
     pure-string resolution paths of `extract_repo()`'s `--repo`/`-R` flag check (`-R` shorthand added in
-    dev-env#616) and its GitHub-URL parse. The `pull_main` / `list_worktrees` git calls and `extract_repo`'s
-    git-remote subprocess fallback are not covered
+    dev-env#616) and its GitHub-URL parse. Also (PR5 of dev-env#717,
+    [dev-env#736](https://github.com/brownm09/dev-env/issues/736)) exercises the pure message builders
+    `format_pull_message()` (success / already-up-to-date / git-fail / timeout / exception) and
+    `format_park_message()` (parked / checkout-raised / branch-already-exists), plus the `plan_advisory()`
+    channel decision — a park message means the model's own cwd branch changed underneath it, so it routes
+    to `_hookout.emit_block` (exit-2 stderr, model-visible), while routine pull status alone routes to
+    `_hookout.emit_advisory(audience="user")` (a systemMessage toast), and nothing-to-say returns `None`;
+    `pull_main`/`park_worktree_off_main` now return their message and `main()` dispatches once. The
+    `pull_main` / `park_worktree_off_main` / `list_worktrees` git calls and `extract_repo`'s git-remote
+    subprocess fallback are not covered
     ([ADR-050](docs/adr/050-shared-hookio-sibling-hook-fixes.md), incl. Amendment 9 for the command-shape
     anchoring).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,11 +104,14 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
    silently dropped the snapshot on every worktree merge
    ([dev-env#474](https://github.com/brownm09/dev-env/issues/474), ADR-049/ADR-050 amendment). Also
    (PR5 of dev-env#717, [dev-env#736](https://github.com/brownm09/dev-env/issues/736)) pins
-   `status_emoji()` and `format_snapshot()` output as `.isascii()`: the emoji and `≤` were ASCII-ified
-   (OVER/NEAR/OK tokens, `<=`) and all four emissions moved onto `_hookout.emit_block` (exit-2 stderr,
-   `ascii_sanitize` backstop + exit-code-safe `finally`), so a cp1252 encode crash can no longer flip
-   exit 2→0 and silently drop the snapshot (the #670 pattern); `status_emoji`/`format_snapshot` were
-   previously unexercised. The
+   `status_label()` (renamed from `status_emoji`) and the `format_snapshot()` static template as
+   `.isascii()`, plus — the real end-to-end guarantee — that
+   `ascii_sanitize(format_snapshot(<non-ASCII action>))` is `.isascii()` (the action column
+   interpolates arbitrary Unicode, so wire-safety lives in `emit_block`, not `format_snapshot`): the
+   emoji and `≤` were ASCII-ified (OVER/NEAR/OK tokens, `<=`) and all four emissions moved onto
+   `_hookout.emit_block` (exit-2 stderr, `ascii_sanitize` backstop + exit-code-safe `finally`), so a
+   cp1252 encode crash can no longer flip exit 2→0 and silently drop the snapshot (the #670 pattern);
+   `status_label`/`format_snapshot` were previously unexercised. The
    live usage API call is not covered (the repo avoids urllib mocks).
 
    ```bash

--- a/claude/scripts/post-pr-merge-pull.py
+++ b/claude/scripts/post-pr-merge-pull.py
@@ -288,19 +288,20 @@ def is_successful_merge(command: str, output: str) -> bool:
     return output_has_merge_marker(output)
 
 
-def plan_advisory(status_msg: str | None, park_msg: str | None) -> tuple[str, str] | None:
-    """Pure: which _hookout channel + combined text this merge's messages need.
+def plan_advisory(status_msg: str | None, park_msg: str | None) -> tuple[bool, str] | None:
+    """Pure: whether this merge's advisory must reach the model, and its combined text.
 
     A park message means this worktree's branch changed underneath the model, so the
-    model must see it (channel "block" -> exit-2 stderr via emit_block); routine pull
-    status alone is a user systemMessage (channel "user"). Returns (channel, text), or
-    None when there is nothing to say.
+    model must see it (needs_block True -> exit-2 stderr via emit_block); routine pull
+    status alone is a user systemMessage (needs_block False). Returns (needs_block, text),
+    or None when there is nothing to say. Returning a bool (not a channel string) keeps
+    the untested main() consumer un-typo-able: a mistaken channel string would silently
+    downgrade a park warning to a toast — the exact invisibility this migration removes.
     """
     lines = [m for m in (status_msg, park_msg) if m]
     if not lines:
         return None
-    channel = "block" if park_msg else "user"
-    return (channel, "\n".join(lines))
+    return (bool(park_msg), "\n".join(lines))
 
 
 def main() -> None:
@@ -350,6 +351,7 @@ def main() -> None:
         sys.exit(0)
 
     if not os.path.isdir(local_path):
+        # emit_advisory is NoReturn (exits 0 here) — nothing below this branch runs.
         _hookout.emit_advisory(
             "PostToolUse",
             f"[post-merge-pull] {repo}: local path not found ({local_path}) — skipping",
@@ -363,8 +365,8 @@ def main() -> None:
     planned = plan_advisory(status_msg, park_msg)
     if planned is None:
         sys.exit(0)
-    channel, text = planned
-    if channel == "block":
+    needs_block, text = planned
+    if needs_block:
         # The model's own cwd branch just changed underneath it — it must see this.
         _hookout.emit_block(text)
     _hookout.emit_advisory("PostToolUse", text, audience="user")

--- a/claude/scripts/post-pr-merge-pull.py
+++ b/claude/scripts/post-pr-merge-pull.py
@@ -19,7 +19,11 @@ Stdin JSON shape (PostToolUse):
     "cwd": "..."
   }
 
-Exit 0 always — informational output only; never blocks Claude.
+Output channels (via _hookout, PR5 of dev-env#717): routine pull status is a user
+systemMessage (exit 0); a "parked this worktree off main" warning goes to the model
+via exit-2 stderr — the model's own cwd branch just changed underneath it and it must
+know. Exit-2 on PostToolUse only feeds stderr to the model as feedback; it never
+blocks Claude's work.
 """
 import _winsubp  # noqa: F401  -- suppress console windows on Windows
 import json
@@ -28,6 +32,7 @@ import re
 import subprocess
 import sys
 
+import _hookout
 from _hookio import (
     confirm_merge_via_gh,
     effective_merge_dir,
@@ -155,38 +160,75 @@ def pull_command(local_path: str, on_main: bool) -> list[str]:
     return ["git", "-C", local_path, "fetch", "origin", "main:main"]
 
 
-def pull_main(local_path: str, repo: str, on_main: bool) -> None:
-    """Fast-forward local main from origin (see pull_command for command choice)."""
+def format_pull_message(
+    repo: str,
+    kind: str,
+    *,
+    returncode: int | None = None,
+    stdout: str = "",
+    stderr: str = "",
+    timed_out: bool = False,
+    error: str | None = None,
+) -> str:
+    """Pure: the status line for a local-main fast-forward outcome.
+
+    Split out from pull_main so the user-facing message text is testable without a
+    live git call — mirrors dev-env-sync.py's formatter extraction (CLAUDE.md
+    Testing item 56).
+    """
+    if timed_out:
+        return f"[post-merge-pull] {repo}: git {kind} timed out"
+    if error is not None:
+        return f"[post-merge-pull] {repo}: unexpected error — {error}"
+    if returncode == 0:
+        parts = [p for p in (stdout.strip(), stderr.strip()) if p]
+        detail = "\n".join(parts) or "already up to date"
+        return f"[post-merge-pull] {repo}: local main updated — {detail}"
+    err = (stderr or stdout).strip()
+    return f"[post-merge-pull] {repo}: git {kind} failed — {err}"
+
+
+def pull_main(local_path: str, repo: str, on_main: bool) -> str:
+    """Fast-forward local main from origin; return the status line (see pull_command)."""
     cmd = pull_command(local_path, on_main)
     kind = "pull" if on_main else "fetch"
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-        if result.returncode == 0:
-            parts = [p for p in (result.stdout.strip(), result.stderr.strip()) if p]
-            detail = "\n".join(parts) or "already up to date"
-            print(
-                f"[post-merge-pull] {repo}: local main updated — {detail}",
-                file=sys.stderr,
-            )
-        else:
-            err = (result.stderr or result.stdout).strip()
-            print(
-                f"[post-merge-pull] {repo}: git {kind} failed — {err}",
-                file=sys.stderr,
-            )
+        return format_pull_message(
+            repo, kind,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
     except subprocess.TimeoutExpired:
-        print(
-            f"[post-merge-pull] {repo}: git {kind} timed out",
-            file=sys.stderr,
-        )
+        return format_pull_message(repo, kind, timed_out=True)
     except Exception as exc:
-        print(
-            f"[post-merge-pull] {repo}: unexpected error — {exc}",
-            file=sys.stderr,
+        return format_pull_message(repo, kind, error=str(exc))
+
+
+def format_park_message(park: str, *, ok: bool = False, exc: str | None = None, detail: str = "") -> str:
+    """Pure: the message when this worktree was (or couldn't be) parked off main.
+
+    `ok` — parked successfully; `exc` — the checkout itself raised; otherwise the
+    checkout exited non-zero (the branch likely already exists), with git's stderr in
+    `detail`. Split out so the model-visible warning text is testable without a live
+    checkout (mirrors format_pull_message / CLAUDE.md Testing item 56).
+    """
+    if ok:
+        return (
+            f"[post-merge-pull] parked this worktree off main onto {park} — freed the main ref. "
+            "The canonical ~/Git/dev-env is off main; dev-env-sync returns it on the next prompt "
+            "if clean (else switch it back manually to refresh ~/.claude/)."
         )
+    if exc is not None:
+        return f"[post-merge-pull] could not park worktree off main — {exc}"
+    return (
+        f"[post-merge-pull] could not park worktree off main (branch {park} may already exist) "
+        f"— {detail}"
+    )
 
 
-def park_worktree_off_main(cwd: str, worktrees: list[dict]) -> None:
+def park_worktree_off_main(cwd: str, worktrees: list[dict]) -> str | None:
     """If `gh pr merge --delete-branch` left this worktree squatting main, park it off.
 
     gh deletes the merged local branch and checks out the default branch; from a worktree
@@ -201,33 +243,25 @@ def park_worktree_off_main(cwd: str, worktrees: list[dict]) -> None:
     on-main detection via `list_worktrees` — one `git worktree list` call per merge event),
     so it parks only when `cwd` is genuinely a worktree of that repo on main — a `gh pr merge
     --repo X` run from an unrelated checkout never touches that other repo (correctness review).
+
+    Returns the message to surface (the caller routes it to the model via exit-2 stderr),
+    or None when no park was needed.
     """
     if not cwd:
-        return
+        return None
     park = merge_park_target(cwd, worktrees)
     if not park:
-        return
+        return None
     try:
         r = subprocess.run(
             ["git", "-C", cwd, "checkout", "-b", park],
             capture_output=True, text=True, timeout=15,
         )
     except Exception as exc:
-        print(f"[post-merge-pull] could not park worktree off main — {exc}", file=sys.stderr)
-        return
+        return format_park_message(park, exc=str(exc))
     if r.returncode == 0:
-        print(
-            f"[post-merge-pull] parked this worktree off main onto {park} — freed the main ref. "
-            "The canonical ~/Git/dev-env is off main; dev-env-sync returns it on the next prompt "
-            "if clean (else switch it back manually to refresh ~/.claude/).",
-            file=sys.stderr,
-        )
-    else:
-        print(
-            f"[post-merge-pull] could not park worktree off main (branch {park} may already exist) "
-            f"— {r.stderr.strip()}",
-            file=sys.stderr,
-        )
+        return format_park_message(park, ok=True)
+    return format_park_message(park, detail=r.stderr.strip())
 
 
 def is_successful_merge(command: str, output: str) -> bool:
@@ -252,6 +286,21 @@ def is_successful_merge(command: str, output: str) -> bool:
     if not scan_top_level(command, _check_merge_stmt):
         return False
     return output_has_merge_marker(output)
+
+
+def plan_advisory(status_msg: str | None, park_msg: str | None) -> tuple[str, str] | None:
+    """Pure: which _hookout channel + combined text this merge's messages need.
+
+    A park message means this worktree's branch changed underneath the model, so the
+    model must see it (channel "block" -> exit-2 stderr via emit_block); routine pull
+    status alone is a user systemMessage (channel "user"). Returns (channel, text), or
+    None when there is nothing to say.
+    """
+    lines = [m for m in (status_msg, park_msg) if m]
+    if not lines:
+        return None
+    channel = "block" if park_msg else "user"
+    return (channel, "\n".join(lines))
 
 
 def main() -> None:
@@ -301,16 +350,24 @@ def main() -> None:
         sys.exit(0)
 
     if not os.path.isdir(local_path):
-        print(
+        _hookout.emit_advisory(
+            "PostToolUse",
             f"[post-merge-pull] {repo}: local path not found ({local_path}) — skipping",
-            file=sys.stderr,
+            audience="user",
         )
-        sys.exit(0)
 
     worktrees = list_worktrees(local_path)
-    pull_main(local_path, repo, canonical_on_main(worktrees))
-    park_worktree_off_main(cwd, worktrees)
-    sys.exit(0)
+    status_msg = pull_main(local_path, repo, canonical_on_main(worktrees))
+    park_msg = park_worktree_off_main(cwd, worktrees)
+
+    planned = plan_advisory(status_msg, park_msg)
+    if planned is None:
+        sys.exit(0)
+    channel, text = planned
+    if channel == "block":
+        # The model's own cwd branch just changed underneath it — it must see this.
+        _hookout.emit_block(text)
+    _hookout.emit_advisory("PostToolUse", text, audience="user")
 
 
 if __name__ == "__main__":

--- a/claude/scripts/post-pr-merge-reclaim.py
+++ b/claude/scripts/post-pr-merge-reclaim.py
@@ -33,13 +33,16 @@ Stdin JSON shape (PostToolUse):
     "cwd": "..."
   }
 
-Exit 0 always — informational only; never blocks Claude.
+Exit 0 always — a background-housekeeping systemMessage toast at most (via _hookout,
+PR5 of dev-env#717); never blocks Claude.
 """
 import _winsubp  # noqa: F401  -- suppress console windows on Windows
 import json
 import re
 import subprocess
 import sys
+
+import _hookout
 from pathlib import Path
 
 from _hookio import (
@@ -50,6 +53,11 @@ from _hookio import (
     read_command_output,
     scan_top_level,
     should_confirm_via_gh,
+)
+
+RECLAIM_MSG = (
+    "[post-merge-reclaim] PR merged - reclaiming node_modules/.turbo from "
+    "now-idle worktrees in the background (regenerable on next use)."
 )
 
 SCAN_DIR = "C:/Users/brown/Git"
@@ -151,11 +159,7 @@ def main() -> None:
             sys.exit(0)
 
     if _spawn_reclaim(cwd):
-        print(
-            "[post-merge-reclaim] PR merged — reclaiming node_modules/.turbo from "
-            "now-idle worktrees in the background (regenerable on next use).",
-            file=sys.stderr,
-        )
+        _hookout.emit_advisory("PostToolUse", RECLAIM_MSG, audience="user")
 
     sys.exit(0)
 

--- a/claude/scripts/tests/test_hook_output_contract.py
+++ b/claude/scripts/tests/test_hook_output_contract.py
@@ -131,13 +131,11 @@ from _hookout import STDOUT_MODEL_VISIBLE_EVENTS  # noqa: E402  (the SSOT, ADR-1
 # a second offense can't hide behind an existing entry. Line numbers are deliberately
 # NOT recorded here (they rot); the gate prints live line numbers on failure.
 # Migration owner per ADR-103:
-#   PR5 -> post-pr-merge-pull, post-pr-merge-reclaim
 #   PR6 -> token-tracker, journal-stop-check (checks 2-3), posttooluse-inert-advisory
-#   (post-compact's exit-0 stderr status was swept onto _hookout in dev-env#727.)
+#   (PR5 swept post-pr-merge-pull + post-pr-merge-reclaim onto _hookout -- dev-env#736;
+#    post-compact's exit-0 stderr status was swept in dev-env#727.)
 _OUTPUT_CONTRACT_ALLOWLIST: dict[tuple[str, str], int] = {
     ("journal-stop-check.py", "B"): 1,        # checks 2-3 print()+exit0 (PR6)
-    ("post-pr-merge-pull.py", "A"): 8,        # stderr status/park warnings, all exit 0 (PR5)
-    ("post-pr-merge-reclaim.py", "A"): 1,     # stderr status, exit 0 (PR5)
     ("posttooluse-inert-advisory.py", "B"): 1,  # bare stdout on Stop, exit 0 (PR6)
     ("token-tracker.py", "A"): 1,             # stderr diagnostic, exit 0 (PR6)
     ("token-tracker.py", "B"): 2,             # stdout echoes on Stop, exit 0 (PR6)
@@ -146,18 +144,14 @@ _OUTPUT_CONTRACT_ALLOWLIST: dict[tuple[str, str], int] = {
 # {script: count} — scripts emitting a non-ASCII string literal DIRECTLY in a
 # raw-stream call (mostly em-dash U+2014 / ellipsis U+2026 -- cp1252-safe but not
 # .isascii(), the stronger _hookout guarantee), with the count of such emission
-# lines. PR5 clears usage-snapshot (its emoji reach stderr via a variable -- see the
-# indirection limitation in the module docstring -- so it is flagged here only via a
-# direct em-dash; PR5's own .isascii() pin covers the emoji). PR5 also clears
-# post-pr-merge-pull/reclaim; PR6 token-tracker; PR7 dev-env-sync. post-compact /
+# lines. PR5 cleared usage-snapshot (emoji + <= now ASCII, emissions on _hookout,
+# with an .isascii() pin on format_snapshot) and post-pr-merge-pull/reclaim
+# (dev-env#736); PR6 token-tracker; PR7 dev-env-sync. post-compact /
 # post-merge-tile-checkpoint / pre-merge-findings-gate were swept onto _hookout in
 # dev-env#727.
 _NONASCII_EMISSION_ALLOWLIST: dict[str, int] = {
     "dev-env-sync.py": 4,
-    "post-pr-merge-pull.py": 7,
-    "post-pr-merge-reclaim.py": 1,
     "token-tracker.py": 2,
-    "usage-snapshot.py": 1,
 }
 
 

--- a/claude/scripts/tests/test_hook_output_contract.py
+++ b/claude/scripts/tests/test_hook_output_contract.py
@@ -50,10 +50,13 @@ wire. This is the `.isascii()` guarantee `_hookout`'s `ascii_sanitize` /
 Detection limitations (documented, per gotcha #6):
   - The non-ASCII literal must appear directly in the emission call's args. A
     literal reaching the stream INDIRECTLY -- through a variable or a helper's
-    return value -- is not detected. usage-snapshot is the worked example: its
-    emoji come from `status_emoji()` and reach stderr via the built `snapshot`
-    string, so this lint flags it only via an incidental direct em-dash (L486);
-    the emoji flow is covered by PR5's per-hook `.isascii()` self-pin instead.
+    return value -- is not detected. usage-snapshot was the worked example
+    (pre-dev-env#736): its emoji came from `status_label()` (then `status_emoji`)
+    and reached stderr via the built `snapshot` string, so this lint flagged it
+    only via an incidental direct em-dash -- the emoji flow was covered by a
+    per-hook `.isascii()` self-pin instead. PR5 migrated it onto `_hookout`
+    (ASCII content + emit_block), so it is no longer allowlisted here, but the
+    indirection limitation it illustrated still holds for any future hook.
   - Check D reads only a LITERAL json.dumps payload dict. A payload built
     dynamically (a variable, a dict comprehension) classifies as "unknown" and is
     exempt -- the same indirection limitation as the non-ASCII lint. No wired hook

--- a/claude/scripts/tests/test_post_pr_merge_pull.py
+++ b/claude/scripts/tests/test_post_pr_merge_pull.py
@@ -41,8 +41,12 @@ composition test below pins that `is_successful_merge` (the predicate the
 guard sits behind) returns False for exactly the `--help` shape
 `is_merge_help_only` returns True for.
 
-The `pull_main` / `extract_repo` git calls are intentionally not tested (they
-shell out and the repo avoids subprocess mocks).
+The `pull_main` / `park_worktree_off_main` / `extract_repo` git calls are
+intentionally not tested (they shell out and the repo avoids subprocess mocks);
+their pure message builders (`format_pull_message` / `format_park_message`) and
+the `plan_advisory` channel decision — extracted in PR5 (dev-env#736) so the
+hook's advisories route through `_hookout` (park warning -> model via exit-2
+stderr, routine pull status -> user systemMessage) — are covered below.
 
 Usage:
     py -3 claude/scripts/tests/test_post_pr_merge_pull.py
@@ -69,6 +73,9 @@ _spec.loader.exec_module(ppmp)  # safe: main() is guarded by __main__
 is_successful_merge = ppmp.is_successful_merge
 extract_repo = ppmp.extract_repo
 pull_command = ppmp.pull_command
+format_pull_message = ppmp.format_pull_message
+format_park_message = ppmp.format_park_message
+plan_advisory = ppmp.plan_advisory
 
 # is_merge_help_only lives in _hookio (a sibling); SCRIPT.parent already on
 # sys.path via the insert above.
@@ -301,6 +308,93 @@ def test_unresolved_real_merge_is_not_help_only() -> str:
     return "unresolved real merge (no marker, non-help) -> is_merge_help_only False (fallback unaffected)"
 
 
+# ---------------------------------------------------------------------------
+# PR5 (dev-env#736): pure message builders + channel decision. The
+# subprocess-bound pull_main / park_worktree_off_main wrappers stay untested
+# (repo convention); their message text and the channel routing are pinned here.
+# ---------------------------------------------------------------------------
+
+def test_format_pull_message_success_with_detail() -> str:
+    msg = format_pull_message(
+        "brownm09/dev-env", "pull", returncode=0, stdout="Updating 1abc..2def", stderr="",
+    )
+    assert msg == "[post-merge-pull] brownm09/dev-env: local main updated — Updating 1abc..2def", msg
+    return "returncode 0 with detail -> 'local main updated — <detail>'"
+
+
+def test_format_pull_message_already_up_to_date() -> str:
+    msg = format_pull_message("brownm09/dev-env", "pull", returncode=0, stdout="", stderr="")
+    assert msg.endswith("local main updated — already up to date"), msg
+    return "returncode 0, no output -> 'already up to date'"
+
+
+def test_format_pull_message_git_failed() -> str:
+    msg = format_pull_message(
+        "brownm09/dev-env", "fetch", returncode=1, stdout="", stderr="fatal: refusing",
+    )
+    assert msg == "[post-merge-pull] brownm09/dev-env: git fetch failed — fatal: refusing", msg
+    return "returncode != 0 -> 'git <kind> failed — <err>'"
+
+
+def test_format_pull_message_timeout() -> str:
+    msg = format_pull_message("brownm09/dev-env", "pull", timed_out=True)
+    assert msg == "[post-merge-pull] brownm09/dev-env: git pull timed out", msg
+    return "timed_out -> 'git pull timed out'"
+
+
+def test_format_pull_message_exception() -> str:
+    msg = format_pull_message("brownm09/dev-env", "fetch", error="boom")
+    assert msg == "[post-merge-pull] brownm09/dev-env: unexpected error — boom", msg
+    return "error -> 'unexpected error — <exc>'"
+
+
+def test_format_park_message_success() -> str:
+    msg = format_park_message("claude/foo", ok=True)
+    assert "parked this worktree off main onto claude/foo" in msg, msg
+    assert "freed the main ref" in msg, msg
+    return "ok -> 'parked this worktree off main onto <branch> — freed the main ref ...'"
+
+
+def test_format_park_message_exception() -> str:
+    msg = format_park_message("claude/foo", exc="detached HEAD")
+    assert msg == "[post-merge-pull] could not park worktree off main — detached HEAD", msg
+    return "exc -> 'could not park worktree off main — <exc>'"
+
+
+def test_format_park_message_branch_exists() -> str:
+    msg = format_park_message("claude/foo", detail="fatal: branch 'claude/foo' already exists")
+    assert "could not park worktree off main (branch claude/foo may already exist)" in msg, msg
+    assert "already exists" in msg, msg
+    return "non-zero checkout -> 'could not park ... (branch <b> may already exist) — <detail>'"
+
+
+def test_plan_advisory_park_present_is_block() -> str:
+    # A park message means the model's own cwd branch changed underneath it, so it
+    # must be surfaced to the model (channel "block" -> exit-2 stderr), carrying the
+    # routine status too.
+    planned = plan_advisory("status line", "parked ...")
+    assert planned == ("block", "status line\nparked ..."), planned
+    return "status + park -> ('block', both lines) — model must see it"
+
+
+def test_plan_advisory_park_only_is_block() -> str:
+    planned = plan_advisory(None, "parked ...")
+    assert planned == ("block", "parked ..."), planned
+    return "park only -> ('block', park)"
+
+
+def test_plan_advisory_status_only_is_user() -> str:
+    planned = plan_advisory("status line", None)
+    assert planned == ("user", "status line"), planned
+    return "status only -> ('user', status) — systemMessage toast"
+
+
+def test_plan_advisory_nothing_is_none() -> str:
+    assert plan_advisory(None, None) is None
+    assert plan_advisory("", "") is None
+    return "no messages -> None (nothing to emit)"
+
+
 def main() -> int:
     tests = [
         ("merge marker present -> pulls", test_clean_merge_with_marker_pulls),
@@ -323,6 +417,18 @@ def main() -> int:
         ("pull_command: canonical off main -> fetch-into-ref", test_pull_command_off_main_uses_fetch_into_ref),
         ("gh pr merge --help: guard fires (dev-env#557)", test_help_command_not_successful_merge_and_is_help_only),
         ("unresolved real merge: guard does not suppress fallback", test_unresolved_real_merge_is_not_help_only),
+        ("format_pull_message: success with detail", test_format_pull_message_success_with_detail),
+        ("format_pull_message: already up to date", test_format_pull_message_already_up_to_date),
+        ("format_pull_message: git failed", test_format_pull_message_git_failed),
+        ("format_pull_message: timeout", test_format_pull_message_timeout),
+        ("format_pull_message: exception", test_format_pull_message_exception),
+        ("format_park_message: success", test_format_park_message_success),
+        ("format_park_message: checkout raised", test_format_park_message_exception),
+        ("format_park_message: branch already exists", test_format_park_message_branch_exists),
+        ("plan_advisory: status + park -> block", test_plan_advisory_park_present_is_block),
+        ("plan_advisory: park only -> block", test_plan_advisory_park_only_is_block),
+        ("plan_advisory: status only -> user", test_plan_advisory_status_only_is_user),
+        ("plan_advisory: nothing -> None", test_plan_advisory_nothing_is_none),
     ]
     failed = 0
     for name, fn in tests:

--- a/claude/scripts/tests/test_post_pr_merge_pull.py
+++ b/claude/scripts/tests/test_post_pr_merge_pull.py
@@ -368,25 +368,25 @@ def test_format_park_message_branch_exists() -> str:
     return "non-zero checkout -> 'could not park ... (branch <b> may already exist) — <detail>'"
 
 
-def test_plan_advisory_park_present_is_block() -> str:
+def test_plan_advisory_park_present_needs_block() -> str:
     # A park message means the model's own cwd branch changed underneath it, so it
-    # must be surfaced to the model (channel "block" -> exit-2 stderr), carrying the
+    # must be surfaced to the model (needs_block True -> exit-2 stderr), carrying the
     # routine status too.
     planned = plan_advisory("status line", "parked ...")
-    assert planned == ("block", "status line\nparked ..."), planned
-    return "status + park -> ('block', both lines) — model must see it"
+    assert planned == (True, "status line\nparked ..."), planned
+    return "status + park -> (True, both lines) — model must see it"
 
 
-def test_plan_advisory_park_only_is_block() -> str:
+def test_plan_advisory_park_only_needs_block() -> str:
     planned = plan_advisory(None, "parked ...")
-    assert planned == ("block", "parked ..."), planned
-    return "park only -> ('block', park)"
+    assert planned == (True, "parked ..."), planned
+    return "park only -> (True, park)"
 
 
-def test_plan_advisory_status_only_is_user() -> str:
+def test_plan_advisory_status_only_is_user_toast() -> str:
     planned = plan_advisory("status line", None)
-    assert planned == ("user", "status line"), planned
-    return "status only -> ('user', status) — systemMessage toast"
+    assert planned == (False, "status line"), planned
+    return "status only -> (False, status) — systemMessage toast"
 
 
 def test_plan_advisory_nothing_is_none() -> str:
@@ -425,9 +425,9 @@ def main() -> int:
         ("format_park_message: success", test_format_park_message_success),
         ("format_park_message: checkout raised", test_format_park_message_exception),
         ("format_park_message: branch already exists", test_format_park_message_branch_exists),
-        ("plan_advisory: status + park -> block", test_plan_advisory_park_present_is_block),
-        ("plan_advisory: park only -> block", test_plan_advisory_park_only_is_block),
-        ("plan_advisory: status only -> user", test_plan_advisory_status_only_is_user),
+        ("plan_advisory: status + park -> needs_block", test_plan_advisory_park_present_needs_block),
+        ("plan_advisory: park only -> needs_block", test_plan_advisory_park_only_needs_block),
+        ("plan_advisory: status only -> user toast", test_plan_advisory_status_only_is_user_toast),
         ("plan_advisory: nothing -> None", test_plan_advisory_nothing_is_none),
     ]
     failed = 0

--- a/claude/scripts/tests/test_post_pr_merge_reclaim.py
+++ b/claude/scripts/tests/test_post_pr_merge_reclaim.py
@@ -164,14 +164,17 @@ def test_unresolved_real_merge_is_not_help_only() -> str:
 
 def test_reclaim_msg_content_and_ascii() -> str:
     # PR5 (dev-env#736): the post-merge status moved off a raw stderr print onto
-    # _hookout.emit_advisory(audience="user"). The channel is enforced by the
-    # output-contract gate; here we pin the message text + that it is cp1252-safe
-    # (ASCII) so it can't vanish under the hook-output pipe.
+    # _hookout.emit_advisory(audience="user"). That systemMessage channel is
+    # json.dumps(ensure_ascii=True) -- wire-safe regardless of content -- so the
+    # .isascii() check here is a *consistency* guard with the raw-channel messages
+    # (it caught the original em-dash -> hyphen), NOT a safety requirement of this
+    # channel (that vanishing class is specific to raw stderr). The channel itself
+    # is enforced by the output-contract gate.
     assert RECLAIM_MSG.startswith("[post-merge-reclaim] PR merged"), RECLAIM_MSG
     assert "reclaiming node_modules/.turbo" in RECLAIM_MSG, RECLAIM_MSG
     assert "regenerable on next use" in RECLAIM_MSG, RECLAIM_MSG
-    assert RECLAIM_MSG.isascii(), "RECLAIM_MSG must be ASCII (cp1252-safe)"
-    return "RECLAIM_MSG content pinned + .isascii() (dev-env#736)"
+    assert RECLAIM_MSG.isascii(), "RECLAIM_MSG kept ASCII for consistency (systemMessage is JSON-escaped)"
+    return "RECLAIM_MSG content pinned + .isascii() consistency guard (dev-env#736)"
 
 
 def main() -> int:

--- a/claude/scripts/tests/test_post_pr_merge_reclaim.py
+++ b/claude/scripts/tests/test_post_pr_merge_reclaim.py
@@ -33,7 +33,10 @@ that `is_successful_merge` (the predicate the guard sits behind) returns
 False for exactly the `--help` shape `is_merge_help_only` returns True for.
 
 The detached spawn (`_spawn_reclaim`) is intentionally not tested — it shells out
-and the repo avoids subprocess mocks.
+and the repo avoids subprocess mocks. PR5 (dev-env#736) routed the post-merge
+status through `_hookout.emit_advisory(audience="user")` (a systemMessage toast);
+the channel itself is enforced by the output-contract gate, and the message
+constant `RECLAIM_MSG` is pinned below (content + cp1252-safety).
 
 Usage:
     py -3 claude/scripts/tests/test_post_pr_merge_reclaim.py
@@ -58,6 +61,7 @@ assert _spec and _spec.loader, f"cannot load module spec from {SCRIPT}"
 ppmr = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(ppmr)  # safe: main() is guarded by __main__
 is_successful_merge = ppmr.is_successful_merge
+RECLAIM_MSG = ppmr.RECLAIM_MSG
 
 # is_merge_help_only lives in _hookio (a sibling); SCRIPT.parent already on
 # sys.path via the insert above.
@@ -158,9 +162,22 @@ def test_unresolved_real_merge_is_not_help_only() -> str:
     return "unresolved real merge (no marker, non-help) -> is_merge_help_only False (fallback unaffected)"
 
 
+def test_reclaim_msg_content_and_ascii() -> str:
+    # PR5 (dev-env#736): the post-merge status moved off a raw stderr print onto
+    # _hookout.emit_advisory(audience="user"). The channel is enforced by the
+    # output-contract gate; here we pin the message text + that it is cp1252-safe
+    # (ASCII) so it can't vanish under the hook-output pipe.
+    assert RECLAIM_MSG.startswith("[post-merge-reclaim] PR merged"), RECLAIM_MSG
+    assert "reclaiming node_modules/.turbo" in RECLAIM_MSG, RECLAIM_MSG
+    assert "regenerable on next use" in RECLAIM_MSG, RECLAIM_MSG
+    assert RECLAIM_MSG.isascii(), "RECLAIM_MSG must be ASCII (cp1252-safe)"
+    return "RECLAIM_MSG content pinned + .isascii() (dev-env#736)"
+
+
 def main() -> int:
     tests = [
         ("merge marker present -> reclaims", test_clean_merge_with_marker_reclaims),
+        ("RECLAIM_MSG content + .isascii() (dev-env#736)", test_reclaim_msg_content_and_ascii),
         ("non-merge command ignored", test_non_merge_command_ignored),
         ("failed merge with no marker ignored", test_failed_merge_no_marker_ignored),
         ("gh pr merge --help (no marker) ignored (dev-env#485)", test_help_invocation_no_marker_ignored),

--- a/claude/scripts/tests/test_usage_snapshot.py
+++ b/claude/scripts/tests/test_usage_snapshot.py
@@ -35,10 +35,12 @@ False for exactly the `--help` shape `is_merge_help_only` returns True for.
 
 PR5 (dev-env#736) routed all four emissions through `_hookout.emit_block`
 (exit-2 stderr, `ascii_sanitize` backstop + exit-code-safe `finally`) and made the
-snapshot content ASCII (`status_emoji` returns OVER/NEAR/OK tokens; the target
-line uses `<=` not U+2264). The two tests below pin `status_emoji` and
-`format_snapshot(...)` output as `.isascii()` so the snapshot can't be silently
-lost to a cp1252 encode crash again (the #670 pattern); both were previously
+snapshot's static content ASCII (`status_label` returns OVER/NEAR/OK tokens; the
+target line uses `<=` not U+2264). The tests below pin `status_label` and the
+`format_snapshot` static template as `.isascii()`, and — the real end-to-end
+guarantee — that `ascii_sanitize(format_snapshot(<non-ASCII action>))` is
+`.isascii()`, since the action column interpolates arbitrary Unicode and wire-safety
+lives in `emit_block`, not `format_snapshot` (the #670 pattern). All were previously
 unexercised.
 
 The live network call (`fetch_usage`) is intentionally not tested — the repo
@@ -70,12 +72,15 @@ _spec.loader.exec_module(usage_snapshot)  # safe: main() is guarded by __main__
 classify_token = usage_snapshot.classify_token
 snapshot_action = usage_snapshot.snapshot_action
 merge_confirmed = usage_snapshot.merge_confirmed
-status_emoji = usage_snapshot.status_emoji
+status_label = usage_snapshot.status_label
 format_snapshot = usage_snapshot.format_snapshot
 
 # is_merge_help_only lives in _hookio (a sibling); SCRIPT.parent already on
 # sys.path via the insert above.
 from _hookio import is_merge_help_only  # noqa: E402
+# ascii_sanitize is emit_block's wire-safety backstop — the real guarantee that a
+# snapshot interpolating a non-ASCII exchange action can't crash the stderr write.
+from _hookout import ascii_sanitize  # noqa: E402
 
 NOW_MS = 1_700_000_000_000  # fixed synthetic "now"; real time never consulted
 HOUR_MS = 3_600_000
@@ -187,24 +192,26 @@ def test_unresolved_real_merge_is_not_help_only() -> str:
     return "unresolved real merge (no marker, non-help) -> is_merge_help_only False (fallback unaffected)"
 
 
-def test_status_emoji_bands_are_ascii() -> str:
-    # PR5 (dev-env#736): status_emoji returned emoji outside cp1252; on the raw
-    # stderr channel the print raised, flipping exit 2 -> 0 and silently dropping
-    # the whole snapshot. It now returns ASCII tokens.
-    over = status_emoji(120, 100, 5)
-    near = status_emoji(97, 100, 5)
-    under = status_emoji(50, 100, 5)
-    none = status_emoji(0, 0, 5)
+def test_status_label_bands_are_ascii() -> str:
+    # PR5 (dev-env#736): this returned emoji outside cp1252; on the raw stderr channel
+    # the print raised, flipping exit 2 -> 0 and silently dropping the whole snapshot.
+    # It now returns ASCII tokens.
+    over = status_label(120, 100, 5)
+    near = status_label(97, 100, 5)
+    under = status_label(50, 100, 5)
+    none = status_label(0, 0, 5)
     for s in (over, near, under, none):
         assert s.isascii(), f"non-ASCII status token: {s!r}"
     assert (over, near, under, none) == ("OVER cap", "NEAR cap", "OK under cap", ""), \
         (over, near, under, none)
-    return "status_emoji bands -> ASCII tokens (OVER/NEAR/OK), .isascii() (dev-env#736)"
+    return "status_label bands -> ASCII tokens (OVER/NEAR/OK), .isascii() (dev-env#736)"
 
 
-def test_format_snapshot_output_is_ascii() -> str:
-    # The assembled snapshot (previously carrying U+2264 and emoji) must be
-    # .isascii() so emit_block's stderr write can't crash under cp1252.
+def test_format_snapshot_static_template_is_ascii() -> str:
+    # Pins that the STATIC template carries no literal emoji / U+2264 (the PR5
+    # ASCII-ification of status_label + the target line). This does NOT prove the
+    # whole snapshot is ASCII — the action column interpolates arbitrary Unicode;
+    # end-to-end wire-safety is emit_block's ascii_sanitize backstop, pinned below.
     config = {"alert_approaching_margin": 5}
     over = format_snapshot(
         {
@@ -218,18 +225,36 @@ def test_format_snapshot_output_is_ascii() -> str:
     under = format_snapshot(
         {"seven_day": {"utilization": 10}, "five_hour": {"utilization": 5}}, config, [],
     )
-    assert over.isascii(), f"non-ASCII in snapshot: {over!r}"
-    assert under.isascii(), f"non-ASCII in snapshot: {under!r}"
+    assert over.isascii(), f"non-ASCII in snapshot template: {over!r}"
+    assert under.isascii(), f"non-ASCII in snapshot template: {under!r}"
     # the target line now uses ASCII "<=" instead of U+2264
     assert "<=" in under and "≤" not in under, under
-    return "format_snapshot output is .isascii() (emoji + U+2264 removed) (dev-env#736)"
+    return "format_snapshot static template is .isascii() (emoji + U+2264 removed) (dev-env#736)"
+
+
+def test_snapshot_wire_safe_even_with_non_ascii_action() -> str:
+    # The REAL crash guard (the #670 pattern): even when an exchange action carries
+    # arbitrary Unicode (describe_content() of the assistant's text, truncated), the
+    # bytes emit_block actually writes are ascii_sanitize'd, so the stderr write can't
+    # crash under cp1252. format_snapshot ALONE is not .isascii() here — the guarantee
+    # lives in emit_block, not format_snapshot.
+    config = {"alert_approaching_margin": 5}
+    snap = format_snapshot(
+        {"seven_day": {"utilization": 50}, "five_hour": {"utilization": 5}},
+        config,
+        [{"action": "fix the café 😀 bug", "input": 1000, "cache_write": 50, "output": 200, "total": 1250}],
+    )
+    assert not snap.isascii(), "fixture must carry non-ASCII so the backstop is what's under test"
+    assert ascii_sanitize(snap).isascii(), "emit_block's ascii_sanitize must guarantee wire-safe bytes"
+    return "non-ASCII action -> format_snapshot not ASCII, but ascii_sanitize(snapshot) is (emit_block backstop)"
 
 
 def main() -> int:
     tests = [
         ("no-expiry token proceeds silently", test_no_expiry_proceeds_silently),
-        ("status_emoji bands are ASCII (dev-env#736)", test_status_emoji_bands_are_ascii),
-        ("format_snapshot output is ASCII (dev-env#736)", test_format_snapshot_output_is_ascii),
+        ("status_label bands are ASCII (dev-env#736)", test_status_label_bands_are_ascii),
+        ("format_snapshot static template is ASCII (dev-env#736)", test_format_snapshot_static_template_is_ascii),
+        ("snapshot wire-safe via ascii_sanitize despite non-ASCII action (dev-env#736)", test_snapshot_wire_safe_even_with_non_ascii_action),
         ("valid token proceeds silently", test_valid_token_proceeds_silently),
         ("token expiring within 1h warns", test_expiring_within_hour_warns),
         ("expired token now yields advisory", test_expired_token_now_visible),

--- a/claude/scripts/tests/test_usage_snapshot.py
+++ b/claude/scripts/tests/test_usage_snapshot.py
@@ -33,6 +33,14 @@ itself is exhaustively tested in `test_hookio.py`; the composition test below
 pins that `merge_confirmed` (the predicate the guard sits behind) returns
 False for exactly the `--help` shape `is_merge_help_only` returns True for.
 
+PR5 (dev-env#736) routed all four emissions through `_hookout.emit_block`
+(exit-2 stderr, `ascii_sanitize` backstop + exit-code-safe `finally`) and made the
+snapshot content ASCII (`status_emoji` returns OVER/NEAR/OK tokens; the target
+line uses `<=` not U+2264). The two tests below pin `status_emoji` and
+`format_snapshot(...)` output as `.isascii()` so the snapshot can't be silently
+lost to a cp1252 encode crash again (the #670 pattern); both were previously
+unexercised.
+
 The live network call (`fetch_usage`) is intentionally not tested — the repo
 avoids urllib mocks, consistent with the other script tests.
 
@@ -62,6 +70,8 @@ _spec.loader.exec_module(usage_snapshot)  # safe: main() is guarded by __main__
 classify_token = usage_snapshot.classify_token
 snapshot_action = usage_snapshot.snapshot_action
 merge_confirmed = usage_snapshot.merge_confirmed
+status_emoji = usage_snapshot.status_emoji
+format_snapshot = usage_snapshot.format_snapshot
 
 # is_merge_help_only lives in _hookio (a sibling); SCRIPT.parent already on
 # sys.path via the insert above.
@@ -177,9 +187,49 @@ def test_unresolved_real_merge_is_not_help_only() -> str:
     return "unresolved real merge (no marker, non-help) -> is_merge_help_only False (fallback unaffected)"
 
 
+def test_status_emoji_bands_are_ascii() -> str:
+    # PR5 (dev-env#736): status_emoji returned emoji outside cp1252; on the raw
+    # stderr channel the print raised, flipping exit 2 -> 0 and silently dropping
+    # the whole snapshot. It now returns ASCII tokens.
+    over = status_emoji(120, 100, 5)
+    near = status_emoji(97, 100, 5)
+    under = status_emoji(50, 100, 5)
+    none = status_emoji(0, 0, 5)
+    for s in (over, near, under, none):
+        assert s.isascii(), f"non-ASCII status token: {s!r}"
+    assert (over, near, under, none) == ("OVER cap", "NEAR cap", "OK under cap", ""), \
+        (over, near, under, none)
+    return "status_emoji bands -> ASCII tokens (OVER/NEAR/OK), .isascii() (dev-env#736)"
+
+
+def test_format_snapshot_output_is_ascii() -> str:
+    # The assembled snapshot (previously carrying U+2264 and emoji) must be
+    # .isascii() so emit_block's stderr write can't crash under cp1252.
+    config = {"alert_approaching_margin": 5}
+    over = format_snapshot(
+        {
+            "seven_day": {"utilization": 99, "resets_at": "2026-07-14T00:00:00Z"},
+            "five_hour": {"utilization": 40},
+            "extra_usage": {"is_enabled": True, "used_credits": 1.5, "monthly_limit": 50, "utilization": 3.0},
+        },
+        config,
+        [{"action": "Bash", "input": 1000, "cache_write": 50, "output": 200, "total": 1250}],
+    )
+    under = format_snapshot(
+        {"seven_day": {"utilization": 10}, "five_hour": {"utilization": 5}}, config, [],
+    )
+    assert over.isascii(), f"non-ASCII in snapshot: {over!r}"
+    assert under.isascii(), f"non-ASCII in snapshot: {under!r}"
+    # the target line now uses ASCII "<=" instead of U+2264
+    assert "<=" in under and "≤" not in under, under
+    return "format_snapshot output is .isascii() (emoji + U+2264 removed) (dev-env#736)"
+
+
 def main() -> int:
     tests = [
         ("no-expiry token proceeds silently", test_no_expiry_proceeds_silently),
+        ("status_emoji bands are ASCII (dev-env#736)", test_status_emoji_bands_are_ascii),
+        ("format_snapshot output is ASCII (dev-env#736)", test_format_snapshot_output_is_ascii),
         ("valid token proceeds silently", test_valid_token_proceeds_silently),
         ("token expiring within 1h warns", test_expiring_within_hour_warns),
         ("expired token now yields advisory", test_expired_token_now_visible),

--- a/claude/scripts/usage-snapshot.py
+++ b/claude/scripts/usage-snapshot.py
@@ -39,6 +39,7 @@ import urllib.error
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
+import _hookout
 from _hookio import (
     confirm_merge_via_gh,
     effective_merge_dir,
@@ -227,13 +228,17 @@ def refresh_token_now(timeout: int = 45) -> bool:
 
 
 def status_emoji(util: float, target: int, margin: int) -> str:
+    # ASCII tokens (not emoji) so the snapshot stays cp1252-encodable on the raw
+    # stderr channel: emoji are outside cp1252 and crashed the print, flipping
+    # exit 2 -> 0 and silently dropping the whole snapshot (PR5 of dev-env#717).
+    # Name kept (not renamed) to avoid churning its call site and test names.
     if target == 0:
         return ""
     if util >= target:
-        return "🔴 over cap"
+        return "OVER cap"
     if util >= target - margin:
-        return "⚠️ approaching cap"
-    return "✅ under cap"
+        return "NEAR cap"
+    return "OK under cap"
 
 
 # --- JSONL parsing ---
@@ -385,7 +390,7 @@ def format_snapshot(util_data: dict, config: dict, exchanges: list[dict]) -> str
     lines = ["### Usage Snapshot (post-merge)"]
     lines.append(
         f"- **Weekly:** {util_7d:.0f}% used "
-        f"(day {day_num}/{window_days} — target ≤{target}% — {emoji})"
+        f"(day {day_num}/{window_days} - target <={target}% - {emoji})"
     )
     lines.append(f"- **5-hour window:** {util_5h:.0f}%")
 
@@ -411,7 +416,7 @@ def format_snapshot(util_data: dict, config: dict, exchanges: list[dict]) -> str
             )
     else:
         lines.append("")
-        lines.append("*(No session JSONL found — exchange breakdown unavailable)*")
+        lines.append("*(No session JSONL found - exchange breakdown unavailable)*")
 
     return "\n".join(lines)
 
@@ -465,12 +470,10 @@ def main() -> None:
     if not token:
         # Creds file exists but holds no usable token — surface it rather than
         # failing silently (creds-file-absent is handled silently above).
-        print(
+        _hookout.emit_block(
             "[usage-snapshot] Skipped: .credentials.json has no usable OAuth token "
-            "(missing or unparseable). Run `claude` interactively to rewrite it.",
-            file=sys.stderr,
+            "(missing or unparseable). Run `claude` interactively to rewrite it."
         )
-        sys.exit(2)
 
     # Only a truly-expired token blocks the snapshot. Claude Code refreshes lazily,
     # so a scheduled keep-warm can't fully close the gap; instead, refresh on demand
@@ -483,12 +486,10 @@ def main() -> None:
             token, expires_at_ms = get_access_token(creds)
             state, _ = classify_token(expires_at_ms, time.time() * 1000)
         if state == "expired" or not token:
-            print(
+            _hookout.emit_block(
                 "[usage-snapshot] OAuth token expired and on-demand refresh failed "
-                "(the refresh token may be dead) — run `claude` interactively to re-auth.",
-                file=sys.stderr,
+                "(the refresh token may be dead) - run `claude` interactively to re-auth."
             )
-            sys.exit(2)
 
     util_data = fetch_usage(token)
     if not util_data:
@@ -496,12 +497,10 @@ def main() -> None:
         time.sleep(1)
         util_data = fetch_usage(token)
     if not util_data:
-        print(
+        _hookout.emit_block(
             "[usage-snapshot] Skipped: usage API unavailable (network error or "
-            "transient 5xx). The snapshot was omitted for this merge.",
-            file=sys.stderr,
+            "transient 5xx). The snapshot was omitted for this merge."
         )
-        sys.exit(2)
 
     config = load_config()
     session_id = data.get("session_id", "")
@@ -510,8 +509,7 @@ def main() -> None:
     exchanges = top_exchanges(jsonl_path) if jsonl_path else []
 
     snapshot = format_snapshot(util_data, config, exchanges)
-    print(snapshot, file=sys.stderr)
-    sys.exit(2)
+    _hookout.emit_block(snapshot)
 
 
 if __name__ == "__main__":

--- a/claude/scripts/usage-snapshot.py
+++ b/claude/scripts/usage-snapshot.py
@@ -227,11 +227,10 @@ def refresh_token_now(timeout: int = 45) -> bool:
         return False
 
 
-def status_emoji(util: float, target: int, margin: int) -> str:
+def status_label(util: float, target: int, margin: int) -> str:
     # ASCII tokens (not emoji) so the snapshot stays cp1252-encodable on the raw
     # stderr channel: emoji are outside cp1252 and crashed the print, flipping
     # exit 2 -> 0 and silently dropping the whole snapshot (PR5 of dev-env#717).
-    # Name kept (not renamed) to avoid churning its call site and test names.
     if target == 0:
         return ""
     if util >= target:
@@ -377,7 +376,7 @@ def format_snapshot(util_data: dict, config: dict, exchanges: list[dict]) -> str
     margin = config.get("alert_approaching_margin", 5)
 
     target, day_num, window_days = compute_cumulative_target(resets_at_str, config)
-    emoji = status_emoji(util_7d, target, margin)
+    label = status_label(util_7d, target, margin)
 
     resets_display = ""
     if resets_at_str:
@@ -390,7 +389,7 @@ def format_snapshot(util_data: dict, config: dict, exchanges: list[dict]) -> str
     lines = ["### Usage Snapshot (post-merge)"]
     lines.append(
         f"- **Weekly:** {util_7d:.0f}% used "
-        f"(day {day_num}/{window_days} - target <={target}% - {emoji})"
+        f"(day {day_num}/{window_days} - target <={target}% - {label})"
     )
     lines.append(f"- **5-hour window:** {util_5h:.0f}%")
 


### PR DESCRIPTION
## Summary

PR5 (Phase C) of the hook-reliability initiative **#717**. Moves three `PostToolUse`/`Bash` hooks off channels the Claude Code contract makes invisible or unsafe, onto the shared `_hookout` emitter (PR2, #719), and deletes their now-stale two-sided allowlist entries.

- **`post-pr-merge-pull.py`** — extracts pure `format_pull_message` / `format_park_message` and a `plan_advisory` channel decision; `main()` accumulates and emits **once**: the *"parked this worktree off main"* warning → `emit_block` (exit-2 stderr, **model-visible** — its own cwd branch just changed underneath it), routine pull status → `emit_advisory(audience="user")` (a `systemMessage` toast). Was 8 `print(..., file=sys.stderr)` sites at exit 0 (all invisible).
- **`post-pr-merge-reclaim.py`** — background-housekeeping status → `emit_advisory(audience="user")`; `RECLAIM_MSG` constant.
- **`usage-snapshot.py`** — channel was already correct (exit-2 stderr) but content carried emoji + `≤` (outside cp1252 → the `print` raised → the `except: sys.exit(0)` guard flipped exit 2→0 → the snapshot was **silently dropped**). Now: `status_emoji` → ASCII `OVER`/`NEAR`/`OK` tokens, `≤` → `<=`, and all four emissions → `emit_block` (whose `ascii_sanitize` backstop + exit-code-safe `finally` also close the exit-2→0 flip).

Channel policy per #717 (model-visible first; `systemMessage` where human awareness suffices).

Closes #736

## Deleted allowlist entries (in `test_hook_output_contract.py`)

The AST gate fails on `stale` once the code is migrated, so these were removed in the same PR:
- `_OUTPUT_CONTRACT_ALLOWLIST`: `("post-pr-merge-pull.py","A"): 8`, `("post-pr-merge-reclaim.py","A"): 1`
- `_NONASCII_EMISSION_ALLOWLIST`: `"post-pr-merge-pull.py": 7`, `"post-pr-merge-reclaim.py": 1`, `"usage-snapshot.py": 1`

Remaining offenders (token-tracker, journal-stop-check, posttooluse-inert-advisory, dev-env-sync) are PR6/PR7's and are untouched.

## Testing

Full offline suite (the CI gate): **`Tests: 63 passed, 2 skipped, 0 failed`** (`py -3 claude/scripts/run-hook-tests.py`; the 2 skips are documented — shellcheck not installed, and the runner's own `test_pyw_stdio` skip). Re-run green after rebasing onto `origin/main` (#735).

New/updated coverage:
- `test_post_pr_merge_pull.py` 20 → 32: `format_pull_message` (5 outcomes), `format_park_message` (3 outcomes), `plan_advisory` (park→block / status→user / both→block / none).
- `test_post_pr_merge_reclaim.py` 9 → 10: `RECLAIM_MSG` content + `.isascii()`.
- `test_usage_snapshot.py` 13 → 15: `status_emoji` + `format_snapshot` output `.isascii()` pins (the #670 pattern; both were previously unexercised).
- `test_hook_output_contract.py` / `test_hook_safe_exit_guard.py`: green (safe-exit unchanged — all three keep compliant `__main__` guards).

Channel behavior verified concretely end-to-end: `emit_advisory("PostToolUse", …, audience="user")` → `{"systemMessage": …}` on stdout, exit 0; `emit_block(…)` → text on stderr, exit 2. All three hooks load and no-op cleanly on a non-merge payload.

**Coverage gate:** new pure helpers and the `.isascii()` pins are the added tests; the subprocess-bound wrappers (`pull_main` / `park_worktree_off_main` / detached reclaim / live API) stay untested per repo convention, with channel correctness enforced by the output-contract gate.

**Suppression / test-integrity greps:** clean (no suppressions, skip markers, or deleted tests). No `package.json` changed (lockfile gate N/A).

## ADR / docs

No new ADR — covered by **ADR-103** (which already describes PR5's scope, incl. the `🔴 → OVER` usage-snapshot glyph case). REFERENCE/README hook descriptions remain accurate (no channel they assert is contradicted); CLAUDE.md `## Testing` items 8/10/15 updated.

## Risk-dimension audit (Pass 3)

- **Testing** — covered above. **Observability** — this *is* an observability fix (advisories now reach their intended audience); routing enforced by the AST gate. **Security** — N/A (no authz/input/secret surface). **Resilience** — `emit_block`'s `finally` guarantees the exit code even on a stream-write error; the hooks' fail-open `__main__` guards are unchanged. **Performance** — N/A (no new hot path). **Data integrity** — N/A.

## Review findings disposition

[`/review`](https://github.com/brownm09/dev-env/pull/738#issuecomment-4949740280) (two parallel opus sub-reviewers) found **0 blocking, 5 non-blocking** — all fixed in `6abf1f9`:
- `plan_advisory` now returns `(needs_block: bool, text)` instead of a typo-prone `("block"/"user", text)` channel string (the `main()` consumer is untested) — fixed in `6abf1f9`.
- `format_snapshot` ASCII test split into the static-template pin **plus** the real end-to-end guarantee `ascii_sanitize(format_snapshot(<non-ASCII action>)).isascii()` (the action column carries arbitrary Unicode; wire-safety lives in `emit_block`) — fixed in `6abf1f9`.
- `status_emoji` renamed → `status_label` (returns ASCII tokens, not emoji) — fixed in `6abf1f9`.
- `post-pr-merge-pull` NoReturn skip branch commented so it doesn't read as fall-through — fixed in `6abf1f9`.
- `RECLAIM_MSG` `.isascii()` test comment reworded (systemMessage is JSON-escaped; ASCII is a consistency guard, not a safety requirement) — fixed in `6abf1f9`.

The one Question (routine status toasting on every merge) is resolved as **intended behavior**: post-merge the local `main` genuinely advances, so the toast is a meaningful "local main updated" confirmation, not noise, and it's a user `systemMessage` with zero model-context/token cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
