### PR TITLE
docs: correct --force claim in worktree deregistration recovery runbook

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -924,12 +924,22 @@ branch on **main**. Mid-session the harness surfaces it as
 `PreToolUse:Edit hook error: [...worktree-path-check.py]: No stderr output` — the session's own cwd
 worktree is orphaned, which blocks **every** Edit (the hook keys off session cwd, not the target path).
 
-**Recovery** (validated 2026-06-04):
+**Recovery** (validated 2026-06-04; `--force` caveat corrected 2026-07-13 — dev-env#751):
 
 ```bash
 git -C <main-repo-path> checkout main                # frees the branch
 git -C <main-repo-path> worktree prune               # drop stale admin entries
-git -C <main-repo-path> worktree add --force .claude/worktrees/<name> <feature-branch>   # --force: orphaned dir still has files
+
+# If .claude/worktrees/<name> still exists on disk, `worktree add` fails with
+# `fatal: '.claude/worktrees/<name>' already exists` — `--force` overrides only the
+# "branch already checked out elsewhere" safeguard, NOT a pre-existing non-empty target
+# directory (confirmed live, git 2.37.1.windows.1). Inspect before removing: confirm
+# there is no `.git` file/link inside (i.e. it is not a live registered worktree) and no
+# valuable uncommitted content, then clear it.
+ls -la .claude/worktrees/<name>                      # confirm: no .git link, no real content
+rm -rf .claude/worktrees/<name>                      # only once the above is confirmed safe
+
+git -C <main-repo-path> worktree add --force .claude/worktrees/<name> <feature-branch>   # --force: branch-checked-out-elsewhere safeguard only
 npm install                                          # from the recreated worktree, no cd
 ```
 


### PR DESCRIPTION
## Summary
- Corrects the "Worktree deregistration recovery" runbook in `docs/REFERENCE.md` — the recovery
  command's inline comment claimed `--force` on `git worktree add` handles "orphaned dir still has
  files"; confirmed inaccurate live (git 2.37.1.windows.1): `--force` only overrides the "branch
  already checked out elsewhere" safeguard, not a pre-existing non-empty target directory.
- Adds an inspect-then-clear step before `git worktree add`, so the recipe actually succeeds when
  the orphaned directory still has stale content on disk.

Closes #751

## ADR-warrant check
Not warranted against ADR-011's four criteria: no `claude/` rule/hook/skill/settings changed, no
`claude/` directory restructured, no workflow rule other CLAUDE.md files reference is being
established or changed (the recovery sequence's meaning is unchanged — only an inaccurate inline
comment is corrected and a conditional cleanup step added), and the rationale (a git CLI behavior
fact) is fully recoverable from this PR description plus the linked issues #751 and dev-env#630
(comment). ADR-066 (which established this runbook) is unaffected — it never asserted the
"orphaned dir still has files" claim itself, only referenced the `--force` recipe by name.

## Testing
Docs-only change — no hook/script/settings touched, so `py -3 claude/scripts/run-hook-tests.py`
is not applicable. Manually verified: grepped the repo for the exact "orphaned dir still has
files" phrase both before and after the edit — it appeared only at `docs/REFERENCE.md:932` before,
and zero occurrences remain after. Confirmed `docs/adr/066-worktree-session-safety-rules.md`,
`docs/adr/024-worktree-path-guard-hook.md`, and
`claude/scripts/pre-tool-use-worktree-path-check.py` all reference the same `--force` recipe but
never asserted the false claim, so none needed changes. No suppressions, no test-integrity
changes, no lockfile changes.