### PR TITLE
fix(hooks): safe-exit guard sweep + final dev-env-sync ASCII cleanup (PR7 of #717)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1620,9 +1620,10 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     allowlists (the `test_no_crude_command_substring_checks.py` mechanism): `_OUTPUT_CONTRACT_ALLOWLIST`
     keyed by `(script, check)` (**empty** as of PR6/dev-env#740 — PR5 swept the PostToolUse hooks and PR6
     the Stop-family hooks, so every output-contract offender is now migrated onto `_hookout`; a new entry
-    the gate reports is a genuine regression), `_NONASCII_EMISSION_ALLOWLIST` keyed by script (1 remaining:
-    `dev-env-sync.py`'s 4 cp1252-safe em-dash/ellipsis lines, PR7 — token-tracker's 2 lines cleared in PR6
-    when the per-turn echoes carrying them were dropped). Documented limitations: the ASCII lint and Check D both see only literals
+    the gate reports is a genuine regression), `_NONASCII_EMISSION_ALLOWLIST` keyed by script (**empty**
+    as of PR7/dev-env#743 — `dev-env-sync.py`'s 4 em-dash print() calls were hand-fixed to plain ASCII
+    hyphens, the last remaining offender; token-tracker's 2 lines were cleared in PR6 when the per-turn
+    echoes carrying them were dropped; a new entry the gate reports is a genuine regression). Documented limitations: the ASCII lint and Check D both see only literals
     *direct* in the emission call (usage-snapshot's emoji reach stderr via a variable, flagged only via
     an incidental em-dash — PR5's own `.isascii()` self-pin covers the emoji; a json payload built from
     a variable classifies as "unknown" and is exempt), and the cross-function Check C pass is one level
@@ -1645,8 +1646,12 @@ the colliding item(s) to the next free number, and re-run `gh pr merge`.
     pass-through is correctly ignored (not mistaken for the fail-direction handler). Pins the guard-shape
     self-tests (guarded exit 0/2, exit-2-via-helper, unguarded bare `main()` / `sys.exit(main())` / no
     `__main__` block / handler-without-exit, wrong-direction reported faithfully) and that `FAIL_CLOSED`
