### PR TITLE
docs(adr-096): correct 2026-07-11 addendum test count (Six→Eight Layer 1, note ninth review test)

### DIFF
--- a/docs/adr/096-journal-compose-mechanical-force-guard.md
+++ b/docs/adr/096-journal-compose-mechanical-force-guard.md
@@ -335,9 +335,13 @@ checks so it still fires only when a genuine compose op is being evaluated.
 raw command and cwd strings — no re-parse of segments. The compose path re-uses the already-split
 segments from the outer `command_targets_today_compose` call; no double-split.
 
-**Testing.** Eight new tests in `test_pre_tool_use_journal_compose_force_guard.py`:
-- Six Layer 1 unit tests for `_is_compose_op` covering: compose cwd (hyphen and slash forms), `-C`
+**Testing.** Twelve new tests in `test_pre_tool_use_journal_compose_force_guard.py`:
+- Eight Layer 1 unit tests for `_is_compose_op` covering: compose cwd (hyphen and slash forms), `-C`
   compose path, stub-write simple push, stub-write refspec push, compose token in message prose
   (must not trigger), empty cwd, and the normal worktree-add command.
 - Four Layer 2 e2e tests: stub push allowed without marker; full refspec push allowed without marker;
   push from compose cwd still blocked; push with `-C compose-<today>` still blocked.
+
+A ninth e2e test — `test_e2e_chained_stub_write_allows_without_marker`, confirming that a stub-write
+push chained after an unrelated command (`&&`-joined) still allows without a marker — was added in
+the `/review` follow-up commit on PR #735 and is not counted in the twelve above.


### PR DESCRIPTION
## Summary

- Corrects the 2026-07-11 addendum Testing paragraph in ADR-096: PR #735 landed with **eight** Layer 1 unit tests for `_is_compose_op`, not six as stated.
- Updates the overall count header from "Eight new tests" → "Twelve new tests" (8 Layer 1 + 4 Layer 2).
- Notes that a ninth e2e test (`test_e2e_chained_stub_write_allows_without_marker`) was added in the `/review` follow-up commit on PR #735 and is counted separately.

Closes #737

## Testing

Docs-only change (no hook/script modifications). Full test suite still passes:

```
Suite: 63 passed, 2 skipped, 0 failed (85.2s)
Tests: 63 passed, 2 skipped, 0 failed (85.2s)
```

**Suppression check:** `git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'` — no matches.

**Test-integrity check:** no skip markers, deleted tests, or threshold changes — docs-only diff.

**Coverage gate:** N/A — docs-only change; no new testable behavior.

## Pass 3 Risk Dimensions

1. **Testing** — N/A — docs-only.
2. **Observability** — N/A — no runtime.
3. **Security** — N/A — no code.
4. **Resilience** — N/A — no code.
5. **Performance** — N/A — no code.
6. **Data integrity** — N/A — no code.