-    names only wired scripts. Two-sided `_UNGUARDED_ALLOWLIST` (14 current offenders lacking a compliant
-    guard; the PR7 safe-exit sweep shrinks it — a stale entry, i.e. a now-guarded script, fails too). A
+    names only wired scripts. Two-sided `_UNGUARDED_ALLOWLIST` (**empty** as of PR7/dev-env#743 — the last
+    14 offenders (awake-blocker, idle-refresher, multi-worktree-alert, pre-commit-branch-check,
+    pre-merge-branch-check, pre-merge-findings-gate, pre-merge-message-check, pre-merge-numbering-check,
+    pre-pr-create-check, pre-tool-use-canonical-mutate-guard, pre-tool-use-worktree-path-check,
+    session-mode-prompt, token-tracker, turn-count-hook) were all guarded; a stale entry, i.e. a
+    now-guarded script, fails too, and a new unguarded hook not in the allowlist also fails). A
     guarded hook whose crash-exit contradicts its declared direction is a hard failure, never
     allowlist-able. Does NOT verify the fail-closed gates' module-level dependency-load guard (rule 5) —
     that surface is pinned by items 52/55. ([ADR-103](docs/adr/103-shared-hookout-emitter.md);

--- a/claude/scripts/awake-blocker.py
+++ b/claude/scripts/awake-blocker.py
@@ -283,4 +283,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/dev-env-sync.py
+++ b/claude/scripts/dev-env-sync.py
@@ -180,7 +180,7 @@ def main() -> None:
             # warning and let the user switch back manually.
             print(
                 f"[dev-env-sync] WARNING: Canonical worktree is on '{current_branch}' and its worktree "
-                "list could not be read — ~/.claude/ symlinks may serve stale hooks/scripts.\n"
+                "list could not be read - ~/.claude/ symlinks may serve stale hooks/scripts.\n"
                 f"Switch it back manually: git -C {DEV_ENV_REPO} checkout main"
             )
             sys.exit(0)
@@ -194,8 +194,8 @@ def main() -> None:
             print(
                 f"[dev-env-sync] WARNING: Canonical worktree is on '{current_branch}' and worktree\n"
                 f"  {action.squatter_path}\n"
-                "is squatting 'main' — the canonical cannot return until that worktree is parked\n"
-                "off main. Free the ref (non-destructive — changes no files):\n"
+                "is squatting 'main' - the canonical cannot return until that worktree is parked\n"
+                "off main. Free the ref (non-destructive - changes no files):\n"
                 f"  git -C {action.squatter_path} checkout -b {action.park_branch}\n"
                 "then the next prompt returns the canonical to main automatically (or run\n"
                 f"  git -C {DEV_ENV_REPO} checkout main\n"
@@ -206,7 +206,7 @@ def main() -> None:
         if action.kind == "warn-dirty":
             print(
                 f"[dev-env-sync] WARNING: Canonical worktree is on '{current_branch}' with uncommitted\n"
-                "changes — ~/.claude/ symlinks may serve stale hooks/scripts. Not auto-switching to\n"
+                "changes - ~/.claude/ symlinks may serve stale hooks/scripts. Not auto-switching to\n"
                 "preserve your drift; commit or stash, then:\n"
                 f"  git -C {DEV_ENV_REPO} checkout main"
             )
@@ -222,7 +222,7 @@ def main() -> None:
                 )
                 sys.exit(0)
             print(
-                f"[dev-env-sync] Returned canonical worktree to main (was on '{current_branch}') — "
+                f"[dev-env-sync] Returned canonical worktree to main (was on '{current_branch}') - "
                 "symlinked tooling restored."
             )
             current_branch = "main"

--- a/claude/scripts/idle-refresher.py
+++ b/claude/scripts/idle-refresher.py
@@ -239,4 +239,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/multi-worktree-alert.py
+++ b/claude/scripts/multi-worktree-alert.py
@@ -130,4 +130,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/pre-commit-branch-check.py
+++ b/claude/scripts/pre-commit-branch-check.py
@@ -74,4 +74,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/pre-merge-branch-check.py
+++ b/claude/scripts/pre-merge-branch-check.py
@@ -92,4 +92,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/pre-merge-findings-gate.py
+++ b/claude/scripts/pre-merge-findings-gate.py
@@ -254,4 +254,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/pre-merge-message-check.py
+++ b/claude/scripts/pre-merge-message-check.py
@@ -89,4 +89,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/pre-merge-numbering-check.py
+++ b/claude/scripts/pre-merge-numbering-check.py
@@ -307,4 +307,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/pre-pr-create-check.py
+++ b/claude/scripts/pre-pr-create-check.py
@@ -192,4 +192,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/pre-tool-use-canonical-mutate-guard.py
+++ b/claude/scripts/pre-tool-use-canonical-mutate-guard.py
@@ -800,4 +800,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/pre-tool-use-worktree-path-check.py
+++ b/claude/scripts/pre-tool-use-worktree-path-check.py
@@ -207,4 +207,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/session-mode-prompt.py
+++ b/claude/scripts/session-mode-prompt.py
@@ -167,4 +167,8 @@ def main():
     sys.exit(0)
 
 
-main()
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/tests/test_hook_output_contract.py
+++ b/claude/scripts/tests/test_hook_output_contract.py
@@ -150,12 +150,13 @@ _OUTPUT_CONTRACT_ALLOWLIST: dict[tuple[str, str], int] = {}
 # lines. PR5 cleared usage-snapshot (emoji + <= now ASCII, emissions on _hookout,
 # with an .isascii() pin on format_snapshot) and post-pr-merge-pull/reclaim
 # (dev-env#736); PR6 (dev-env#740) cleared token-tracker (both non-ASCII lines were
-# in the dropped per-turn echoes); PR7 -> dev-env-sync (the last remaining). post-compact /
-# post-merge-tile-checkpoint / pre-merge-findings-gate were swept onto _hookout in
-# dev-env#727.
-_NONASCII_EMISSION_ALLOWLIST: dict[str, int] = {
-    "dev-env-sync.py": 4,
-}
+# in the dropped per-turn echoes); PR7 (dev-env#743) hand-fixed dev-env-sync's 4
+# em-dash print() calls to plain ASCII hyphens (the last remaining offender), so
+# this allowlist is now empty; any new entry the gate reports is a genuine
+# regression to route through _hookout or hand-fix, not something to re-add here.
+# post-compact / post-merge-tile-checkpoint / pre-merge-findings-gate were swept
+# onto _hookout in dev-env#727.
+_NONASCII_EMISSION_ALLOWLIST: dict[str, int] = {}
 
 
 # ---------------------------------------------------------------------------

--- a/claude/scripts/tests/test_hook_safe_exit_guard.py
+++ b/claude/scripts/tests/test_hook_safe_exit_guard.py
@@ -90,24 +90,15 @@ def fail_direction(script: str) -> int:
 
 # Scripts that do NOT yet carry a compliant safe-exit `__main__` guard (bare
 # `main()` / `sys.exit(main())` / no `__main__` block). Two-sided: a stale entry
-# (script since guarded) fails the gate, so the PR7 sweep must delete each entry
-# as it lands the guard. Verified against origin/main @ 2cc6afa (2026-07-11).
-_UNGUARDED_ALLOWLIST: set[str] = {
-    "awake-blocker.py",
-    "idle-refresher.py",
-    "multi-worktree-alert.py",
-    "pre-commit-branch-check.py",
-    "pre-merge-branch-check.py",
-    "pre-merge-findings-gate.py",
-    "pre-merge-message-check.py",
-    "pre-merge-numbering-check.py",
-    "pre-pr-create-check.py",
-    "pre-tool-use-canonical-mutate-guard.py",
-    "pre-tool-use-worktree-path-check.py",
-    "session-mode-prompt.py",
-    "token-tracker.py",
-    "turn-count-hook.py",
-}
+# (script since guarded) fails the gate. PR7 (dev-env#743) guarded the last 14
+# offenders (awake-blocker, idle-refresher, multi-worktree-alert,
+# pre-commit-branch-check, pre-merge-branch-check, pre-merge-findings-gate,
+# pre-merge-message-check, pre-merge-numbering-check, pre-pr-create-check,
+# pre-tool-use-canonical-mutate-guard, pre-tool-use-worktree-path-check,
+# session-mode-prompt, token-tracker, turn-count-hook), so this allowlist is now
+# empty; any new entry the gate reports is a genuine regression to guard, not
+# something to re-add here.
+_UNGUARDED_ALLOWLIST: set[str] = set()
 
 
 # ---------------------------------------------------------------------------

--- a/claude/scripts/token-tracker.py
+++ b/claude/scripts/token-tracker.py
@@ -288,4 +288,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/claude/scripts/turn-count-hook.py
+++ b/claude/scripts/turn-count-hook.py
@@ -210,4 +210,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        sys.exit(0)


### PR DESCRIPTION
## Summary

Phase C (final) of the #717 hook-reliability initiative. Sub-issue: #743.

- Adds the top-level `if __name__ == "__main__": try: main() except Exception: sys.exit(0)` safe-exit guard to the last 14 unguarded advisory hooks: `awake-blocker.py`, `idle-refresher.py`, `multi-worktree-alert.py`, `pre-commit-branch-check.py`, `pre-merge-branch-check.py`, `pre-merge-findings-gate.py`, `pre-merge-message-check.py`, `pre-merge-numbering-check.py`, `pre-pr-create-check.py`, `pre-tool-use-canonical-mutate-guard.py`, `pre-tool-use-worktree-path-check.py`, `session-mode-prompt.py` (previously had no `__main__` guard at all — bare `main()` at module level), `token-tracker.py` (previously had no crash guard of any kind), `turn-count-hook.py`.
- All 14 are advisory (fail-open, exit 0) — none belong in `FAIL_CLOSED`. For the two PreToolUse *gate* hooks (`pre-tool-use-canonical-mutate-guard.py`, `pre-tool-use-worktree-path-check.py`) that legitimately block via exit 2, their blocking helpers (`_emit_block`, `_block`) call `sys.exit(2)` internally, which raises `SystemExit` — not an `Exception` subclass — so the new `except Exception:` handler never intercepts a legitimate block. Verified by auditing every `sys.exit()` call site in all 14 files (only codes 0 and 2 appear anywhere) and confirmed by the full existing test suite's end-to-end subprocess tests, which drive the real blocking paths of both gate hooks and three of the `pre-merge-*` hooks and still pass.
- Hand-fixes `dev-env-sync.py`'s 4 remaining em-dash (U+2014) `print()` calls to plain ASCII hyphens — the last `_NONASCII_EMISSION_ALLOWLIST` entry. Kept as a surgical character substitution rather than migrating onto `_hookout`, since this file already carries extensive, specific rationale (dev-env#694, ADR-098, PR #701) for its current plain-`print()` + exit-0 approach that a mechanism change shouldn't disturb without cause.
- Both two-sided allowlists — `_UNGUARDED_ALLOWLIST` in `test_hook_safe_exit_guard.py` and `_NONASCII_EMISSION_ALLOWLIST` in `test_hook_output_contract.py` — are now **empty**, the intended end state of the PR5→PR7 migration sequence.
- Updates the two now-stale CLAUDE.md `## Testing` item descriptions (61, 62) that cited the old allowlist counts.

## Test plan

- [x] `py -3 claude/scripts/run-hook-tests.py` — 64 passed, 2 skipped (both pre-existing documented environment skips: `test_pyw_stdio.py` needs a real Windows console, `run-shellcheck.sh` needs the `shellcheck` binary), 0 failed. Run twice (before and after the CLAUDE.md doc edit).
- [x] Smoke-tested all 14 guarded hooks + `dev-env-sync.py` directly with empty stdin — all exit 0, matching the authoring-rule-1 verification pattern.
- [x] Confirmed via `analyze_nonascii_emissions()` (the actual AST detector) that `dev-env-sync.py` now reports zero flagged lines.
- [x] Suppression grep, test-integrity grep, deleted-test-file check, and the crude-command-substring AST gate (item 39) — all clean.

Tests: 64 passed, 2 skipped, 0 failed (90.3s)

## Not in scope

Phase D (heartbeat/liveness, PowerShell matchers/#620, scratch-state GC — PR8-10) and Phase E (shared repo-target/helper SSOT — PR11-12) are separate, later units per #717.

No new ADR — covered by ADR-103.

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)